### PR TITLE
SAPI-412 Appointment/resignation date should not contain time; only display month + year in DOB

### DIFF
--- a/src/it/java/uk/gov/companieshouse/company_appointments/CompanyAppointmentControllerITest.java
+++ b/src/it/java/uk/gov/companieshouse/company_appointments/CompanyAppointmentControllerITest.java
@@ -1,6 +1,10 @@
 package uk.gov.companieshouse.company_appointments;
 
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.CoreMatchers.nullValue;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -71,6 +75,7 @@ public class CompanyAppointmentControllerITest {
                 .andExpect(jsonPath("$.name", is("NOSURNAME, Noname1 Noname2")))
                 .andExpect(jsonPath("$.appointed_on", is("2020-08-26")))
                 .andExpect(jsonPath("$.resigned_on", is("2020-08-26")))
+                .andExpect(jsonPath("$.date_of_birth", not(contains("day"))))
                 .andExpect(jsonPath("$.date_of_birth.year", is(1980)))
                 .andExpect(jsonPath("$.date_of_birth.month", is(1)));
     }

--- a/src/it/java/uk/gov/companieshouse/company_appointments/CompanyAppointmentControllerITest.java
+++ b/src/it/java/uk/gov/companieshouse/company_appointments/CompanyAppointmentControllerITest.java
@@ -69,6 +69,8 @@ public class CompanyAppointmentControllerITest {
         //then
         result.andExpect(status().isOk())
                 .andExpect(jsonPath("$.name", is("NOSURNAME, Noname1 Noname2")))
+                .andExpect(jsonPath("$.appointed_on", is("2020-08-26")))
+                .andExpect(jsonPath("$.resigned_on", is("2020-08-26")))
                 .andExpect(jsonPath("$.date_of_birth.year", is(1980)))
                 .andExpect(jsonPath("$.date_of_birth.month", is(1)));
     }

--- a/src/it/java/uk/gov/companieshouse/company_appointments/CompanyAppointmentControllerITest.java
+++ b/src/it/java/uk/gov/companieshouse/company_appointments/CompanyAppointmentControllerITest.java
@@ -1,10 +1,8 @@
 package uk.gov.companieshouse.company_appointments;
 
-import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
-import static org.hamcrest.CoreMatchers.nullValue;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;

--- a/src/main/java/uk/gov/companieshouse/company_appointments/CompanyAppointmentMapper.java
+++ b/src/main/java/uk/gov/companieshouse/company_appointments/CompanyAppointmentMapper.java
@@ -90,7 +90,6 @@ public class CompanyAppointmentMapper {
     private DateOfBirth mapDateOfBirth(CompanyAppointmentData companyAppointmentData) {
         return Optional.ofNullable(companyAppointmentData.getData().getDateOfBirth())
                 .map(dateOfBirth -> new DateOfBirth(
-                        dateOfBirth.getDayOfMonth(),
                         dateOfBirth.getMonthValue(),
                         dateOfBirth.getYear()))
                 .orElse(null);

--- a/src/main/java/uk/gov/companieshouse/company_appointments/model/view/CompanyAppointmentView.java
+++ b/src/main/java/uk/gov/companieshouse/company_appointments/model/view/CompanyAppointmentView.java
@@ -3,8 +3,8 @@ package uk.gov.companieshouse.company_appointments.model.view;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Objects;
-import java.util.StringJoiner;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
@@ -15,9 +15,11 @@ public class CompanyAppointmentView {
     private ServiceAddressView serviceAddress;
 
     @JsonProperty("appointed_on")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
     private LocalDateTime appointedOn;
 
     @JsonProperty("resigned_on")
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
     private LocalDateTime resignedOn;
 
     @JsonProperty("country_of_residence")

--- a/src/main/java/uk/gov/companieshouse/company_appointments/model/view/DateOfBirth.java
+++ b/src/main/java/uk/gov/companieshouse/company_appointments/model/view/DateOfBirth.java
@@ -11,6 +11,10 @@ public class DateOfBirth {
     private Integer month;
     private Integer year;
 
+    public DateOfBirth(Integer month, Integer year) {
+        this(null, month, year);
+    }
+
     public DateOfBirth(Integer day, Integer month, Integer year) {
         this.day = day;
         this.month = month;

--- a/src/test/java/uk/gov/companieshouse/company_appointments/CompanyAppointmentMapperTest.java
+++ b/src/test/java/uk/gov/companieshouse/company_appointments/CompanyAppointmentMapperTest.java
@@ -263,7 +263,7 @@ public class CompanyAppointmentMapperTest {
                 .withAppointedOn(LocalDateTime.of(2020, 8, 26, 12, 0))
                 .withResignedOn(LocalDateTime.of(2020, 8, 26, 13, 0))
                 .withCountryOfResidence("Country")
-                .withDateOfBirth(new DateOfBirth(null, 1, 1980))
+                .withDateOfBirth(new DateOfBirth(1, 1980))
                 .withLinks(new LinksView("/company/12345678/appointment/123", "/officers/abc/appointments"))
                 .withNationality("Nationality")
                 .withOccupation("Occupation")

--- a/src/test/java/uk/gov/companieshouse/company_appointments/CompanyAppointmentMapperTest.java
+++ b/src/test/java/uk/gov/companieshouse/company_appointments/CompanyAppointmentMapperTest.java
@@ -263,7 +263,7 @@ public class CompanyAppointmentMapperTest {
                 .withAppointedOn(LocalDateTime.of(2020, 8, 26, 12, 0))
                 .withResignedOn(LocalDateTime.of(2020, 8, 26, 13, 0))
                 .withCountryOfResidence("Country")
-                .withDateOfBirth(new DateOfBirth(1, 1, 1980))
+                .withDateOfBirth(new DateOfBirth(null, 1, 1980))
                 .withLinks(new LinksView("/company/12345678/appointment/123", "/officers/abc/appointments"))
                 .withNationality("Nationality")
                 .withOccupation("Occupation")


### PR DESCRIPTION
* Hide time from appointment/resignation date and hide day by default in date of birth view object.