### PR TITLE
Standard SnakeCase strategy wasn't as required, so using our own

### DIFF
--- a/src/main/java/uk/gov/companieshouse/company_appointments/config/Config.java
+++ b/src/main/java/uk/gov/companieshouse/company_appointments/config/Config.java
@@ -2,6 +2,7 @@ package uk.gov.companieshouse.company_appointments.config;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.data.mongodb.core.mapping.MongoMappingContext;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 import uk.gov.companieshouse.company_appointments.interceptor.AuthenticationInterceptor;
@@ -14,6 +15,11 @@ public class Config implements WebMvcConfigurer {
 
     @Autowired
     private AuthenticationInterceptor authenticationInterceptor;
+
+    @Autowired
+    private void setNamingStrategy(MongoMappingContext mappingContext) {
+        mappingContext.setFieldNamingStrategy(new JsonNamingStrategy());
+    }
 
     @Override
     public void addInterceptors(InterceptorRegistry registry) {

--- a/src/main/java/uk/gov/companieshouse/company_appointments/config/JsonNamingStrategy.java
+++ b/src/main/java/uk/gov/companieshouse/company_appointments/config/JsonNamingStrategy.java
@@ -1,0 +1,29 @@
+package uk.gov.companieshouse.company_appointments.config;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.mongodb.lang.NonNull;
+import java.util.Objects;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.mapping.PersistentProperty;
+import org.springframework.data.mapping.model.SnakeCaseFieldNamingStrategy;
+import org.springframework.stereotype.Component;
+
+@Component
+public class JsonNamingStrategy extends SnakeCaseFieldNamingStrategy {
+
+    @Autowired
+    public JsonNamingStrategy() {
+    }
+
+    @Override
+    @NonNull
+    public String getFieldName(@NonNull PersistentProperty<?> property) {
+        try {
+            JsonProperty jsonProperty =
+                Objects.requireNonNull(property.findAnnotation(JsonProperty.class));
+            return jsonProperty.value();
+        } catch (Throwable e) {
+            return super.getFieldName(property);
+        }
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -3,4 +3,4 @@ logging.level.org.springframework.web=${WEB_LOGGING_LEVEL:INFO}
 logging.level.uk.gov.companieshouse.company_appointments=${LOGGING_LEVEL}
 logging.level.org.springframework.web.filter.CommonsRequestLoggingFilter=${REQUEST_LOGGING_LEVEL:INFO}
 
-spring.data.mongodb.field-naming-strategy=org.springframework.data.mapping.model.SnakeCaseFieldNamingStrategy
+spring.data.mongodb.field-naming-strategy= uk.gov.companieshouse.company_appointments.config.JsonNamingStrategy

--- a/src/test/java/uk/gov/companieshouse/company_appointments/config/JsonNamingStrategyTest.java
+++ b/src/test/java/uk/gov/companieshouse/company_appointments/config/JsonNamingStrategyTest.java
@@ -1,0 +1,52 @@
+package uk.gov.companieshouse.company_appointments.config;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.mapping.PersistentProperty;
+
+@ExtendWith(MockitoExtension.class)
+class JsonNamingStrategyTest {
+
+    private JsonNamingStrategy jsonNamingStrategy;
+
+    @Mock
+    private PersistentProperty<?> persistentProperty;
+
+    @Mock
+    private JsonProperty jsonProperty;
+
+    @BeforeEach
+    void setup() {
+        jsonNamingStrategy = new JsonNamingStrategy();
+    }
+
+    @Test
+    void returnsFieldName() {
+        // given
+        when(persistentProperty.findAnnotation(JsonProperty.class)).thenReturn(jsonProperty);
+
+        // when
+        String result = jsonNamingStrategy.getFieldName(persistentProperty);
+
+        // then
+        assertEquals(null, result);
+    }
+
+    @Test
+    void returnsFieldNameThrows() {
+        // given
+        when(persistentProperty.findAnnotation(JsonProperty.class)).thenThrow(new RuntimeException());
+
+        // then
+        assertThrows(IllegalArgumentException.class, () -> {jsonNamingStrategy.getFieldName(persistentProperty);});
+    }
+
+}


### PR DESCRIPTION
Revert back to our JsonNamingStrategy

DSND-185

fixes the `address_line1` to `address_line_1` issue:

![Screenshot 2021-09-17 at 13 26 12](https://user-images.githubusercontent.com/2736331/133782340-f5fea050-2518-4e49-8e82-b3295521a2ec.png)

