### PR TITLE
Stop storing of of date deltas

### DIFF
--- a/src/main/java/uk/gov/companieshouse/company_appointments/AppointmentApiRepository.java
+++ b/src/main/java/uk/gov/companieshouse/company_appointments/AppointmentApiRepository.java
@@ -12,4 +12,16 @@ public interface AppointmentApiRepository extends MongoRepository<AppointmentApi
         return save(new AppointmentApiEntity(appointmentAPI));
     }
 
+    /**
+     * Checks for the existence of an appointment with a particular ID and a deltaAt greater then
+     * the one provided. The comparison of deltaAt is lexicographical as the field is a string.
+     * When the field is a numeric timestamp this produces the desired behaviour, however, if the
+     * deltaAt field contains characters which are not numeric then is will produce incorrect results.
+     * As the incoming data is assumed to be correct, this shouldn't be an issue.
+     *
+     * @param id The id of the appointment to check
+     * @param deltaAt The incoming deltaAt to compare to
+     * @return if there exists an appointment with a newer deltaAt field
+     */
+    boolean existsByIdAndDeltaAtGreaterThanEqual(final String id, final String deltaAt);
 }

--- a/src/main/java/uk/gov/companieshouse/company_appointments/CompanyAppointmentV2Controller.java
+++ b/src/main/java/uk/gov/companieshouse/company_appointments/CompanyAppointmentV2Controller.java
@@ -38,8 +38,8 @@ public class CompanyAppointmentV2Controller {
 
     @PutMapping(consumes = "application/json")
     public ResponseEntity<Void> submitOfficerData(@RequestBody final AppointmentAPI companyAppointmentData) {
+        companyAppointmentService.insertAppointmentDelta(companyAppointmentData);
 
-        companyAppointmentService.putAppointmentData(companyAppointmentData);
         return ResponseEntity.ok().build();
     }
 

--- a/src/main/java/uk/gov/companieshouse/company_appointments/model/data/AppointmentApiEntity.java
+++ b/src/main/java/uk/gov/companieshouse/company_appointments/model/data/AppointmentApiEntity.java
@@ -12,4 +12,7 @@ public class AppointmentApiEntity extends AppointmentAPI {
             appointmentAPI.getPreviousOfficerId(), appointmentAPI.getDeltaAt());
     }
 
+    // No arg constructor needed for Spring data
+    public AppointmentApiEntity() {
+    }
 }

--- a/src/test/java/uk/gov/companieshouse/company_appointments/CompanyAppointmentServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/company_appointments/CompanyAppointmentServiceTest.java
@@ -3,20 +3,28 @@ package uk.gov.companieshouse.company_appointments;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.function.Executable;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.verification.VerificationMode;
 import uk.gov.companieshouse.api.model.delta.officers.AppointmentAPI;
 import uk.gov.companieshouse.api.model.delta.officers.OfficerAPI;
 import uk.gov.companieshouse.company_appointments.model.data.CompanyAppointmentData;
 import uk.gov.companieshouse.company_appointments.model.view.CompanyAppointmentView;
+
+import java.util.Optional;
+import java.util.stream.Stream;
 
 @ExtendWith(MockitoExtension.class)
 class CompanyAppointmentServiceTest {
@@ -44,10 +52,22 @@ class CompanyAppointmentServiceTest {
 
     private final static String APPOINTMENT_ID = "345678";
 
+    private static Stream<Arguments> deltaAtTestCases() {
+        return Stream.of(
+                // exitingDelta, incomingDelta, shouldBeStale
+                Arguments.of("1", "2", false), // 1 < 2 so delta should not be stale
+                Arguments.of("11", "1", true), // shorter string is considered less than
+                Arguments.of("2", "1", true), // 2 < 1 so delta should be stale
+                Arguments.of("1", "1", true), // 1 == 1 so delta should be stale
+                Arguments.of("20140925171003950844", "20140925171003950845", false), // Newer timestamp not stale
+                Arguments.of("20140925171003950844", "20140925171003950843", true) // Older timestamp stale
+        );
+    }
+
     @BeforeEach
     void setUp() {
         companyAppointmentService = new CompanyAppointmentService(companyAppointmentRepository,
-            appointmentApiRepository, companyAppointmentMapper);
+                appointmentApiRepository, companyAppointmentMapper);
     }
 
     @Test
@@ -79,11 +99,48 @@ class CompanyAppointmentServiceTest {
 
     @Test
     void testPutAppointmentData() {
-        // when
-        appointment = new AppointmentAPI("id", new OfficerAPI(), "internalId", "appointmentId", "officerId", "previousOfficerId", "deltaAt");
-        companyAppointmentService.putAppointmentData(appointment);
+        // given
+        appointment = new AppointmentAPI(
+                "id",
+                new OfficerAPI(),
+                "internalId",
+                "appointmentId",
+                "officerId",
+                "previousOfficerId",
+                "deltaAt");
+
+        // When
+        companyAppointmentService.insertAppointmentDelta(appointment);
 
         // then
         verify(appointmentApiRepository).insertOrUpdate(appointment);
+    }
+
+    @ParameterizedTest
+    @MethodSource("deltaAtTestCases")
+    void testRejectStaleDelta(
+            final String existingDeltaAt,
+            final String incomingDeltaAt,
+            boolean shouldBeStale) throws Exception {
+
+        // given
+        appointment = new AppointmentAPI(
+                "id",
+                new OfficerAPI(),
+                "internalId",
+                "appointmentId",
+                "officerId",
+                "previousOfficerId",
+                incomingDeltaAt);
+
+        when(appointmentApiRepository.existsByIdAndDeltaAtGreaterThanEqual("id", appointment.getDeltaAt()))
+                .thenReturn(existingDeltaAt.compareTo(appointment.getDeltaAt()) >= 0);
+
+        // When
+        companyAppointmentService.insertAppointmentDelta(appointment);
+
+        // then
+        final VerificationMode verificationMode = shouldBeStale ? never() : atLeastOnce();
+        verify(appointmentApiRepository, verificationMode).insertOrUpdate(appointment);
     }
 }

--- a/src/test/java/uk/gov/companieshouse/company_appointments/CompanyAppointmentV2ControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/company_appointments/CompanyAppointmentV2ControllerTest.java
@@ -2,6 +2,7 @@ package uk.gov.companieshouse.company_appointments;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -67,12 +68,10 @@ class CompanyAppointmentV2ControllerTest {
     @Test
     void testControllerReturns200WhenDataSubmitted() {
         // given
-        when(companyAppointmentService.putAppointmentData(appointment)).thenReturn(appointment);
 
         // when
         ResponseEntity<Void> response = companyAppointmentV2Controller.submitOfficerData(appointment);
 
         assertEquals(HttpStatus.OK, response.getStatusCode());
     }
-
 }


### PR DESCRIPTION
Prevents appointment deltas being stored in the database if there is an existing appointment with a deltaAt greater than, or equal to, the incoming delta.

On receiving an out-of-date appointment delta, an error log message is produced and the delta  is produced.

The "out-of-date-ness" of a delta is checked with a mongo query that checks for the existance and a record with a deltaAt field greaterThanOrEqual to the incoming appointment. This comparison is lexographical, not numeric, but produces the correct behaviour when the deltaAt field is numeric.