### PR TITLE
Remove additional properties on save

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
 
         <structured-logging.version>1.9.4</structured-logging.version>
         <sdk-manager-java.version>1.5.1</sdk-manager-java.version>
-        <private-api-sdk-java.version>2.0.94</private-api-sdk-java.version>
+        <private-api-sdk-java.version>2.0.95</private-api-sdk-java.version>
 
         <!--sonar configuration-->
         <sonar.coverage.jacoco.xmlReportPaths>${project.basedir}/target/site/jacoco/jacoco.xml,

--- a/src/test/java/uk/gov/companieshouse/company_appointments/CompanyAppointmentServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/company_appointments/CompanyAppointmentServiceTest.java
@@ -5,10 +5,12 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.function.Executable;
@@ -18,11 +20,18 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.verification.VerificationMode;
+import uk.gov.companieshouse.api.model.delta.officers.AddressAPI;
 import uk.gov.companieshouse.api.model.delta.officers.AppointmentAPI;
+import uk.gov.companieshouse.api.model.delta.officers.FormerNamesAPI;
+import uk.gov.companieshouse.api.model.delta.officers.IdentificationAPI;
+import uk.gov.companieshouse.api.model.delta.officers.LinksAPI;
 import uk.gov.companieshouse.api.model.delta.officers.OfficerAPI;
+import uk.gov.companieshouse.api.model.delta.officers.OfficerLinksAPI;
 import uk.gov.companieshouse.company_appointments.model.data.CompanyAppointmentData;
 import uk.gov.companieshouse.company_appointments.model.view.CompanyAppointmentView;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
 import java.util.stream.Stream;
 
@@ -142,5 +151,54 @@ class CompanyAppointmentServiceTest {
         // then
         final VerificationMode verificationMode = shouldBeStale ? never() : atLeastOnce();
         verify(appointmentApiRepository, verificationMode).insertOrUpdate(appointment);
+    }
+
+
+    @Test
+    @DisplayName("Tests if the additionalProperties field is set to null to prevent being stored")
+    void additionalPropertiesRemoved() {
+        // given
+        final OfficerAPI officer = spy(OfficerAPI.class);
+
+        final AddressAPI serviceAddress = spy(AddressAPI.class);
+        when(officer.getServiceAddress()).thenReturn(serviceAddress);
+
+        final AddressAPI ura = spy(AddressAPI.class);
+        when(officer.getUsualResidentialAddress()).thenReturn(ura);
+
+        final FormerNamesAPI formerName = spy(FormerNamesAPI.class);
+        final List<FormerNamesAPI> formerNames = new ArrayList<>();
+        formerNames.add(formerName);
+        when(officer.getFormerNameData()).thenReturn(formerNames);
+
+        final IdentificationAPI identificationAPI = spy(IdentificationAPI.class);
+        when(officer.getIdentificationData()).thenReturn(identificationAPI);
+
+        final LinksAPI linksAPI = spy(LinksAPI.class);
+        when(officer.getLinksData()).thenReturn(linksAPI);
+
+        final OfficerLinksAPI officerLinksAPI = spy(OfficerLinksAPI.class);
+        when(linksAPI.getOfficerLinksData()).thenReturn(officerLinksAPI);
+
+        appointment = spy(new AppointmentAPI(
+                "id",
+                officer,
+                "internalId",
+                "appointmentId",
+                "officerId",
+                "previousOfficerId",
+                "deltaAt"));
+
+        // When
+        companyAppointmentService.insertAppointmentDelta(appointment);
+
+        // then
+        verify(officer).setAdditionalProperties(null);
+        verify(serviceAddress).setAdditionalProperties(null);
+        verify(ura).setAdditionalProperties(null);
+        verify(formerName).setAdditionalProperties(null);
+        verify(identificationAPI).setAdditionalProperties(null);
+        verify(linksAPI).setAdditionalProperties(null);
+        verify(officerLinksAPI).setAdditionalProperties(null);
     }
 }


### PR DESCRIPTION
Prevents the additional properties field from being daved by setting it to null before saving in the database. 

Related SDK PR: https://github.com/companieshouse/private-api-sdk-java/pull/123

Resolves: [DSND-196](https://companieshouse.atlassian.net/browse/DSND-196)