### PR TITLE
Add authentication on endpoint to return officer data

### DIFF
--- a/src/it/java/uk/gov/companieshouse/company_appointments/AuthenticationInterceptorsIT.java
+++ b/src/it/java/uk/gov/companieshouse/company_appointments/AuthenticationInterceptorsIT.java
@@ -1,0 +1,137 @@
+package uk.gov.companieshouse.company_appointments;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.HttpHeaders;
+import org.springframework.test.web.servlet.MockMvc;
+import uk.gov.companieshouse.api.model.delta.officers.OfficerAPI;
+import uk.gov.companieshouse.company_appointments.config.LoggingConfig;
+import uk.gov.companieshouse.company_appointments.interceptor.AuthenticationHelperImpl;
+import uk.gov.companieshouse.company_appointments.interceptor.AuthenticationInterceptor;
+import uk.gov.companieshouse.company_appointments.model.view.CompanyAppointmentFullRecordView;
+import uk.gov.companieshouse.company_appointments.model.view.CompanyAppointmentView;
+import uk.gov.companieshouse.logging.Logger;
+
+@WebMvcTest(controllers = {CompanyAppointmentController.class, CompanyAppointmentFullRecordController.class})
+@Import({LoggingConfig.class, AuthenticationHelperImpl.class})
+class AuthenticationInterceptorsIT {
+    private static final String APP_ID = "N-YqKNwdT_HvetusfTJ0H0jAQbA";
+    private static final String COMPANY_NUMBER = "09876543";
+    private static final String AUTH_EMAIL = "user@somewhere.com";
+    private static final String NAME = "OFFICER";
+    public static final String URL_TEMPLATE = "/company/{company_number}/appointments/{appointment_id}";
+    public static final String URL_TEMPLATE_FULL_RECORD = URL_TEMPLATE + "/full_record";
+
+    @Autowired
+    private MockMvc mockMvc;
+    @Autowired
+    private AuthenticationInterceptor authenticationInterceptor;
+    @MockBean
+    private Logger logger;
+    @MockBean
+    private CompanyAppointmentService companyAppointmentService;
+    @MockBean
+    private CompanyAppointmentFullRecordService companyAppointmentFullRecordService;
+
+    private HttpHeaders httpHeaders;
+    private CompanyAppointmentView companyAppointmentView;
+    private CompanyAppointmentFullRecordView companyAppointmentFullRecordView;
+
+    @BeforeEach
+    void setUp() {
+        httpHeaders = new HttpHeaders();
+        companyAppointmentView = CompanyAppointmentView.builder().withName(NAME)
+                .build();
+        companyAppointmentFullRecordView =
+                CompanyAppointmentFullRecordView.Builder.view(new OfficerAPI()).withName(NAME)
+                        .build();
+    }
+
+    @Test
+    void fetchAppointmentWhenOauth2AuthThenAllowed() throws Exception {
+        addOauth2Headers();
+        when(companyAppointmentService.fetchAppointment(COMPANY_NUMBER, APP_ID)).thenReturn(companyAppointmentView);
+        mockMvc.perform(get(URL_TEMPLATE, COMPANY_NUMBER, APP_ID).headers(httpHeaders))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.name").value(NAME));
+    }
+
+    @Test
+    void fetchAppointmentWhenPrivilegedKeyAuthThenAllowed() throws Exception {
+        addApiKeyHeaders(true);
+        when(companyAppointmentService.fetchAppointment(COMPANY_NUMBER, APP_ID)).thenReturn(companyAppointmentView);
+        mockMvc.perform(get(URL_TEMPLATE, COMPANY_NUMBER, APP_ID).headers(httpHeaders))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.name").value(NAME));
+    }
+
+    @Test
+    void fetchAppointmentWhenNonPrivilegedKeyAuthThenAllowed() throws Exception {
+        addApiKeyHeaders(false);
+        when(companyAppointmentService.fetchAppointment(COMPANY_NUMBER, APP_ID)).thenReturn(companyAppointmentView);
+        mockMvc.perform(get(URL_TEMPLATE, COMPANY_NUMBER, APP_ID).headers(httpHeaders))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.name").value(NAME));
+    }
+
+    @Test
+    void fetchAppointmentWhenAuthMissingThenDenied() throws Exception {
+        mockMvc.perform(get(URL_TEMPLATE, COMPANY_NUMBER, APP_ID).headers(httpHeaders))
+                .andDo(print())
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void getAppointmentWhenPrivilegedKeyAuthThenAllowed() throws Exception {
+        addApiKeyHeaders(true);
+        when(companyAppointmentFullRecordService.getAppointment(COMPANY_NUMBER, APP_ID)).thenReturn(
+                companyAppointmentFullRecordView);
+        mockMvc.perform(get(URL_TEMPLATE_FULL_RECORD, COMPANY_NUMBER, APP_ID).headers(httpHeaders))
+                .andDo(print())
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.name").value(NAME));
+    }
+
+    @Test
+    void getAppointmentWhenPrivilegedKeyMissingThenDenied() throws Exception {
+        addOauth2Headers();
+        mockMvc.perform(get(URL_TEMPLATE_FULL_RECORD, COMPANY_NUMBER, APP_ID).headers(httpHeaders))
+                .andDo(print())
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void getAppointmentWhenAuthKeyNotPrivilegedThenDenied() throws Exception {
+        addApiKeyHeaders(false);
+        mockMvc.perform(get(URL_TEMPLATE_FULL_RECORD, COMPANY_NUMBER, APP_ID).headers(httpHeaders))
+                .andDo(print())
+                .andExpect(status().isUnauthorized());
+    }
+
+    private void addOauth2Headers() {
+        httpHeaders.add("ERIC-Identity-Type", "oauth2");
+        httpHeaders.add("ERIC-Identity", "user");
+        httpHeaders.add("ERIC-Authorised-User", AUTH_EMAIL);
+    }
+
+    private void addApiKeyHeaders(final boolean isPrivileged) {
+        httpHeaders.add("ERIC-Identity-Type", "key");
+        httpHeaders.add("ERIC-Identity", "user");
+        httpHeaders.add("ERIC-Authorised-User", AUTH_EMAIL);
+        httpHeaders.add("ERIC-Authorised-Key-Roles", isPrivileged ? "*" : "none");
+    }
+
+}

--- a/src/main/java/uk/gov/companieshouse/company_appointments/config/Config.java
+++ b/src/main/java/uk/gov/companieshouse/company_appointments/config/Config.java
@@ -5,20 +5,26 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 import uk.gov.companieshouse.company_appointments.interceptor.AuthenticationInterceptor;
+import uk.gov.companieshouse.company_appointments.interceptor.FullRecordAuthenticationInterceptor;
 import uk.gov.companieshouse.company_appointments.interceptor.RequestLoggingInterceptor;
 
 @Configuration
 public class Config implements WebMvcConfigurer {
+    public static final String PATTERN_FULL_RECORD = "/**/full_record";
     @Autowired
     private RequestLoggingInterceptor loggingInterceptor;
 
     @Autowired
     private AuthenticationInterceptor authenticationInterceptor;
 
+    @Autowired
+    private FullRecordAuthenticationInterceptor fullRecordAuthenticationInterceptor;
+
     @Override
     public void addInterceptors(InterceptorRegistry registry) {
         registry.addInterceptor(loggingInterceptor);
-        registry.addInterceptor(authenticationInterceptor);
+        registry.addInterceptor(authenticationInterceptor).excludePathPatterns(PATTERN_FULL_RECORD);
+        registry.addInterceptor(fullRecordAuthenticationInterceptor).addPathPatterns(PATTERN_FULL_RECORD);
     }
 
 }

--- a/src/main/java/uk/gov/companieshouse/company_appointments/interceptor/AuthenticationHelper.java
+++ b/src/main/java/uk/gov/companieshouse/company_appointments/interceptor/AuthenticationHelper.java
@@ -1,0 +1,122 @@
+package uk.gov.companieshouse.company_appointments.interceptor;
+
+import javax.servlet.http.HttpServletRequest;
+
+/**
+ * Helper class for authenticating users
+ */
+public interface AuthenticationHelper {
+
+    /**
+     * Returns the authorised identify
+     *
+     * @param request the {@link HttpServletRequest}
+     * @return the identify
+     */
+    String getAuthorisedIdentity(HttpServletRequest request);
+
+    /**
+     * Returns the authorised identity type
+     *
+     * @param request the {@link HttpServletRequest}
+     * @return the identity type
+     */
+    String getAuthorisedIdentityType(HttpServletRequest request);
+
+    /**
+     * Verifies that the identity type is key
+     *
+     * @param identityType the identify type to be checked
+     * @return true if the identity type is the key
+     */
+    boolean isApiKeyIdentityType(final String identityType);
+
+    /**
+     * Verifies that the identity type is Oauth2
+     *
+     * @param identityType the identity type to be checked
+     * @return true if the identity type is Oauth2
+     */
+    boolean isOauth2IdentityType(final String identityType);
+
+    /**
+     * Returns the authorised user information
+     *
+     * @param request the {@link HttpServletRequest}
+     * @return the authorised user
+     */
+    String getAuthorisedUser(HttpServletRequest request);
+
+    /**
+     * Returns the authorised user email
+     *
+     * @param request the {@link HttpServletRequest}
+     * @return the user email
+     */
+    String getAuthorisedUserEmail(HttpServletRequest request);
+
+    /**
+     * Returns the authorised user forename
+     *
+     * @param request the {@link HttpServletRequest}
+     * @return the authorised user forename
+     */
+    String getAuthorisedUserForename(HttpServletRequest request);
+
+    /**
+     * Returns the authorised user surname
+     *
+     * @param request the {@link HttpServletRequest}
+     * @return the authorised user surname
+     */
+    String getAuthorisedUserSurname(HttpServletRequest request);
+
+    /**
+     * Returns the authorised scope
+     *
+     * @param request the {@link HttpServletRequest}
+     * @return the authorised scope
+     */
+    String getAuthorisedScope(HttpServletRequest request);
+
+    /**
+     * Returns the authorised roles information
+     *
+     * @param request the {@link HttpServletRequest}
+     * @return the authorised roles
+     */
+    String getAuthorisedRoles(HttpServletRequest request);
+
+    /**
+     * Returns an array of the authorised roles
+     *
+     * @param request the {@link HttpServletRequest}
+     * @return the authorised roles
+     */
+    String[] getAuthorisedRolesArray(HttpServletRequest request);
+
+    /**
+     * Checks whether the specified role has authorisation
+     *
+     * @param request the {@link HttpServletRequest}
+     * @param role the role to be checked
+     * @return true if the role is authorised
+     */
+    boolean isRoleAuthorised(HttpServletRequest request, String role);
+
+    /**
+     * Returns the authorised key role
+     *
+     * @param request the {@link HttpServletRequest}
+     * @return the key role
+     */
+    String getAuthorisedKeyRoles(HttpServletRequest request);
+
+    /**
+     * Checks whether the key has elevated privileges
+     *
+     * @param request the {@link HttpServletRequest}
+     * @return true if the key has elevated privileges
+     */
+    boolean isKeyElevatedPrivilegesAuthorised(HttpServletRequest request);
+}

--- a/src/main/java/uk/gov/companieshouse/company_appointments/interceptor/AuthenticationHelperImpl.java
+++ b/src/main/java/uk/gov/companieshouse/company_appointments/interceptor/AuthenticationHelperImpl.java
@@ -1,0 +1,147 @@
+package uk.gov.companieshouse.company_appointments.interceptor;
+
+import org.apache.commons.lang.ArrayUtils;
+import org.springframework.stereotype.Component;
+
+import javax.servlet.http.HttpServletRequest;
+
+/**
+ * Helper class for user authentication
+ */
+@Component
+public class AuthenticationHelperImpl implements AuthenticationHelper {
+    public static final String OAUTH2_IDENTITY_TYPE = "oauth2";
+    public static final String API_KEY_IDENTITY_TYPE = "key";
+    public static final String API_KEY_ELEVATED_ROLE = "*";
+
+    public static final int USER_EMAIL_INDEX = 0;
+    public static final int USER_FORENAME_INDEX = 1;
+    public static final int USER_SURNAME_INDEX = 2;
+
+    private static final String ERIC_IDENTITY = "ERIC-Identity";
+    private static final String ERIC_IDENTITY_TYPE = "ERIC-Identity-Type";
+    private static final String ERIC_AUTHORISED_USER = "ERIC-Authorised-User";
+    private static final String ERIC_AUTHORISED_SCOPE = "ERIC-Authorised-Scope";
+    private static final String ERIC_AUTHORISED_ROLES = "ERIC-Authorised-Roles";
+    private static final String ERIC_AUTHORISED_KEY_ROLES = "ERIC-Authorised-Key-Roles";
+
+    @Override
+    public String getAuthorisedIdentity(HttpServletRequest request) {
+        return getRequestHeader(request, ERIC_IDENTITY);
+    }
+
+    @Override
+    public String getAuthorisedIdentityType(HttpServletRequest request) {
+        return getRequestHeader(request, ERIC_IDENTITY_TYPE);
+    }
+
+    @Override
+    public boolean isApiKeyIdentityType(final String identityType) {
+        return API_KEY_IDENTITY_TYPE.equals(identityType);
+    }
+
+    @Override
+    public boolean isOauth2IdentityType(final String identityType) {
+        return OAUTH2_IDENTITY_TYPE.equals(identityType);
+    }
+
+    @Override
+    public String getAuthorisedUser(HttpServletRequest request) {
+        return getRequestHeader(request, ERIC_AUTHORISED_USER);
+    }
+
+    @Override
+    public String getAuthorisedUserEmail(HttpServletRequest request) {
+        final String authorisedUser = getAuthorisedUser(request);
+
+        if (authorisedUser == null || authorisedUser.trim().length() == 0) {
+            return null;
+        }
+        else {
+            final String[] details = authorisedUser.split(";");
+
+            return indexExists(details, USER_EMAIL_INDEX) ? details[USER_EMAIL_INDEX].trim() : null;
+        }
+    }
+
+    @Override
+    public String getAuthorisedUserForename(HttpServletRequest request) {
+        return getUserAttribute(request, USER_FORENAME_INDEX);
+    }
+
+    @Override
+    public String getAuthorisedUserSurname(HttpServletRequest request) {
+        return getUserAttribute(request, USER_SURNAME_INDEX);
+    }
+
+    @Override
+    public String getAuthorisedScope(HttpServletRequest request) {
+        return getRequestHeader(request, ERIC_AUTHORISED_SCOPE);
+    }
+
+    @Override
+    public String getAuthorisedRoles(HttpServletRequest request) {
+        return getRequestHeader(request, ERIC_AUTHORISED_ROLES);
+    }
+
+    @Override
+    public String[] getAuthorisedRolesArray(HttpServletRequest request) {
+        String roles = getAuthorisedRoles(request);
+        if (roles == null || roles.length() == 0) {
+            return new String[0];
+        }
+
+        // roles are space separated list of authorized roles
+        return roles.split(" ");
+    }
+
+    @Override
+    public boolean isRoleAuthorised(HttpServletRequest request, String role) {
+        if (role == null || role.length() == 0) {
+            return false;
+        }
+
+        String[] roles = getAuthorisedRolesArray(request);
+        if (roles.length == 0) {
+            return false;
+        }
+
+        return ArrayUtils.contains(roles, role);
+    }
+
+    @Override
+    public String getAuthorisedKeyRoles(HttpServletRequest request) {
+        return getRequestHeader(request, ERIC_AUTHORISED_KEY_ROLES);
+    }
+
+    @Override
+    public boolean isKeyElevatedPrivilegesAuthorised(HttpServletRequest request) {
+        return API_KEY_ELEVATED_ROLE.equals(getAuthorisedKeyRoles(request));
+    }
+
+    private String getRequestHeader(HttpServletRequest request, String header) {
+        return request == null ? null : request.getHeader(header);
+    }
+
+    private String getUserAttribute(final HttpServletRequest request, final int userAttributeIndex) {
+        final String authorisedUser = getAuthorisedUser(request);
+
+        if (authorisedUser == null || authorisedUser.trim().length() == 0) {
+            return null;
+        }
+        else {
+            final String[] details = authorisedUser.split(";");
+
+            return indexExists(details, userAttributeIndex) ? getValue(details[userAttributeIndex].trim()) : null;
+        }
+    }
+
+    private String getValue(String value) {
+        return indexExists(value.split("="), 1) ? value.split("=")[1] : null;
+    }
+
+    private boolean indexExists(final String[] list, final int index) {
+        return index >= 0 && index < list.length;
+    }
+
+}

--- a/src/main/java/uk/gov/companieshouse/company_appointments/interceptor/FullRecordAuthenticationInterceptor.java
+++ b/src/main/java/uk/gov/companieshouse/company_appointments/interceptor/FullRecordAuthenticationInterceptor.java
@@ -1,0 +1,33 @@
+package uk.gov.companieshouse.company_appointments.interceptor;
+
+import org.apache.http.HttpStatus;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+@Component
+public class FullRecordAuthenticationInterceptor implements HandlerInterceptor {
+    private AuthenticationHelper authHelper;
+
+    @Autowired
+    public FullRecordAuthenticationInterceptor(AuthenticationHelper authHelper) {
+        this.authHelper = authHelper;
+    }
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) {
+        final String identityType = authHelper.getAuthorisedIdentityType(request);
+        boolean shouldAllow = true;
+
+        if (!(authHelper.isApiKeyIdentityType(identityType) && authHelper.isKeyElevatedPrivilegesAuthorised(request))) {
+            shouldAllow = false;
+            response.setStatus(HttpStatus.SC_UNAUTHORIZED);
+        }
+
+        return shouldAllow;
+    }
+
+}

--- a/src/test/java/uk/gov/companieshouse/company_appointments/config/ConfigTest.java
+++ b/src/test/java/uk/gov/companieshouse/company_appointments/config/ConfigTest.java
@@ -1,0 +1,57 @@
+package uk.gov.companieshouse.company_appointments.config;
+
+import static org.mockito.ArgumentMatchers.contains;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistration;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import uk.gov.companieshouse.company_appointments.interceptor.AuthenticationInterceptor;
+import uk.gov.companieshouse.company_appointments.interceptor.FullRecordAuthenticationInterceptor;
+import uk.gov.companieshouse.company_appointments.interceptor.RequestLoggingInterceptor;
+
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration(classes = Config.class)
+class ConfigTest {
+    @Autowired
+    private Config testConfig;
+
+    @Mock
+    private InterceptorRegistry registry;
+    @Mock
+    private InterceptorRegistration registration;
+    @MockBean
+    private RequestLoggingInterceptor requestLoggingInterceptor;
+    @MockBean
+    private AuthenticationInterceptor authenticationInterceptor;
+    @MockBean
+    private FullRecordAuthenticationInterceptor fullRecordAuthenticationInterceptor;
+
+    @Test
+    void addInterceptors() {
+        when(registry.addInterceptor(requestLoggingInterceptor)).thenReturn(registration);
+        when(registry.addInterceptor(authenticationInterceptor)).thenReturn(registration);
+        when(registry.addInterceptor(fullRecordAuthenticationInterceptor)).thenReturn(registration);
+
+        testConfig.addInterceptors(registry);
+
+        InOrder inOrder = inOrder(registry);
+
+        inOrder.verify(registry).addInterceptor(requestLoggingInterceptor);
+        inOrder.verify(registry).addInterceptor(authenticationInterceptor);
+        inOrder.verify(registry).addInterceptor(fullRecordAuthenticationInterceptor);
+        verify(registration).excludePathPatterns(contains("/full_record"));
+        verify(registration).addPathPatterns(contains("/full_record"));
+        verifyNoMoreInteractions(registry, registration);
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/company_appointments/interceptor/AuthenticationHelperImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/company_appointments/interceptor/AuthenticationHelperImplTest.java
@@ -1,0 +1,285 @@
+package uk.gov.companieshouse.company_appointments.interceptor;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import javax.servlet.http.HttpServletRequest;
+import java.text.MessageFormat;
+
+@ExtendWith(MockitoExtension.class)
+class AuthenticationHelperImplTest {
+    private static final String USER_EMAIL = "user@somewhere.email.com";
+    private static final String USER_FORENAME = "Quentin";
+    private static final String USER_SURNAME = "Schaden";
+
+    private AuthenticationHelper testHelper;
+
+    @Mock
+    private HttpServletRequest request;
+
+    @BeforeEach
+    void setUp() {
+        testHelper = new AuthenticationHelperImpl();
+    }
+
+    @Test
+    void getAuthorisedIdentityWhenRequestNull() {
+
+        assertThat(testHelper.getAuthorisedIdentity(null), is(nullValue()));
+    }
+
+    @Test
+    void getAuthorisedIdentityWhenRequestNotNull() {
+        String expected = "identity";
+
+        when(request.getHeader("ERIC-Identity")).thenReturn(expected);
+
+        assertThat(testHelper.getAuthorisedIdentity(request), is(expected));
+    }
+
+    @Test
+    void getAuthorisedIdentityType() {
+        String expected = "identity-type";
+
+        when(request.getHeader("ERIC-Identity-Type")).thenReturn(expected);
+
+        assertThat(testHelper.getAuthorisedIdentityType(request), is(expected));
+    }
+
+    @Test
+    void isApiKeyIdentityTypeWhenItIs() {
+        assertThat(testHelper.isApiKeyIdentityType("key"), is(true));
+    }
+
+    @Test
+    void isApiKeyIdentityTypeWhenItIsNot() {
+        assertThat(testHelper.isApiKeyIdentityType("KEY"), is(false));
+    }
+
+    @Test
+    void isOauth2IdentityTypeWhenItIs() {
+        assertThat(testHelper.isOauth2IdentityType("oauth2"), is(true));
+    }
+
+    @Test
+    void isOauth2IdentityTypeWhenItIsNot() {
+        assertThat(testHelper.isOauth2IdentityType("Oauth2"), is(false));
+    }
+
+    @Test
+    void getAuthorisedUser() {
+        String expected = "authorised-user";
+
+        when(request.getHeader("ERIC-Authorised-User")).thenReturn(expected);
+
+        assertThat(testHelper.getAuthorisedUser(request), is(expected));
+    }
+
+    @Test
+    void getAuthorisedUserEmail() {
+        when(request.getHeader("ERIC-Authorised-User")).thenReturn(
+                MessageFormat.format("{0};forename={1};surname={2}", USER_EMAIL, USER_FORENAME, USER_SURNAME));
+
+        assertThat(testHelper.getAuthorisedUserEmail(request), is(USER_EMAIL));
+    }
+
+    @Test
+    void getAuthorisedUserEmailWhenUserNul() {
+        assertThat(testHelper.getAuthorisedUserEmail(request), is(nullValue()));
+    }
+
+    @Test
+    void getAuthorisedUserEmailWhenUserMissing() {
+        when(request.getHeader("ERIC-Authorised-User")).thenReturn("");
+
+        assertThat(testHelper.getAuthorisedUserEmail(request), is(nullValue()));
+    }
+
+    @Test
+    void getAuthorisedUserEmailWhenEmpty() {
+        when(request.getHeader("ERIC-Authorised-User")).thenReturn(";");
+
+        assertThat(testHelper.getAuthorisedUserEmail(request), is(nullValue()));
+    }
+
+    @Test
+    void getAuthorisedUserEmailWhenNull() {
+        assertThat(testHelper.getAuthorisedUserEmail(request), is(nullValue()));
+    }
+
+    @Test
+    void getAuthorisedUserForename() {
+        when(request.getHeader("ERIC-Authorised-User")).thenReturn(
+                MessageFormat.format("{0};forename={1};surname={2}", USER_EMAIL, USER_FORENAME, USER_SURNAME));
+
+        assertThat(testHelper.getAuthorisedUserForename(request), is(USER_FORENAME));
+    }
+
+    @Test
+    void getAuthorisedUserForenameWhenUserNull() {
+        assertThat(testHelper.getAuthorisedUserForename(request), is(nullValue()));
+    }
+
+    @Test
+    void getAuthorisedUserForenameWhenUserEmpty() {
+        when(request.getHeader("ERIC-Authorised-User")).thenReturn("");
+
+        assertThat(testHelper.getAuthorisedUserForename(request), is(nullValue()));
+    }
+
+    @Test
+    void getAuthorisedUserForenameWhenMissing() {
+        when(request.getHeader("ERIC-Authorised-User")).thenReturn(
+                MessageFormat.format("{0}", USER_EMAIL));
+
+        assertThat(testHelper.getAuthorisedUserForename(request), is(nullValue()));
+    }
+
+    @Test
+    void getAuthorisedUserForenameWhenUnnamed() {
+        when(request.getHeader("ERIC-Authorised-User")).thenReturn(
+                MessageFormat.format("{0};{1}", USER_EMAIL, USER_FORENAME));
+
+        assertThat(testHelper.getAuthorisedUserForename(request), is(nullValue()));
+    }
+
+    @Test
+    void getAuthorisedUserSurname() {
+        when(request.getHeader("ERIC-Authorised-User")).thenReturn(
+                MessageFormat.format("{0};forename={1};surname={2}", USER_EMAIL, USER_FORENAME, USER_SURNAME));
+
+        assertThat(testHelper.getAuthorisedUserSurname(request), is(USER_SURNAME));
+    }
+
+    @Test
+    void getAuthorisedUserSurnameWhenMissing() {
+        when(request.getHeader("ERIC-Authorised-User")).thenReturn(
+                MessageFormat.format("{0};forename={1}", USER_EMAIL, USER_FORENAME));
+
+        assertThat(testHelper.getAuthorisedUserSurname(request), is(nullValue()));
+    }
+
+    @Test
+    void getAuthorisedUserSurnameWhenUnnamed() {
+        when(request.getHeader("ERIC-Authorised-User")).thenReturn(
+                MessageFormat.format("{0};forename={1};{2}", USER_EMAIL, USER_FORENAME, USER_SURNAME));
+
+        assertThat(testHelper.getAuthorisedUserSurname(request), is(nullValue()));
+    }
+
+    @Test
+    void getAuthorisedScope() {
+        String expected = "authorised-scope";
+
+        when(request.getHeader("ERIC-Authorised-Scope")).thenReturn(expected);
+
+        assertThat(testHelper.getAuthorisedScope(request), is(expected));
+    }
+
+    @Test
+    void getAuthorisedRoles() {
+        String expected = "authorised-roles";
+
+        when(request.getHeader("ERIC-Authorised-Roles")).thenReturn(expected);
+
+        assertThat(testHelper.getAuthorisedRoles(request), is(expected));
+    }
+
+    @Test
+    void getAuthorisedRolesArray() {
+        String[] expected = new String[]{"role-1", "role-2"};
+
+        when(request.getHeader("ERIC-Authorised-Roles")).thenReturn("role-1 role-2");
+
+        assertThat(testHelper.getAuthorisedRolesArray(request), is(expected));
+    }
+
+    @Test
+    void getAuthorisedRolesArrayWhenRolesNull() {
+        String[] expected = new String[]{};
+
+        when(request.getHeader("ERIC-Authorised-Roles")).thenReturn(null);
+
+        assertThat(testHelper.getAuthorisedRolesArray(request), is(expected));
+    }
+
+    @Test
+    void getAuthorisedRolesArrayWhenRolesEmpty() {
+        String[] expected = new String[]{};
+
+        when(request.getHeader("ERIC-Authorised-Roles")).thenReturn("");
+
+        assertThat(testHelper.getAuthorisedRolesArray(request), is(expected));
+    }
+
+    @Test
+    void isRoleAuthorisedWhenItIs() {
+        when(request.getHeader("ERIC-Authorised-Roles")).thenReturn("role-1 role-2");
+
+        assertThat(testHelper.isRoleAuthorised(request, "role-1"), is(true));
+    }
+
+    @Test
+    void isRoleAuthorisedWhenItIsNot() {
+        when(request.getHeader("ERIC-Authorised-Roles")).thenReturn("role-1 role-2");
+
+        assertThat(testHelper.isRoleAuthorised(request, "role-0"), is(false));
+    }
+
+    @Test
+    void isRoleAuthorisedWhenItIsNull() {
+        assertThat(testHelper.isRoleAuthorised(request, null), is(false));
+    }
+
+    @Test
+    void isRoleAuthorisedWhenItIsEmpty() {
+        assertThat(testHelper.isRoleAuthorised(request, ""), is(false));
+    }
+
+    @Test
+    void isRoleAuthorisedWhenRolesNull() {
+        when(request.getHeader("ERIC-Authorised-Roles")).thenReturn(null);
+
+        assertThat(testHelper.isRoleAuthorised(request, "role-1"), is(false));
+    }
+
+    @Test
+    void isRoleAuthorisedWhenRolesEmpty() {
+        when(request.getHeader("ERIC-Authorised-Roles")).thenReturn("");
+
+        assertThat(testHelper.isRoleAuthorised(request, "role-1"), is(false));
+    }
+
+    @Test
+    void getAuthorisedKeyRoles() {
+        String expected = "authorised-key-roles";
+
+        when(request.getHeader("ERIC-Authorised-Key-Roles")).thenReturn(expected);
+
+        assertThat(testHelper.getAuthorisedKeyRoles(request), is(expected));
+
+    }
+
+    @Test
+    void isKeyElevatedPrivilegesAuthorisedWhenItIs() {
+        when(request.getHeader("ERIC-Authorised-Key-Roles")).thenReturn("*");
+
+        assertThat(testHelper.isKeyElevatedPrivilegesAuthorised(request), is(true));
+    }
+
+    @Test
+    void isKeyElevatedPrivilegesAuthorisedWhenItIsNot() {
+        when(request.getHeader("ERIC-Authorised-Key-Roles")).thenReturn("role-1 role-2");
+
+        assertThat(testHelper.isKeyElevatedPrivilegesAuthorised(request), is(false));
+    }
+
+}

--- a/src/test/java/uk/gov/companieshouse/company_appointments/interceptor/FullRecordAuthenticationInterceptorTest.java
+++ b/src/test/java/uk/gov/companieshouse/company_appointments/interceptor/FullRecordAuthenticationInterceptorTest.java
@@ -1,0 +1,103 @@
+package uk.gov.companieshouse.company_appointments.interceptor;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import org.apache.http.HttpStatus;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullSource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+@ExtendWith(MockitoExtension.class)
+class FullRecordAuthenticationInterceptorTest {
+    private FullRecordAuthenticationInterceptor authenticationInterceptor;
+
+    @Mock
+    private HttpServletRequest request;
+    @Mock
+    private HttpServletResponse response;
+    @Mock
+    private Object handler;
+    @Mock
+    private AuthenticationHelper authHelper;
+
+    @BeforeEach
+    void setUp() {
+        authenticationInterceptor = new FullRecordAuthenticationInterceptor(authHelper);
+    }
+
+    @Test
+    void preHandleReturnsFalseIfIdentityTypeNotApiKey() {
+        // given
+        when(authHelper.getAuthorisedIdentityType(request)).thenReturn(AuthenticationHelperImpl.OAUTH2_IDENTITY_TYPE);
+
+        // when
+        boolean actual = authenticationInterceptor.preHandle(request, response, handler);
+
+        // then
+        checkUnauthorised(actual);
+    }
+
+    @Test
+    void preHandleReturnsFalseIfApiKeyNotElevated() {
+        // given
+        when(authHelper.getAuthorisedIdentityType(request)).thenReturn(AuthenticationHelperImpl.API_KEY_IDENTITY_TYPE);
+        when(authHelper.isApiKeyIdentityType(AuthenticationHelperImpl.API_KEY_IDENTITY_TYPE)).thenReturn(true);
+        when(authHelper.isKeyElevatedPrivilegesAuthorised(request)).thenReturn(false);
+
+        // when
+        boolean actual = authenticationInterceptor.preHandle(request, response, handler);
+
+        // then
+        checkUnauthorised(actual);
+    }
+
+    @ParameterizedTest(name = "invalid identityType: {0}")
+    @NullSource
+    @ValueSource(strings = {"", "legit"})
+    void preHandleReturnsFalseIfEricIdentityTypeIsNull(final String identityType) {
+        // given
+        when(authHelper.getAuthorisedIdentityType(request)).thenReturn(identityType);
+
+        // when
+        boolean actual = authenticationInterceptor.preHandle(request, response, handler);
+
+        // then
+        checkUnauthorised(actual);
+    }
+
+    @Test
+    void preHandleReturnsTrueIfEricIdentitySetAndIdentityTypeKey() {
+        // given
+        when(authHelper.getAuthorisedIdentityType(request)).thenReturn(AuthenticationHelperImpl.API_KEY_IDENTITY_TYPE);
+        when(authHelper.isApiKeyIdentityType(AuthenticationHelperImpl.API_KEY_IDENTITY_TYPE)).thenReturn(true);
+        when(authHelper.isKeyElevatedPrivilegesAuthorised(request)).thenReturn(true);
+
+        // when
+        boolean actual = authenticationInterceptor.preHandle(request, response, handler);
+
+        // then
+        checkAuthorised(actual);
+    }
+
+    private void checkUnauthorised(final boolean actual) {
+        assertThat(actual, is(false));
+        verify(response).setStatus(HttpStatus.SC_UNAUTHORIZED);
+    }
+
+    private void checkAuthorised(final boolean actual) {
+        assertThat(actual, is(true));
+        verifyNoInteractions(response);
+    }
+}


### PR DESCRIPTION
- add auth interceptor for 'full_record' path GET and PUT

NOTE:
officer-delta-processor and manual requests must now use a CHS key with `internal_app_privileges:true`