### PR TITLE
Replaced depreciated eric auth header

### DIFF
--- a/src/main/java/uk/gov/companieshouse/company_appointments/interceptor/AuthenticationHelper.java
+++ b/src/main/java/uk/gov/companieshouse/company_appointments/interceptor/AuthenticationHelper.java
@@ -99,18 +99,18 @@ public interface AuthenticationHelper {
      * Checks whether the specified role has authorisation
      *
      * @param request the {@link HttpServletRequest}
-     * @param role the role to be checked
+     * @param role    the role to be checked
      * @return true if the role is authorised
      */
     boolean isRoleAuthorised(HttpServletRequest request, String role);
 
     /**
-     * Returns the authorised key role
+     * Returns the privileges granted to the API key
      *
      * @param request the {@link HttpServletRequest}
-     * @return the key role
+     * @return the privileges of the API key
      */
-    String getAuthorisedKeyRoles(HttpServletRequest request);
+    String[] getApiKeyPrivileges(HttpServletRequest request);
 
     /**
      * Checks whether the key has elevated privileges

--- a/src/main/java/uk/gov/companieshouse/company_appointments/interceptor/AuthenticationHelperImpl.java
+++ b/src/main/java/uk/gov/companieshouse/company_appointments/interceptor/AuthenticationHelperImpl.java
@@ -106,6 +106,7 @@ public class AuthenticationHelperImpl implements AuthenticationHelper {
         return ArrayUtils.contains(roles, role);
     }
 
+    @Override
     public String[] getApiKeyPrivileges(HttpServletRequest request) {
         return request.getHeader("ERIC-Authorised-Key-Privileges")
                 .split(",");

--- a/src/main/java/uk/gov/companieshouse/company_appointments/interceptor/AuthenticationHelperImpl.java
+++ b/src/main/java/uk/gov/companieshouse/company_appointments/interceptor/AuthenticationHelperImpl.java
@@ -17,13 +17,14 @@ public class AuthenticationHelperImpl implements AuthenticationHelper {
     public static final int USER_EMAIL_INDEX = 0;
     public static final int USER_FORENAME_INDEX = 1;
     public static final int USER_SURNAME_INDEX = 2;
-    public static final String INTERNAL_APP_PRIVILEGE = "internal-app";
+    private static final String INTERNAL_APP_PRIVILEGE = "internal-app";
+    private static final String ERIC_AUTHORISED_KEY_PRIVILEGES_HEADER
+            = "ERIC-Authorised-Key-Privileges";
     private static final String ERIC_IDENTITY = "ERIC-Identity";
     private static final String ERIC_IDENTITY_TYPE = "ERIC-Identity-Type";
     private static final String ERIC_AUTHORISED_USER = "ERIC-Authorised-User";
     private static final String ERIC_AUTHORISED_SCOPE = "ERIC-Authorised-Scope";
     private static final String ERIC_AUTHORISED_ROLES = "ERIC-Authorised-Roles";
-    public static final String ERIC_AUTHORISED_KEY_PRIVILEGES_HEADER = "ERIC-Authorised-Key-Privileges";
 
     @Override
     public String getAuthorisedIdentity(HttpServletRequest request) {

--- a/src/main/java/uk/gov/companieshouse/company_appointments/interceptor/AuthenticationHelperImpl.java
+++ b/src/main/java/uk/gov/companieshouse/company_appointments/interceptor/AuthenticationHelperImpl.java
@@ -12,18 +12,16 @@ import javax.servlet.http.HttpServletRequest;
 public class AuthenticationHelperImpl implements AuthenticationHelper {
     public static final String OAUTH2_IDENTITY_TYPE = "oauth2";
     public static final String API_KEY_IDENTITY_TYPE = "key";
-    public static final String API_KEY_ELEVATED_ROLE = "*";
 
     public static final int USER_EMAIL_INDEX = 0;
     public static final int USER_FORENAME_INDEX = 1;
     public static final int USER_SURNAME_INDEX = 2;
-
+    public static final String INTERNAL_APP_PRIVILEGE = "internal-app";
     private static final String ERIC_IDENTITY = "ERIC-Identity";
     private static final String ERIC_IDENTITY_TYPE = "ERIC-Identity-Type";
     private static final String ERIC_AUTHORISED_USER = "ERIC-Authorised-User";
     private static final String ERIC_AUTHORISED_SCOPE = "ERIC-Authorised-Scope";
     private static final String ERIC_AUTHORISED_ROLES = "ERIC-Authorised-Roles";
-    private static final String ERIC_AUTHORISED_KEY_ROLES = "ERIC-Authorised-Key-Roles";
 
     @Override
     public String getAuthorisedIdentity(HttpServletRequest request) {
@@ -56,8 +54,7 @@ public class AuthenticationHelperImpl implements AuthenticationHelper {
 
         if (authorisedUser == null || authorisedUser.trim().length() == 0) {
             return null;
-        }
-        else {
+        } else {
             final String[] details = authorisedUser.split(";");
 
             return indexExists(details, USER_EMAIL_INDEX) ? details[USER_EMAIL_INDEX].trim() : null;
@@ -109,14 +106,14 @@ public class AuthenticationHelperImpl implements AuthenticationHelper {
         return ArrayUtils.contains(roles, role);
     }
 
-    @Override
-    public String getAuthorisedKeyRoles(HttpServletRequest request) {
-        return getRequestHeader(request, ERIC_AUTHORISED_KEY_ROLES);
+    public String[] getApiKeyPrivileges(HttpServletRequest request) {
+        return request.getHeader("ERIC-Authorised-Key-Privileges")
+                .split(",");
     }
 
     @Override
     public boolean isKeyElevatedPrivilegesAuthorised(HttpServletRequest request) {
-        return API_KEY_ELEVATED_ROLE.equals(getAuthorisedKeyRoles(request));
+        return ArrayUtils.contains(getApiKeyPrivileges(request), INTERNAL_APP_PRIVILEGE);
     }
 
     private String getRequestHeader(HttpServletRequest request, String header) {
@@ -128,8 +125,7 @@ public class AuthenticationHelperImpl implements AuthenticationHelper {
 
         if (authorisedUser == null || authorisedUser.trim().length() == 0) {
             return null;
-        }
-        else {
+        } else {
             final String[] details = authorisedUser.split(";");
 
             return indexExists(details, userAttributeIndex) ? getValue(details[userAttributeIndex].trim()) : null;

--- a/src/main/java/uk/gov/companieshouse/company_appointments/interceptor/AuthenticationHelperImpl.java
+++ b/src/main/java/uk/gov/companieshouse/company_appointments/interceptor/AuthenticationHelperImpl.java
@@ -110,13 +110,13 @@ public class AuthenticationHelperImpl implements AuthenticationHelper {
 
     @Override
     public String[] getApiKeyPrivileges(HttpServletRequest request) {
-        final String headerValue = request.getHeader(ERIC_AUTHORISED_KEY_PRIVILEGES_HEADER);
-        if (headerValue == null) {
-            return new String[]{};
-        }
+        // Could be null if header is not present
+        final String commaSeparatedPrivilegeString = request
+                .getHeader(ERIC_AUTHORISED_KEY_PRIVILEGES_HEADER);
 
-
-        return headerValue.split(",");
+        return Optional.ofNullable(commaSeparatedPrivilegeString)
+                .map(v -> v.split(","))
+                .orElse(new String[]{});
     }
 
     @Override

--- a/src/main/java/uk/gov/companieshouse/company_appointments/interceptor/AuthenticationHelperImpl.java
+++ b/src/main/java/uk/gov/companieshouse/company_appointments/interceptor/AuthenticationHelperImpl.java
@@ -22,6 +22,7 @@ public class AuthenticationHelperImpl implements AuthenticationHelper {
     private static final String ERIC_AUTHORISED_USER = "ERIC-Authorised-User";
     private static final String ERIC_AUTHORISED_SCOPE = "ERIC-Authorised-Scope";
     private static final String ERIC_AUTHORISED_ROLES = "ERIC-Authorised-Roles";
+    public static final String ERIC_AUTHORISED_KEY_PRIVILEGES_HEADER = "ERIC-Authorised-Key-Privileges";
 
     @Override
     public String getAuthorisedIdentity(HttpServletRequest request) {
@@ -108,7 +109,7 @@ public class AuthenticationHelperImpl implements AuthenticationHelper {
 
     @Override
     public String[] getApiKeyPrivileges(HttpServletRequest request) {
-        return request.getHeader("ERIC-Authorised-Key-Privileges")
+        return request.getHeader(ERIC_AUTHORISED_KEY_PRIVILEGES_HEADER)
                 .split(",");
     }
 

--- a/src/main/java/uk/gov/companieshouse/company_appointments/interceptor/AuthenticationHelperImpl.java
+++ b/src/main/java/uk/gov/companieshouse/company_appointments/interceptor/AuthenticationHelperImpl.java
@@ -4,6 +4,7 @@ import org.apache.commons.lang.ArrayUtils;
 import org.springframework.stereotype.Component;
 
 import javax.servlet.http.HttpServletRequest;
+import java.util.Optional;
 
 /**
  * Helper class for user authentication
@@ -109,8 +110,13 @@ public class AuthenticationHelperImpl implements AuthenticationHelper {
 
     @Override
     public String[] getApiKeyPrivileges(HttpServletRequest request) {
-        return request.getHeader(ERIC_AUTHORISED_KEY_PRIVILEGES_HEADER)
-                .split(",");
+        final String headerValue = request.getHeader(ERIC_AUTHORISED_KEY_PRIVILEGES_HEADER);
+        if (headerValue == null) {
+            return new String[]{};
+        }
+
+
+        return headerValue.split(",");
     }
 
     @Override

--- a/src/main/java/uk/gov/companieshouse/company_appointments/interceptor/FullRecordAuthenticationInterceptor.java
+++ b/src/main/java/uk/gov/companieshouse/company_appointments/interceptor/FullRecordAuthenticationInterceptor.java
@@ -14,8 +14,8 @@ import java.util.Map;
 
 @Component
 public class FullRecordAuthenticationInterceptor implements HandlerInterceptor {
-    private AuthenticationHelper authHelper;
-    private Logger logger;
+    private final AuthenticationHelper authHelper;
+    private final Logger logger;
 
     @Autowired
     public FullRecordAuthenticationInterceptor(AuthenticationHelper authHelper, Logger logger) {

--- a/src/test/java/uk/gov/companieshouse/company_appointments/interceptor/AuthenticationHelperImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/company_appointments/interceptor/AuthenticationHelperImplTest.java
@@ -13,6 +13,8 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import javax.servlet.http.HttpServletRequest;
 import java.text.MessageFormat;
+import java.util.HashMap;
+import java.util.Map;
 
 @ExtendWith(MockitoExtension.class)
 class AuthenticationHelperImplTest {
@@ -259,25 +261,29 @@ class AuthenticationHelperImplTest {
     }
 
     @Test
-    void getAuthorisedKeyRoles() {
-        String expected = "authorised-key-roles";
+    void getKeyPrivileges() {
+        Map<String, String[]> testValues = new HashMap<>();
+        testValues.put("role-1", new String[]{"role-1"});
+        testValues.put("role-1,role-2", new String[]{"role-1", "role-2"});
 
-        when(request.getHeader("ERIC-Authorised-Key-Roles")).thenReturn(expected);
+        testValues.forEach((headerValue, expectedPrivileges) -> {
+            when(request.getHeader("ERIC-Authorised-Key-Privileges")).thenReturn(headerValue);
 
-        assertThat(testHelper.getAuthorisedKeyRoles(request), is(expected));
-
+            assertThat(testHelper.getApiKeyPrivileges(request), is(expectedPrivileges));
+        });
     }
 
     @Test
     void isKeyElevatedPrivilegesAuthorisedWhenItIs() {
-        when(request.getHeader("ERIC-Authorised-Key-Roles")).thenReturn("*");
+        when(request.getHeader("ERIC-Authorised-Key-Privileges"))
+                .thenReturn("other-role,internal-app");
 
         assertThat(testHelper.isKeyElevatedPrivilegesAuthorised(request), is(true));
     }
 
     @Test
     void isKeyElevatedPrivilegesAuthorisedWhenItIsNot() {
-        when(request.getHeader("ERIC-Authorised-Key-Roles")).thenReturn("role-1 role-2");
+        when(request.getHeader("ERIC-Authorised-Key-Privileges")).thenReturn("role-1,role-2");
 
         assertThat(testHelper.isKeyElevatedPrivilegesAuthorised(request), is(false));
     }

--- a/src/test/java/uk/gov/companieshouse/company_appointments/interceptor/FullRecordAuthenticationInterceptorTest.java
+++ b/src/test/java/uk/gov/companieshouse/company_appointments/interceptor/FullRecordAuthenticationInterceptorTest.java
@@ -59,6 +59,7 @@ class FullRecordAuthenticationInterceptorTest {
         when(authHelper.getAuthorisedIdentityType(request)).thenReturn(AuthenticationHelperImpl.API_KEY_IDENTITY_TYPE);
         when(authHelper.isApiKeyIdentityType(AuthenticationHelperImpl.API_KEY_IDENTITY_TYPE)).thenReturn(true);
         when(authHelper.isKeyElevatedPrivilegesAuthorised(request)).thenReturn(false);
+        when(authHelper.getApiKeyPrivileges(request)).thenReturn(new String[]{});
 
         // when
         boolean actual = authenticationInterceptor.preHandle(request, response, handler);


### PR DESCRIPTION
FullRecordAuthenticationInterceptor checks if the incoming request has internal api privileges with the depreciated `ERIC-Authorised-Key-Roles` header. This PR replaces it with the `ERIC-Authorised-Key-Privileges`.