### PR TITLE
initial commit save new sensitive data block from processor

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
 
         <structured-logging.version>1.9.11</structured-logging.version>
         <sdk-manager-java.version>1.5.1</sdk-manager-java.version>
-        <private-api-sdk-java.version>2.0.190</private-api-sdk-java.version>
+        <private-api-sdk-java.version>2.0.192</private-api-sdk-java.version>
         <api-helper-java-library.version>1.4.5</api-helper-java-library.version>
         <log4j.version>2.16.0</log4j.version>
 

--- a/src/it/java/uk/gov/companieshouse/company_appointments/AuthenticationInterceptorsITest.java
+++ b/src/it/java/uk/gov/companieshouse/company_appointments/AuthenticationInterceptorsITest.java
@@ -15,6 +15,7 @@ import org.springframework.context.annotation.Import;
 import org.springframework.http.HttpHeaders;
 import org.springframework.test.web.servlet.MockMvc;
 import uk.gov.companieshouse.api.model.delta.officers.OfficerAPI;
+import uk.gov.companieshouse.api.model.delta.officers.SensitiveOfficerAPI;
 import uk.gov.companieshouse.company_appointments.config.LoggingConfig;
 import uk.gov.companieshouse.company_appointments.interceptor.AuthenticationHelperImpl;
 import uk.gov.companieshouse.company_appointments.interceptor.AuthenticationInterceptor;
@@ -53,7 +54,7 @@ class AuthenticationInterceptorsITest {
         companyAppointmentView = CompanyAppointmentView.builder().withName(NAME)
                 .build();
         companyAppointmentFullRecordView =
-                CompanyAppointmentFullRecordView.Builder.view(new OfficerAPI()).withName(NAME)
+                CompanyAppointmentFullRecordView.Builder.view(new OfficerAPI(), new SensitiveOfficerAPI()).withName(NAME)
                         .build();
     }
 

--- a/src/main/java/uk/gov/companieshouse/company_appointments/CompanyAppointmentFullRecordService.java
+++ b/src/main/java/uk/gov/companieshouse/company_appointments/CompanyAppointmentFullRecordService.java
@@ -44,7 +44,7 @@ public class CompanyAppointmentFullRecordService {
         Optional<AppointmentApiEntity> appointmentData = companyAppointmentRepository.findById(appointmentID);
         appointmentData.ifPresent(appt -> LOGGER.debug(String.format("Found appointment [%s] for company [%s]", appointmentID, companyNumber)));
 
-        return appointmentData.map(app -> CompanyAppointmentFullRecordView.Builder.view(app.getData())
+        return appointmentData.map(app -> CompanyAppointmentFullRecordView.Builder.view(app.getData(), app.getSensitiveData())
                         .build())
                 .orElseThrow(() -> new NotFoundException(
                         String.format("Appointment [%s] for company [%s] not found", appointmentID, companyNumber)));
@@ -113,7 +113,6 @@ public class CompanyAppointmentFullRecordService {
             officer.setAdditionalProperties(null);
 
             removeAdditionalProperties(officer.getServiceAddress());
-            removeAdditionalProperties(officer.getUsualResidentialAddress());
             removeAdditionalProperties(officer.getFormerNameData());
             removeAdditionalProperties(officer.getIdentificationData());
             removeAdditionalProperties(officer.getLinksData());

--- a/src/main/java/uk/gov/companieshouse/company_appointments/model/data/AppointmentApiEntity.java
+++ b/src/main/java/uk/gov/companieshouse/company_appointments/model/data/AppointmentApiEntity.java
@@ -7,8 +7,8 @@ import uk.gov.companieshouse.api.model.delta.officers.AppointmentAPI;
 public class AppointmentApiEntity extends AppointmentAPI {
 
     public AppointmentApiEntity(final AppointmentAPI appointmentAPI) {
-        super(appointmentAPI.getId(), appointmentAPI.getData(), appointmentAPI.getInternalId(),
-            appointmentAPI.getAppointmentId(), appointmentAPI.getOfficerId(),
+        super(appointmentAPI.getId(), appointmentAPI.getData(), appointmentAPI.getSensitiveData(),
+            appointmentAPI.getInternalId(), appointmentAPI.getAppointmentId(), appointmentAPI.getOfficerId(),
             appointmentAPI.getPreviousOfficerId(), appointmentAPI.getCompanyNumber(),
             appointmentAPI.getCreated(), appointmentAPI.getUpdated(), appointmentAPI.getDeltaAt());
     }

--- a/src/main/java/uk/gov/companieshouse/company_appointments/model/view/CompanyAppointmentFullRecordView.java
+++ b/src/main/java/uk/gov/companieshouse/company_appointments/model/view/CompanyAppointmentFullRecordView.java
@@ -8,6 +8,7 @@ import uk.gov.companieshouse.api.model.delta.officers.FormerNamesAPI;
 import uk.gov.companieshouse.api.model.delta.officers.IdentificationAPI;
 import uk.gov.companieshouse.api.model.delta.officers.LinksAPI;
 import uk.gov.companieshouse.api.model.delta.officers.OfficerAPI;
+import uk.gov.companieshouse.api.model.delta.officers.SensitiveOfficerAPI;
 
 import java.time.Instant;
 import java.time.ZoneId;
@@ -136,16 +137,16 @@ public class CompanyAppointmentFullRecordView {
             buildSteps = new ArrayList<>();
         }
 
-        public static Builder view(OfficerAPI data) {
+        public static Builder view(OfficerAPI data, SensitiveOfficerAPI sensitiveData) {
 
             Builder builder = new Builder();
 
             return builder.withServiceAddress(data.getServiceAddress())
-                .withUsualResidentialAddress(data.getUsualResidentialAddress())
+                .withUsualResidentialAddress(sensitiveData.getUsualResidentialAddress())
                 .withAppointedOn(data.getAppointedOn())
                 .withAppointedBefore(data.getAppointedBefore())
                 .withCountryOfResidence(data.getCountryOfResidence())
-                .withDateOfBirth(builder.mapDateOfBirth(data.getDateOfBirth()))
+                .withDateOfBirth(builder.mapDateOfBirth(sensitiveData.getDateOfBirth()))
                 .withFormerNames(data.getFormerNameData())
                 .withIdentification(data.getIdentificationData())
                 .withLinks(data.getLinksData())

--- a/src/test/java/uk/gov/companieshouse/company_appointments/AppointmentApiRepositoryTest.java
+++ b/src/test/java/uk/gov/companieshouse/company_appointments/AppointmentApiRepositoryTest.java
@@ -15,6 +15,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.companieshouse.api.model.delta.officers.AppointmentAPI;
 import uk.gov.companieshouse.api.model.delta.officers.InstantAPI;
 import uk.gov.companieshouse.api.model.delta.officers.OfficerAPI;
+import uk.gov.companieshouse.api.model.delta.officers.SensitiveOfficerAPI;
 import uk.gov.companieshouse.company_appointments.model.data.AppointmentApiEntity;
 
 import java.time.Instant;
@@ -38,6 +39,7 @@ class AppointmentApiRepositoryTest {
     void insertOrUpdate() {
         final AppointmentAPI appointment = new AppointmentAPI("id",
                 new OfficerAPI(),
+                new SensitiveOfficerAPI(),
                 "internalId",
                 "appointmentId",
                 "officerId",

--- a/src/test/java/uk/gov/companieshouse/company_appointments/CompanyAppointmentFullRecordServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/company_appointments/CompanyAppointmentFullRecordServiceTest.java
@@ -32,6 +32,7 @@ import uk.gov.companieshouse.api.model.delta.officers.InstantAPI;
 import uk.gov.companieshouse.api.model.delta.officers.LinksAPI;
 import uk.gov.companieshouse.api.model.delta.officers.OfficerAPI;
 import uk.gov.companieshouse.api.model.delta.officers.OfficerLinksAPI;
+import uk.gov.companieshouse.api.model.delta.officers.SensitiveOfficerAPI;
 import uk.gov.companieshouse.company_appointments.model.data.AppointmentApiEntity;
 import uk.gov.companieshouse.company_appointments.model.view.CompanyAppointmentFullRecordView;
 
@@ -92,7 +93,7 @@ class CompanyAppointmentFullRecordServiceTest {
     void testFetchAppointmentReturnsMappedAppointmentData() throws NotFoundException {
         // given
         appointmentApi = new AppointmentApiEntity(
-                new AppointmentAPI("id", new OfficerAPI(), "internalId", "appointmentId", "officerId",
+                new AppointmentAPI("id", new OfficerAPI(), new SensitiveOfficerAPI(), "internalId", "appointmentId", "officerId",
                         "previousOfficerId", "companyNumber", instantAPI, instantAPI, "deltaAt"));
 
         when(companyAppointmentRepository.findById(APPOINTMENT_ID)).thenReturn(Optional.of(appointmentApi));
@@ -120,7 +121,7 @@ class CompanyAppointmentFullRecordServiceTest {
     void testPutAppointmentData() {
         // given
         appointmentApi = new AppointmentApiEntity(
-                new AppointmentAPI("id", new OfficerAPI(), "internalId", "appointmentId", "officerId",
+                new AppointmentAPI("id", new OfficerAPI(), new SensitiveOfficerAPI(), "internalId", "appointmentId", "officerId",
                         "previousOfficerId", "companyNumber", null, null, "deltaAt"));
         when(companyAppointmentRepository.findById("id")).thenReturn(Optional.of(appointmentApiEntity));
 
@@ -142,10 +143,10 @@ class CompanyAppointmentFullRecordServiceTest {
 
         // given
         appointmentApi = new AppointmentApiEntity(
-                new AppointmentAPI("id", new OfficerAPI(), "internalId", "appointmentId", "officerId",
+                new AppointmentAPI("id", new OfficerAPI(), new SensitiveOfficerAPI(), "internalId", "appointmentId", "officerId",
                         "previousOfficerId", "companyNumber", instantAPI, instantAPI, incomingDeltaAt));
 
-        AppointmentApiEntity appointmentEntity = new AppointmentApiEntity(new AppointmentAPI("id", new OfficerAPI(), "internalId", "appointmentId", "officerId", "previousOfficerId", "companyNumber", instantAPI, instantAPI, existingDeltaAt));
+        AppointmentApiEntity appointmentEntity = new AppointmentApiEntity(new AppointmentAPI("id", new OfficerAPI(), new SensitiveOfficerAPI(), "internalId", "appointmentId", "officerId", "previousOfficerId", "companyNumber", instantAPI, instantAPI, existingDeltaAt));
 
         when(companyAppointmentRepository.findById(
             appointmentApi.getId())).thenReturn(deltaExists ? Optional.of(appointmentEntity) : Optional.empty());
@@ -163,12 +164,10 @@ class CompanyAppointmentFullRecordServiceTest {
     void additionalPropertiesRemoved() {
         // given
         final OfficerAPI officer = spy(OfficerAPI.class);
+        final SensitiveOfficerAPI sensitiveOfficer = spy(SensitiveOfficerAPI.class);
 
         final AddressAPI serviceAddress = spy(AddressAPI.class);
         when(officer.getServiceAddress()).thenReturn(serviceAddress);
-
-        final AddressAPI ura = spy(AddressAPI.class);
-        when(officer.getUsualResidentialAddress()).thenReturn(ura);
 
         final FormerNamesAPI formerName = spy(FormerNamesAPI.class);
         final List<FormerNamesAPI> formerNames = new ArrayList<>();
@@ -185,7 +184,7 @@ class CompanyAppointmentFullRecordServiceTest {
         when(linksAPI.getOfficerLinksData()).thenReturn(officerLinksAPI);
 
         appointmentApi = spy(new AppointmentApiEntity(
-                new AppointmentAPI("id", officer, "internalId", "appointmentId", "officerId", "previousOfficerId",
+                new AppointmentAPI("id", officer, sensitiveOfficer, "internalId", "appointmentId", "officerId", "previousOfficerId",
                         "companyNumber", instantAPI, instantAPI, "deltaAt")));
 
         // When
@@ -194,7 +193,6 @@ class CompanyAppointmentFullRecordServiceTest {
         // then
         verify(officer).setAdditionalProperties(null);
         verify(serviceAddress).setAdditionalProperties(null);
-        verify(ura).setAdditionalProperties(null);
         verify(formerName).setAdditionalProperties(null);
         verify(identificationAPI).setAdditionalProperties(null);
         verify(linksAPI).setAdditionalProperties(null);
@@ -206,9 +204,10 @@ class CompanyAppointmentFullRecordServiceTest {
     void additionalPropertiesSkippedWhenOfficerNull() {
         // given
         final OfficerAPI officer = null;
+        final SensitiveOfficerAPI sensitiveOfficer = null;
 
         appointmentApi = spy(new AppointmentApiEntity(
-                new AppointmentAPI("id", officer, "internalId", "appointmentId", "officerId", "previousOfficerId",
+                new AppointmentAPI("id", officer, sensitiveOfficer, "internalId", "appointmentId", "officerId", "previousOfficerId",
                         "companyNumber", instantAPI, instantAPI, "deltaAt")));
 
         // When

--- a/src/test/java/uk/gov/companieshouse/company_appointments/model/view/CompanyAppointmentFullRecordViewTest.java
+++ b/src/test/java/uk/gov/companieshouse/company_appointments/model/view/CompanyAppointmentFullRecordViewTest.java
@@ -12,6 +12,7 @@ import uk.gov.companieshouse.api.model.delta.officers.FormerNamesAPI;
 import uk.gov.companieshouse.api.model.delta.officers.IdentificationAPI;
 import uk.gov.companieshouse.api.model.delta.officers.LinksAPI;
 import uk.gov.companieshouse.api.model.delta.officers.OfficerAPI;
+import uk.gov.companieshouse.api.model.delta.officers.SensitiveOfficerAPI;
 
 import java.time.Instant;
 import java.util.Collections;
@@ -40,12 +41,13 @@ class CompanyAppointmentFullRecordViewTest {
     void setUp() {
 
         OfficerAPI officerData = new OfficerAPI();
+        SensitiveOfficerAPI sensitiveOfficer = new SensitiveOfficerAPI();
         officerData.setServiceAddress(createAddress("service"));
-        officerData.setUsualResidentialAddress(createAddress("usualResidential"));
+        sensitiveOfficer.setUsualResidentialAddress(createAddress("usualResidential"));
         officerData.setAppointedOn(INSTANT_ONE);
         officerData.setAppointedBefore(INSTANT_THREE);
         officerData.setCountryOfResidence("countryOfResidence");
-        officerData.setDateOfBirth(INSTANT_DOB);
+        sensitiveOfficer.setDateOfBirth(INSTANT_DOB);
         officerData.setFormerNameData(formerNames);
         officerData.setIdentificationData(identification);
         officerData.setLinksData(links);
@@ -57,7 +59,7 @@ class CompanyAppointmentFullRecordViewTest {
         officerData.setOfficerRole("director");
         officerData.setResignedOn(INSTANT_TWO);
 
-        testView = CompanyAppointmentFullRecordView.Builder.view(officerData).build();
+        testView = CompanyAppointmentFullRecordView.Builder.view(officerData, sensitiveOfficer).build();
     }
 
     @Test


### PR DESCRIPTION
This PR allows the sensitive data block coming from the officer delta processor to be saved and the get to still show the items as part of the full record view.

**Resolves**
DSND-1246