### PR TITLE
Add OAuth2 authorisation to the full_record request

### DIFF
--- a/src/main/java/uk/gov/companieshouse/company_appointments/interceptor/AuthenticationHelper.java
+++ b/src/main/java/uk/gov/companieshouse/company_appointments/interceptor/AuthenticationHelper.java
@@ -1,6 +1,8 @@
 package uk.gov.companieshouse.company_appointments.interceptor;
 
 import javax.servlet.http.HttpServletRequest;
+import java.util.List;
+import java.util.Map;
 
 /**
  * Helper class for authenticating users
@@ -119,4 +121,20 @@ public interface AuthenticationHelper {
      * @return true if the key has elevated privileges
      */
     boolean isKeyElevatedPrivilegesAuthorised(HttpServletRequest request);
+
+    /**
+     * Returns the permissions granted to the OAuth2 Token
+     *
+     * @param request the {@link HttpServletRequest}
+     * @return the privileges of the OAuth2 Token
+     */
+    Map<String, List<String>> getTokenPermissions(HttpServletRequest request);
+
+    /**
+     * Checks whether the token has required permissions
+     *
+     * @param request the {@link HttpServletRequest}
+     * @return true if the token has required permissions
+     */
+    boolean isTokenProtectedAndCompanyAuthorised(HttpServletRequest request, String companyNumber);
 }

--- a/src/main/java/uk/gov/companieshouse/company_appointments/interceptor/AuthenticationHelperImpl.java
+++ b/src/main/java/uk/gov/companieshouse/company_appointments/interceptor/AuthenticationHelperImpl.java
@@ -31,7 +31,7 @@ public class AuthenticationHelperImpl implements AuthenticationHelper {
     private static final String ERIC_AUTHORISED_USER = "ERIC-Authorised-User";
     private static final String ERIC_AUTHORISED_SCOPE = "ERIC-Authorised-Scope";
     private static final String ERIC_AUTHORISED_ROLES = "ERIC-Authorised-Roles";
-    private static final String COMPANY_OFFICER_PERMISSION = "company_officer";
+    private static final String COMPANY_OFFICER_PERMISSION = "company_officers";
     private static final String READ_PROTECTED = "read-protected";
     private static final String COMPANY_NUMBER_PERMISSION = "company_number";
 

--- a/src/main/java/uk/gov/companieshouse/company_appointments/interceptor/FullRecordAuthenticationInterceptor.java
+++ b/src/main/java/uk/gov/companieshouse/company_appointments/interceptor/FullRecordAuthenticationInterceptor.java
@@ -34,7 +34,7 @@ public class FullRecordAuthenticationInterceptor implements HandlerInterceptor {
             if (authHelper.isTokenProtectedAndCompanyAuthorised(request, companyNumber)) {
                 return true;
             } else {
-                logger.infoRequest(request, "User not authorised. Token has insufficient privileges.", logMap);
+                logger.infoRequest(request, "User not authorised. Token has insufficient permissions.", logMap);
                 response.setStatus(HttpStatus.SC_UNAUTHORIZED);
                 return false;
             }

--- a/src/main/java/uk/gov/companieshouse/company_appointments/interceptor/FullRecordAuthenticationInterceptor.java
+++ b/src/main/java/uk/gov/companieshouse/company_appointments/interceptor/FullRecordAuthenticationInterceptor.java
@@ -26,8 +26,20 @@ public class FullRecordAuthenticationInterceptor implements HandlerInterceptor {
     @Override
     public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) {
         final String identityType = authHelper.getAuthorisedIdentityType(request);
-
         Map<String, Object> logMap = new HashMap<>();
+
+        if (authHelper.isOauth2IdentityType(identityType)) {
+            String companyNumber = request.getRequestURI().split("/")[2];
+
+            if (authHelper.isTokenProtectedAndCompanyAuthorised(request, companyNumber)) {
+                return true;
+            } else {
+                logger.infoRequest(request, "User not authorised. Token has insufficient privileges.", logMap);
+                response.setStatus(HttpStatus.SC_UNAUTHORIZED);
+                return false;
+            }
+        }
+
         if (!authHelper.isApiKeyIdentityType(identityType)) {
             logMap.put("identityType", identityType);
             logger.infoRequest(request, "User not authorised. Identity type not correct", logMap);

--- a/src/test/java/uk/gov/companieshouse/company_appointments/interceptor/AuthenticationHelperImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/company_appointments/interceptor/AuthenticationHelperImplTest.java
@@ -291,21 +291,21 @@ class AuthenticationHelperImplTest {
 
     @Test
     void getTokenPrivileges() {
-        String tokenValue = "company_number=00006400 company_officer=read-protected,write";
+        String tokenValue = "company_number=00006400 company_officers=read-protected,write";
         when(request.getHeader("ERIC-Authorised-Token-Permissions")).thenReturn(tokenValue);
 
         Map<String, List<String>> result = testHelper.getTokenPermissions(request);
 
         assertThat(result.containsKey("company_number"), is(true));
-        assertThat(result.containsKey("company_officer"), is(true));
+        assertThat(result.containsKey("company_officers"), is(true));
         assertThat(result.get("company_number").get(0), is("00006400"));
-        assertThat(result.get("company_officer").get(0), is("read-protected"));;
-        assertThat(result.get("company_officer").get(1), is("write"));
+        assertThat(result.get("company_officers").get(0), is("read-protected"));;
+        assertThat(result.get("company_officers").get(1), is("write"));
     }
 
     @Test
     void isTokenProtectedAndCompanyAuthorisedIsTrue() {
-        String tokenValue = "company_number=00006400 company_officer=read-protected,write";
+        String tokenValue = "company_number=00006400 company_officers=read-protected,write";
         when(request.getHeader("ERIC-Authorised-Token-Permissions")).thenReturn(tokenValue);
 
         assertThat(testHelper.isTokenProtectedAndCompanyAuthorised(request, "00006400"), is(true));
@@ -313,7 +313,7 @@ class AuthenticationHelperImplTest {
 
     @Test
     void isTokenProtectedAndCompanyAuthorisedIsFalseWhenNotProtected() {
-        String tokenValue = "company_number=00006400 company_officer=read,write";
+        String tokenValue = "company_number=00006400 company_officers=read,write";
         when(request.getHeader("ERIC-Authorised-Token-Permissions")).thenReturn(tokenValue);
 
         assertThat(testHelper.isTokenProtectedAndCompanyAuthorised(request, "00006400"), is(false));
@@ -321,7 +321,7 @@ class AuthenticationHelperImplTest {
 
     @Test
     void isTokenProtectedAndCompanyAuthorisedIsFalseWhenIncorrectCompany() {
-        String tokenValue = "company_number=00006400 company_officer=read-protected,write";
+        String tokenValue = "company_number=00006400 company_officers=read-protected,write";
         when(request.getHeader("ERIC-Authorised-Token-Permissions")).thenReturn(tokenValue);
 
         assertThat(testHelper.isTokenProtectedAndCompanyAuthorised(request, "00006401"), is(false));

--- a/src/test/java/uk/gov/companieshouse/company_appointments/interceptor/FullRecordAuthenticationInterceptorTest.java
+++ b/src/test/java/uk/gov/companieshouse/company_appointments/interceptor/FullRecordAuthenticationInterceptorTest.java
@@ -2,6 +2,7 @@ package uk.gov.companieshouse.company_appointments.interceptor;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
@@ -13,6 +14,8 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.NullSource;
 import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.companieshouse.logging.Logger;
@@ -32,9 +35,10 @@ class FullRecordAuthenticationInterceptorTest {
     private Object handler;
     @Mock
     private AuthenticationHelper authHelper;
-
     @Mock
     private Logger logger;
+    @Captor
+    private ArgumentCaptor<String> companyNumber;
 
     @BeforeEach
     void setUp() {
@@ -94,6 +98,34 @@ class FullRecordAuthenticationInterceptorTest {
 
         // then
         checkAuthorised(actual);
+    }
+
+    @Test
+    void preHandleReturnsTrueIfOAuth2TokenWithCorrectAuthorisation() {
+        when(request.getRequestURI()).thenReturn("/company/00006400/appointments/1/full_record");
+
+        when(authHelper.getAuthorisedIdentityType(request)).thenReturn(AuthenticationHelperImpl.OAUTH2_IDENTITY_TYPE);
+        when(authHelper.isOauth2IdentityType(AuthenticationHelperImpl.OAUTH2_IDENTITY_TYPE)).thenReturn(true);
+        when(authHelper.isTokenProtectedAndCompanyAuthorised(any(), companyNumber.capture())).thenReturn(true);
+
+        boolean actual = authenticationInterceptor.preHandle(request, response, handler);
+
+        checkAuthorised(actual);
+        assertThat(companyNumber.getValue(), is("00006400"));
+    }
+
+    @Test
+    void preHandleReturnsFalseIfOAuth2TokenWithIncorrectAuthorisation() {
+        when(request.getRequestURI()).thenReturn("/company/00006400/appointments/1/full_record");
+
+        when(authHelper.getAuthorisedIdentityType(request)).thenReturn(AuthenticationHelperImpl.OAUTH2_IDENTITY_TYPE);
+        when(authHelper.isOauth2IdentityType(AuthenticationHelperImpl.OAUTH2_IDENTITY_TYPE)).thenReturn(true);
+        when(authHelper.isTokenProtectedAndCompanyAuthorised(any(), companyNumber.capture())).thenReturn(false);
+
+        boolean actual = authenticationInterceptor.preHandle(request, response, handler);
+
+        checkUnauthorised(actual);
+        assertThat(companyNumber.getValue(), is("00006400"));
     }
 
     private void checkUnauthorised(final boolean actual) {


### PR DESCRIPTION
This pr adds an OAuth2 authentication route for the full_record request. The OAuth2 token is checked for the company_officers read-protected permission and whether the user is logged into the correct company.

**Resolves:**
- DSND-1240