### PR TITLE
Add sensitive data check to get request

### DIFF
--- a/src/main/java/uk/gov/companieshouse/company_appointments/interceptor/AuthenticationHelperImpl.java
+++ b/src/main/java/uk/gov/companieshouse/company_appointments/interceptor/AuthenticationHelperImpl.java
@@ -22,7 +22,7 @@ public class AuthenticationHelperImpl implements AuthenticationHelper {
     public static final int USER_FORENAME_INDEX = 1;
     public static final int USER_SURNAME_INDEX = 2;
     private static final String INTERNAL_APP_PRIVILEGE = "internal-app";
-    private static final String SENSITIVE_DATA_PRIVELEGE = "sensitive-data";
+    private static final String SENSITIVE_DATA_PRIVILEGE = "sensitive-data";
     private static final String ERIC_AUTHORISED_KEY_PRIVILEGES_HEADER
             = "ERIC-Authorised-Key-Privileges";
     private static final String ERIC_AUTHORISED_TOKEN_PERMISSIONS_HEADER
@@ -136,7 +136,7 @@ public class AuthenticationHelperImpl implements AuthenticationHelper {
     public boolean isKeyElevatedPrivilegesAuthorised(HttpServletRequest request) {
         String[] privileges = getApiKeyPrivileges(request);
         return request.getMethod().equals(PUT_METHOD) ? ArrayUtils.contains(privileges, INTERNAL_APP_PRIVILEGE) :
-                ArrayUtils.contains(privileges, SENSITIVE_DATA_PRIVELEGE);
+                ArrayUtils.contains(privileges, SENSITIVE_DATA_PRIVILEGE);
     }
 
     @Override

--- a/src/main/java/uk/gov/companieshouse/company_appointments/interceptor/AuthenticationHelperImpl.java
+++ b/src/main/java/uk/gov/companieshouse/company_appointments/interceptor/AuthenticationHelperImpl.java
@@ -22,6 +22,7 @@ public class AuthenticationHelperImpl implements AuthenticationHelper {
     public static final int USER_FORENAME_INDEX = 1;
     public static final int USER_SURNAME_INDEX = 2;
     private static final String INTERNAL_APP_PRIVILEGE = "internal-app";
+    private static final String SENSITIVE_DATA_PRIVELEGE = "sensitive-data";
     private static final String ERIC_AUTHORISED_KEY_PRIVILEGES_HEADER
             = "ERIC-Authorised-Key-Privileges";
     private static final String ERIC_AUTHORISED_TOKEN_PERMISSIONS_HEADER
@@ -34,6 +35,8 @@ public class AuthenticationHelperImpl implements AuthenticationHelper {
     private static final String COMPANY_OFFICER_PERMISSION = "company_officers";
     private static final String READ_PROTECTED = "read-protected";
     private static final String COMPANY_NUMBER_PERMISSION = "company_number";
+
+    private static final String PUT_METHOD = "PUT";
 
     @Override
     public String getAuthorisedIdentity(HttpServletRequest request) {
@@ -131,7 +134,9 @@ public class AuthenticationHelperImpl implements AuthenticationHelper {
 
     @Override
     public boolean isKeyElevatedPrivilegesAuthorised(HttpServletRequest request) {
-        return ArrayUtils.contains(getApiKeyPrivileges(request), INTERNAL_APP_PRIVILEGE);
+        String[] privileges = getApiKeyPrivileges(request);
+        return request.getMethod().equals(PUT_METHOD) ? ArrayUtils.contains(privileges, INTERNAL_APP_PRIVILEGE) :
+                ArrayUtils.contains(privileges, SENSITIVE_DATA_PRIVELEGE);
     }
 
     @Override

--- a/src/test/java/uk/gov/companieshouse/company_appointments/interceptor/AuthenticationHelperImplTest.java
+++ b/src/test/java/uk/gov/companieshouse/company_appointments/interceptor/AuthenticationHelperImplTest.java
@@ -275,16 +275,39 @@ class AuthenticationHelperImplTest {
     }
 
     @Test
-    void isKeyElevatedPrivilegesAuthorisedWhenItIs() {
+    void isKeyElevatedPrivilegesAuthorisedWhenItIsPUT() {
         when(request.getHeader("ERIC-Authorised-Key-Privileges"))
                 .thenReturn("other-role,internal-app");
+        when(request.getMethod())
+                .thenReturn("PUT");
 
         assertThat(testHelper.isKeyElevatedPrivilegesAuthorised(request), is(true));
     }
 
     @Test
-    void isKeyElevatedPrivilegesAuthorisedWhenItIsNot() {
-        when(request.getHeader("ERIC-Authorised-Key-Privileges")).thenReturn("role-1,role-2");
+    void isKeyElevatedPrivilegesAuthorisedWhenItIsNotPUT() {
+        when(request.getHeader("ERIC-Authorised-Key-Privileges")).thenReturn("role-1,sensitive-data");
+        when(request.getMethod())
+                .thenReturn("PUT");
+
+        assertThat(testHelper.isKeyElevatedPrivilegesAuthorised(request), is(false));
+    }
+
+    @Test
+    void isKeyElevatedPrivilegesAuthorisedWhenItIsGET() {
+        when(request.getHeader("ERIC-Authorised-Key-Privileges"))
+                .thenReturn("other-role,sensitive-data");
+        when(request.getMethod())
+                .thenReturn("GET");
+
+        assertThat(testHelper.isKeyElevatedPrivilegesAuthorised(request), is(true));
+    }
+
+    @Test
+    void isKeyElevatedPrivilegesAuthorisedWhenItIsNotGET() {
+        when(request.getHeader("ERIC-Authorised-Key-Privileges")).thenReturn("role-1,internal-app");
+        when(request.getMethod())
+                .thenReturn("GET");
 
         assertThat(testHelper.isKeyElevatedPrivilegesAuthorised(request), is(false));
     }


### PR DESCRIPTION
This PR adds a ternary check to the api key check to allow put requests to still use an internal privilege key but force the GET request to use a new sensitive data type key.

**Resolves**
DSND-1241