### PR TITLE
Read appointment id and company number on GET request

### DIFF
--- a/src/main/java/uk/gov/companieshouse/company_appointments/CompanyAppointmentFullRecordRepository.java
+++ b/src/main/java/uk/gov/companieshouse/company_appointments/CompanyAppointmentFullRecordRepository.java
@@ -1,6 +1,9 @@
 package uk.gov.companieshouse.company_appointments;
 
+import java.util.Optional;
+
 import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.data.mongodb.repository.Query;
 import org.springframework.stereotype.Repository;
 import uk.gov.companieshouse.api.model.delta.officers.AppointmentAPI;
 import uk.gov.companieshouse.company_appointments.model.data.AppointmentApiEntity;
@@ -11,4 +14,7 @@ public interface CompanyAppointmentFullRecordRepository extends MongoRepository<
     default AppointmentAPI insertOrUpdate(AppointmentAPI appointmentAPI) {
         return save(new AppointmentApiEntity(appointmentAPI));
     }
+
+    @Query("{'company_number' : '?0', '_id' : '?1'}")
+    Optional<AppointmentApiEntity> readByCompanyNumberAndAppointmentID(String companyNumber, String appointmentId);
 }

--- a/src/main/java/uk/gov/companieshouse/company_appointments/CompanyAppointmentFullRecordRepository.java
+++ b/src/main/java/uk/gov/companieshouse/company_appointments/CompanyAppointmentFullRecordRepository.java
@@ -16,5 +16,5 @@ public interface CompanyAppointmentFullRecordRepository extends MongoRepository<
     }
 
     @Query("{'company_number' : '?0', '_id' : '?1'}")
-    Optional<AppointmentApiEntity> readByCompanyNumberAndAppointmentID(String companyNumber, String appointmentId);
+    Optional<AppointmentApiEntity> readByCompanyNumberAndID(String companyNumber, String appointmentId);
 }

--- a/src/main/java/uk/gov/companieshouse/company_appointments/CompanyAppointmentFullRecordService.java
+++ b/src/main/java/uk/gov/companieshouse/company_appointments/CompanyAppointmentFullRecordService.java
@@ -41,7 +41,7 @@ public class CompanyAppointmentFullRecordService {
 
     public CompanyAppointmentFullRecordView getAppointment(String companyNumber, String appointmentID) throws NotFoundException {
         LOGGER.debug(String.format("Fetching appointment [%s] for company [%s]", appointmentID, companyNumber));
-        Optional<AppointmentApiEntity> appointmentData = companyAppointmentRepository.readByCompanyNumberAndAppointmentID(companyNumber, appointmentID);
+        Optional<AppointmentApiEntity> appointmentData = companyAppointmentRepository.readByCompanyNumberAndID(companyNumber, appointmentID);
         appointmentData.ifPresent(appt -> LOGGER.debug(String.format("Found appointment [%s] for company [%s]", appointmentID, companyNumber)));
 
         return appointmentData.map(app -> CompanyAppointmentFullRecordView.Builder.view(app.getData(), app.getSensitiveData())
@@ -96,7 +96,7 @@ public class CompanyAppointmentFullRecordService {
         final String id = incomingAppointment.getId();
         final String companyNumber = incomingAppointment.getCompanyNumber();
 
-        return companyAppointmentRepository.readByCompanyNumberAndAppointmentID(companyNumber, id);
+        return companyAppointmentRepository.readByCompanyNumberAndID(companyNumber, id);
     }
 
     private void logStaleIncomingDelta(final AppointmentAPI appointmentAPI, final String existingDelta) {

--- a/src/main/java/uk/gov/companieshouse/company_appointments/CompanyAppointmentFullRecordService.java
+++ b/src/main/java/uk/gov/companieshouse/company_appointments/CompanyAppointmentFullRecordService.java
@@ -41,7 +41,7 @@ public class CompanyAppointmentFullRecordService {
 
     public CompanyAppointmentFullRecordView getAppointment(String companyNumber, String appointmentID) throws NotFoundException {
         LOGGER.debug(String.format("Fetching appointment [%s] for company [%s]", appointmentID, companyNumber));
-        Optional<AppointmentApiEntity> appointmentData = companyAppointmentRepository.findById(appointmentID);
+        Optional<AppointmentApiEntity> appointmentData = companyAppointmentRepository.readByCompanyNumberAndAppointmentID(companyNumber, appointmentID);
         appointmentData.ifPresent(appt -> LOGGER.debug(String.format("Found appointment [%s] for company [%s]", appointmentID, companyNumber)));
 
         return appointmentData.map(app -> CompanyAppointmentFullRecordView.Builder.view(app.getData(), app.getSensitiveData())

--- a/src/main/java/uk/gov/companieshouse/company_appointments/CompanyAppointmentFullRecordService.java
+++ b/src/main/java/uk/gov/companieshouse/company_appointments/CompanyAppointmentFullRecordService.java
@@ -94,8 +94,9 @@ public class CompanyAppointmentFullRecordService {
     private Optional<AppointmentApiEntity> getExistingDelta(final AppointmentAPI incomingAppointment) {
 
         final String id = incomingAppointment.getId();
+        final String companyNumber = incomingAppointment.getCompanyNumber();
 
-        return companyAppointmentRepository.findById(id);
+        return companyAppointmentRepository.readByCompanyNumberAndAppointmentID(companyNumber, id);
     }
 
     private void logStaleIncomingDelta(final AppointmentAPI appointmentAPI, final String existingDelta) {

--- a/src/test/java/uk/gov/companieshouse/company_appointments/CompanyAppointmentFullRecordServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/company_appointments/CompanyAppointmentFullRecordServiceTest.java
@@ -96,7 +96,7 @@ class CompanyAppointmentFullRecordServiceTest {
                 new AppointmentAPI("id", new OfficerAPI(), new SensitiveOfficerAPI(), "internalId", "appointmentId", "officerId",
                         "previousOfficerId", "companyNumber", instantAPI, instantAPI, "deltaAt"));
 
-        when(companyAppointmentRepository.findById(APPOINTMENT_ID)).thenReturn(Optional.of(appointmentApi));
+        when(companyAppointmentRepository.readByCompanyNumberAndAppointmentID(COMPANY_NUMBER, APPOINTMENT_ID)).thenReturn(Optional.of(appointmentApi));
 
         // when
         CompanyAppointmentFullRecordView result =
@@ -104,12 +104,12 @@ class CompanyAppointmentFullRecordServiceTest {
 
         // then
         assertThat(result, isA(CompanyAppointmentFullRecordView.class));
-        verify(companyAppointmentRepository).findById(APPOINTMENT_ID);
+        verify(companyAppointmentRepository).readByCompanyNumberAndAppointmentID(COMPANY_NUMBER, APPOINTMENT_ID);
     }
 
     @Test
     void testFetchAppointmentThrowsNotFoundExceptionIfAppointmentDoesntExist() {
-        when(companyAppointmentRepository.findById(any()))
+        when(companyAppointmentRepository.readByCompanyNumberAndAppointmentID(any(), any()))
                 .thenReturn(Optional.empty());
 
         Executable result = () -> companyAppointmentService.getAppointment(COMPANY_NUMBER, APPOINTMENT_ID);
@@ -123,7 +123,8 @@ class CompanyAppointmentFullRecordServiceTest {
         appointmentApi = new AppointmentApiEntity(
                 new AppointmentAPI("id", new OfficerAPI(), new SensitiveOfficerAPI(), "internalId", "appointmentId", "officerId",
                         "previousOfficerId", "companyNumber", null, null, "deltaAt"));
-        when(companyAppointmentRepository.findById("id")).thenReturn(Optional.of(appointmentApiEntity));
+        when(companyAppointmentRepository.readByCompanyNumberAndAppointmentID(appointmentApi.getCompanyNumber(),
+                appointmentApi.getId())).thenReturn(Optional.of(appointmentApiEntity));
 
         // When
         companyAppointmentService.insertAppointmentDelta(appointmentApi);
@@ -148,8 +149,8 @@ class CompanyAppointmentFullRecordServiceTest {
 
         AppointmentApiEntity appointmentEntity = new AppointmentApiEntity(new AppointmentAPI("id", new OfficerAPI(), new SensitiveOfficerAPI(), "internalId", "appointmentId", "officerId", "previousOfficerId", "companyNumber", instantAPI, instantAPI, existingDeltaAt));
 
-        when(companyAppointmentRepository.findById(
-            appointmentApi.getId())).thenReturn(deltaExists ? Optional.of(appointmentEntity) : Optional.empty());
+        when(companyAppointmentRepository.readByCompanyNumberAndAppointmentID(appointmentApi.getCompanyNumber(),
+                appointmentApi.getId())).thenReturn(deltaExists ? Optional.of(appointmentEntity) : Optional.empty());
 
         // When
         companyAppointmentService.insertAppointmentDelta(appointmentApi);

--- a/src/test/java/uk/gov/companieshouse/company_appointments/CompanyAppointmentFullRecordServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/company_appointments/CompanyAppointmentFullRecordServiceTest.java
@@ -96,7 +96,7 @@ class CompanyAppointmentFullRecordServiceTest {
                 new AppointmentAPI("id", new OfficerAPI(), new SensitiveOfficerAPI(), "internalId", "appointmentId", "officerId",
                         "previousOfficerId", "companyNumber", instantAPI, instantAPI, "deltaAt"));
 
-        when(companyAppointmentRepository.readByCompanyNumberAndAppointmentID(COMPANY_NUMBER, APPOINTMENT_ID)).thenReturn(Optional.of(appointmentApi));
+        when(companyAppointmentRepository.readByCompanyNumberAndID(COMPANY_NUMBER, APPOINTMENT_ID)).thenReturn(Optional.of(appointmentApi));
 
         // when
         CompanyAppointmentFullRecordView result =
@@ -104,12 +104,12 @@ class CompanyAppointmentFullRecordServiceTest {
 
         // then
         assertThat(result, isA(CompanyAppointmentFullRecordView.class));
-        verify(companyAppointmentRepository).readByCompanyNumberAndAppointmentID(COMPANY_NUMBER, APPOINTMENT_ID);
+        verify(companyAppointmentRepository).readByCompanyNumberAndID(COMPANY_NUMBER, APPOINTMENT_ID);
     }
 
     @Test
     void testFetchAppointmentThrowsNotFoundExceptionIfAppointmentDoesntExist() {
-        when(companyAppointmentRepository.readByCompanyNumberAndAppointmentID(any(), any()))
+        when(companyAppointmentRepository.readByCompanyNumberAndID(any(), any()))
                 .thenReturn(Optional.empty());
 
         Executable result = () -> companyAppointmentService.getAppointment(COMPANY_NUMBER, APPOINTMENT_ID);
@@ -123,7 +123,7 @@ class CompanyAppointmentFullRecordServiceTest {
         appointmentApi = new AppointmentApiEntity(
                 new AppointmentAPI("id", new OfficerAPI(), new SensitiveOfficerAPI(), "internalId", "appointmentId", "officerId",
                         "previousOfficerId", "companyNumber", null, null, "deltaAt"));
-        when(companyAppointmentRepository.readByCompanyNumberAndAppointmentID(appointmentApi.getCompanyNumber(),
+        when(companyAppointmentRepository.readByCompanyNumberAndID(appointmentApi.getCompanyNumber(),
                 appointmentApi.getId())).thenReturn(Optional.of(appointmentApiEntity));
 
         // When
@@ -149,7 +149,7 @@ class CompanyAppointmentFullRecordServiceTest {
 
         AppointmentApiEntity appointmentEntity = new AppointmentApiEntity(new AppointmentAPI("id", new OfficerAPI(), new SensitiveOfficerAPI(), "internalId", "appointmentId", "officerId", "previousOfficerId", "companyNumber", instantAPI, instantAPI, existingDeltaAt));
 
-        when(companyAppointmentRepository.readByCompanyNumberAndAppointmentID(appointmentApi.getCompanyNumber(),
+        when(companyAppointmentRepository.readByCompanyNumberAndID(appointmentApi.getCompanyNumber(),
                 appointmentApi.getId())).thenReturn(deltaExists ? Optional.of(appointmentEntity) : Optional.empty());
 
         // When


### PR DESCRIPTION
This PR is to fix the GET full record request in the API to also search mongo records for the company number as well as the appointment id.

**Resolves**
- DSND-1286