### PR TITLE
Set name to company name for corporate officers

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -28,7 +28,7 @@
 
         <structured-logging.version>1.9.11</structured-logging.version>
         <sdk-manager-java.version>1.5.1</sdk-manager-java.version>
-        <private-api-sdk-java.version>2.0.192</private-api-sdk-java.version>
+        <private-api-sdk-java.version>2.0.198</private-api-sdk-java.version>
         <api-helper-java-library.version>1.4.5</api-helper-java-library.version>
         <log4j.version>2.16.0</log4j.version>
 

--- a/src/main/java/uk/gov/companieshouse/company_appointments/model/view/CompanyAppointmentFullRecordView.java
+++ b/src/main/java/uk/gov/companieshouse/company_appointments/model/view/CompanyAppointmentFullRecordView.java
@@ -279,6 +279,10 @@ public class CompanyAppointmentFullRecordView {
         }
 
         private String individualOfficerName(OfficerAPI officerData) {
+            if (officerData.getCompanyName() != null) {
+                return officerData.getCompanyName();
+            }
+
             String result = officerData.getSurname();
             if (officerData.getForename() != null || officerData.getOtherForenames() != null) {
                 result = String.join(", ", officerData.getSurname(), Stream.of(officerData.getForename(), officerData.getOtherForenames())
@@ -288,6 +292,7 @@ public class CompanyAppointmentFullRecordView {
             if (officerData.getTitle() != null && !officerData.getTitle().matches(TITLE_REGEX)) {
                 result = String.join(", ", result, officerData.getTitle());
             }
+
             return result;
         }
 


### PR DESCRIPTION
This pr updates the sdk to include the company name field when officer data is saved to mongo. The company name field is also fed into the name property that is sent in GET requests.

**Required for:**
-DSND-1307