### PR TITLE
Add delete endpoint for the full record request

### DIFF
--- a/src/it/java/uk/gov/companieshouse/company_appointments/CompanyAppointmentFullRecordControllerITest.java
+++ b/src/it/java/uk/gov/companieshouse/company_appointments/CompanyAppointmentFullRecordControllerITest.java
@@ -1,0 +1,95 @@
+package uk.gov.companieshouse.company_appointments;
+
+import org.apache.commons.io.IOUtils;
+import org.bson.Document;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.SimpleMongoClientDatabaseFactory;
+import org.springframework.data.mongodb.core.query.Criteria;
+import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.http.MediaType;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.testcontainers.containers.MongoDBContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import uk.gov.companieshouse.company_appointments.model.data.AppointmentApiEntity;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.empty;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@Testcontainers
+@AutoConfigureMockMvc
+@SpringBootTest(classes = CompanyAppointmentsApplication.class, webEnvironment = SpringBootTest.WebEnvironment.MOCK)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
+public class CompanyAppointmentFullRecordControllerITest {
+
+    private static final String COMPANY_NUMBER = "12345678";
+    private static final String OFFICER_ID = "7IjxamNGLlqtIingmTZJJ42Hw9Q";
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Container
+    private static MongoDBContainer mongoDBContainer = new MongoDBContainer("mongo:4.2");
+
+    private static MongoTemplate mongoTemplate;
+
+    @BeforeAll
+    static void start() throws IOException {
+        System.setProperty("spring.data.mongodb.uri", mongoDBContainer.getReplicaSetUrl());
+        mongoTemplate = new MongoTemplate(new SimpleMongoClientDatabaseFactory(mongoDBContainer.getReplicaSetUrl()));
+        mongoTemplate.createCollection("delta_appointments");
+        mongoTemplate.insert(Document.parse(
+                IOUtils.resourceToString("/delta-appointment-data.json", StandardCharsets.UTF_8)),
+                "delta_appointments");
+    }
+
+    @Test
+    void testReturn200IfOfficerIsDeleted() throws Exception{
+        ResultActions result = mockMvc
+                .perform(delete("/company/{company_number}/appointments/{appointment_id}/full_record/delete", COMPANY_NUMBER,
+                        OFFICER_ID)
+                        .header("ERIC-Identity", "123").header("ERIC-Identity-Type", "key")
+                        .header("ERIC-authorised-key-privileges", "internal-app"));
+
+        result.andExpect(status().isOk());
+
+        Query query = new Query();
+        query.addCriteria(Criteria.where("_id").is("7IjxamNGLlqtIingmTZJJ42Hw9Q"));
+        List<AppointmentApiEntity> appointments = mongoTemplate.find(query, AppointmentApiEntity.class);
+        assertThat(appointments, is(empty()));
+    }
+
+    @Test
+    void testReturn404IfOfficerIsNotDeleted() throws Exception{
+        ResultActions result = mockMvc
+                .perform(delete("/company/{company_number}/appointments/{appointment_id}/full_record/delete", COMPANY_NUMBER,
+                        "Incorrect")
+                        .header("ERIC-Identity", "123").header("ERIC-Identity-Type", "key")
+                        .header("ERIC-authorised-key-privileges", "internal-app"));
+
+        result.andExpect(status().isNotFound());
+
+        Query query = new Query();
+        query.addCriteria(Criteria.where("_id").is("7IjxamNGLlqtIingmTZJJ42Hw9Q"));
+        List<AppointmentApiEntity> appointments = mongoTemplate.find(query, AppointmentApiEntity.class);
+        assertThat(appointments.size(), is(1));
+    }
+}

--- a/src/it/java/uk/gov/companieshouse/company_appointments/CompanyAppointmentFullRecordControllerITest.java
+++ b/src/it/java/uk/gov/companieshouse/company_appointments/CompanyAppointmentFullRecordControllerITest.java
@@ -11,7 +11,6 @@ import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.data.mongodb.core.SimpleMongoClientDatabaseFactory;
 import org.springframework.data.mongodb.core.query.Criteria;
 import org.springframework.data.mongodb.core.query.Query;
-import org.springframework.http.MediaType;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
@@ -25,13 +24,9 @@ import java.nio.charset.StandardCharsets;
 import java.util.List;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.empty;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @Testcontainers

--- a/src/main/java/uk/gov/companieshouse/company_appointments/CompanyAppointmentFullRecordController.java
+++ b/src/main/java/uk/gov/companieshouse/company_appointments/CompanyAppointmentFullRecordController.java
@@ -3,6 +3,7 @@ package uk.gov.companieshouse.company_appointments;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -41,6 +42,18 @@ public class CompanyAppointmentFullRecordController {
         companyAppointmentService.insertAppointmentDelta(companyAppointmentData);
 
         return ResponseEntity.ok().build();
+    }
+
+    @DeleteMapping(path = "/delete")
+    public ResponseEntity<Void> deleteOfficerData(@PathVariable("company_number") String companyNumber,
+                                                  @PathVariable("appointment_id") String appointmentId) {
+        try {
+            companyAppointmentService.deleteOfficer(companyNumber, appointmentId);
+            return ResponseEntity.ok().build();
+        } catch (NotFoundException e) {
+            LOGGER.info(e.getMessage());
+            return ResponseEntity.notFound().build();
+        }
     }
 
 }

--- a/src/main/java/uk/gov/companieshouse/company_appointments/CompanyAppointmentFullRecordRepository.java
+++ b/src/main/java/uk/gov/companieshouse/company_appointments/CompanyAppointmentFullRecordRepository.java
@@ -17,4 +17,7 @@ public interface CompanyAppointmentFullRecordRepository extends MongoRepository<
 
     @Query("{'company_number' : '?0', '_id' : '?1'}")
     Optional<AppointmentApiEntity> readByCompanyNumberAndID(String companyNumber, String appointmentId);
+
+    @Query(value="{'company_number' : '?0', '_id' : '?1'}", delete = true)
+    Optional<AppointmentApiEntity> deleteByCompanyNumberAndID(String companyNumber, String appointmentId);
 }

--- a/src/main/java/uk/gov/companieshouse/company_appointments/CompanyAppointmentFullRecordService.java
+++ b/src/main/java/uk/gov/companieshouse/company_appointments/CompanyAppointmentFullRecordService.java
@@ -72,6 +72,15 @@ public class CompanyAppointmentFullRecordService {
         }
     }
 
+    public void deleteOfficer(String companyNumber, String appointmentId) throws NotFoundException {
+        LOGGER.debug(String.format("Deleting appointment [%s] for company [%s]", appointmentId, companyNumber));
+
+        Optional<AppointmentApiEntity> deleted = companyAppointmentRepository.deleteByCompanyNumberAndID(companyNumber, appointmentId);
+
+        deleted.orElseThrow(() -> new NotFoundException(
+                String.format("Appointment [%s] for company [%s] not found", appointmentId, companyNumber)));
+    }
+
     private void saveAppointment(AppointmentAPI appointmentApi, InstantAPI instant) {
         appointmentApi.setCreated(instant);
         companyAppointmentRepository.insertOrUpdate(appointmentApi);

--- a/src/main/java/uk/gov/companieshouse/company_appointments/CompanyAppointmentFullRecordService.java
+++ b/src/main/java/uk/gov/companieshouse/company_appointments/CompanyAppointmentFullRecordService.java
@@ -77,8 +77,9 @@ public class CompanyAppointmentFullRecordService {
 
         Optional<AppointmentApiEntity> deleted = companyAppointmentRepository.deleteByCompanyNumberAndID(companyNumber, appointmentId);
 
-        deleted.orElseThrow(() -> new NotFoundException(
-                String.format("Appointment [%s] for company [%s] not found", appointmentId, companyNumber)));
+        if (!deleted.isPresent()) {
+            throw new NotFoundException(String.format("Appointment [%s] for company [%s] not found", appointmentId, companyNumber));
+        }
     }
 
     private void saveAppointment(AppointmentAPI appointmentApi, InstantAPI instant) {

--- a/src/main/java/uk/gov/companieshouse/company_appointments/config/Config.java
+++ b/src/main/java/uk/gov/companieshouse/company_appointments/config/Config.java
@@ -13,7 +13,7 @@ import java.time.Clock;
 
 @Configuration
 public class Config implements WebMvcConfigurer {
-    public static final String PATTERN_FULL_RECORD = "/**/full_record";
+    public static final String PATTERN_FULL_RECORD = "/**/full_record/**";
     @Autowired
     private RequestLoggingInterceptor loggingInterceptor;
 

--- a/src/main/java/uk/gov/companieshouse/company_appointments/interceptor/AuthenticationHelperImpl.java
+++ b/src/main/java/uk/gov/companieshouse/company_appointments/interceptor/AuthenticationHelperImpl.java
@@ -36,7 +36,7 @@ public class AuthenticationHelperImpl implements AuthenticationHelper {
     private static final String READ_PROTECTED = "readprotected";
     private static final String COMPANY_NUMBER_PERMISSION = "company_number";
 
-    private static final String PUT_METHOD = "PUT";
+    private static final String GET_METHOD = "GET";
 
     @Override
     public String getAuthorisedIdentity(HttpServletRequest request) {
@@ -135,8 +135,8 @@ public class AuthenticationHelperImpl implements AuthenticationHelper {
     @Override
     public boolean isKeyElevatedPrivilegesAuthorised(HttpServletRequest request) {
         String[] privileges = getApiKeyPrivileges(request);
-        return request.getMethod().equals(PUT_METHOD) ? ArrayUtils.contains(privileges, INTERNAL_APP_PRIVILEGE) :
-                ArrayUtils.contains(privileges, SENSITIVE_DATA_PRIVILEGE);
+        return request.getMethod().equals(GET_METHOD) ? ArrayUtils.contains(privileges, SENSITIVE_DATA_PRIVILEGE) :
+                ArrayUtils.contains(privileges, INTERNAL_APP_PRIVILEGE);
     }
 
     @Override

--- a/src/test/java/uk/gov/companieshouse/company_appointments/CompanyAppointmentFullRecordControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/company_appointments/CompanyAppointmentFullRecordControllerTest.java
@@ -2,6 +2,7 @@ package uk.gov.companieshouse.company_appointments;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -72,5 +73,22 @@ class CompanyAppointmentFullRecordControllerTest {
         ResponseEntity<Void> response = companyAppointmentFullRecordController.submitOfficerData(appointment);
 
         assertEquals(HttpStatus.OK, response.getStatusCode());
+    }
+
+    @Test
+    void testControllerReturns200WhenOfficerDeleted() {
+
+        ResponseEntity<Void> response = companyAppointmentFullRecordController.deleteOfficerData(COMPANY_NUMBER, APPOINTMENT_ID);
+
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+    }
+
+    @Test
+    void testControllerReturns404WhenOfficerNotDeleted() throws Exception{
+        doThrow(NotFoundException.class).when(companyAppointmentService).deleteOfficer(any(), any());
+
+        ResponseEntity<Void> response = companyAppointmentFullRecordController.deleteOfficerData(COMPANY_NUMBER, APPOINTMENT_ID);
+
+        assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
     }
 }

--- a/src/test/java/uk/gov/companieshouse/company_appointments/CompanyAppointmentFullRecordServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/company_appointments/CompanyAppointmentFullRecordServiceTest.java
@@ -218,4 +218,24 @@ class CompanyAppointmentFullRecordServiceTest {
         verify(companyAppointmentRepository).insertOrUpdate(appointmentApi);
     }
 
+    @Test
+    void deleteOfficer() throws Exception {
+        when(companyAppointmentRepository.deleteByCompanyNumberAndID(COMPANY_NUMBER, APPOINTMENT_ID))
+                .thenReturn(Optional.of(appointmentApiEntity));
+
+        companyAppointmentService.deleteOfficer(COMPANY_NUMBER, APPOINTMENT_ID);
+
+        verify(companyAppointmentRepository).deleteByCompanyNumberAndID(COMPANY_NUMBER, APPOINTMENT_ID);
+    }
+
+    @Test
+    void deleteOfficerThrowsNotFound() {
+        when(companyAppointmentRepository.deleteByCompanyNumberAndID(COMPANY_NUMBER, APPOINTMENT_ID))
+                .thenReturn(Optional.empty());
+
+        Executable result = () -> companyAppointmentService.deleteOfficer(COMPANY_NUMBER, APPOINTMENT_ID);
+
+        assertThrows(NotFoundException.class, result);
+    }
+
 }

--- a/src/test/resources/delta-appointment-data.json
+++ b/src/test/resources/delta-appointment-data.json
@@ -1,0 +1,57 @@
+{
+  "_id" : "7IjxamNGLlqtIingmTZJJ42Hw9Q",
+  "appointment_id" : "7IjxamNGLlqtIingmTZJJ42Hw9Q",
+  "company_name" : "TEST COMPANY LIMITED",
+  "company_number" : "12345678",
+  "company_status" : "active",
+  "created" : {
+    "at" : ISODate("2020-08-26T12:00:00.000Z")
+  },
+  "data" : {
+    "officer_role" : "director",
+    "title" : "Mrs",
+    "country_of_residence" : "United Kingdom",
+    "links" : {
+      "officer" : {
+        "self" : "/officers/5VEOBB4a9dlB_iugw_vieHjWpCk",
+        "appointments" : "/officers/5VEOBB4a9dlB_iugw_vieHjWpCk/appointments"
+      },
+      "self" : "/company/12345678/appointments/7IjxamNGLlqtIingmTZJJ42Hw9Q"
+    },
+    "nationality" : "British",
+    "forename" : "Noname1",
+    "surname" : "NOSURNAME",
+    "resigned_on" : ISODate("2020-08-26T13:00:00.000Z"),
+    "company_number" : "12345678",
+    "updated_at" : ISODate("2020-08-26T13:00:00.000Z"),
+    "other_forenames" : "Noname2",
+    "appointed_on" : ISODate("2020-08-26T12:00:00.000Z"),
+    "etag" : "8f58a770d34f982a1b2a5a29fcde12528e82f903",
+    "occupation" : "Company Director",
+    "service_address" : {
+      "region" : "Cardiff",
+      "address_line_1" : "1 Crown Way",
+      "postal_code" : "CF14 3UZ",
+      "address_line_2" : "Pavement",
+      "locality" : "Cardiff"
+    }
+  },
+  "sensitive_data" : {
+    "usual_residential_address" : {
+      "region" : "Cardiff",
+      "address_line_1" : "1 Crown Way",
+      "postal_code" : "CF14 3UZ",
+      "address_line_2" : "Pavement",
+      "locality" : "Cardiff"
+    },
+    "date_of_birth" : ISODate("1980-01-01T00:00:00.000Z")
+  },
+  "delta_at" : "20200623121303006153",
+  "internal_id" : "2500085646",
+  "officer_id" : "5VEOBB4a9dlB_iugw_vieHjWpCk",
+  "officer_role_sort_order" : 200,
+  "updated" : {
+    "at" : ISODate("2020-08-26T13:00:00.000Z")
+  },
+  "previous_officer_id" : "5VEOBB4a9dlB_iugw_vieHjWpCk"
+}


### PR DESCRIPTION
This pr adds a delete endpoint to company appointments for the full record request. When called the record is deleted. If the record does not exist a 404 response is sent. Includes a fix to the authenticator for DELETE requests and integration tests.

**Resolves:**
- DSND-1316