### PR TITLE
Create Endpoint for all Company Officers

### DIFF
--- a/routes.yaml
+++ b/routes.yaml
@@ -3,3 +3,4 @@ group: api
 weight: 900
 routes:
   1: ^/company/.*?/appointments/.*?$
+  2: ^/company/.*?/officers$

--- a/src/it/java/uk/gov/companieshouse/company_appointments/CompanyAppointmentControllerITest.java
+++ b/src/it/java/uk/gov/companieshouse/company_appointments/CompanyAppointmentControllerITest.java
@@ -47,6 +47,8 @@ public class CompanyAppointmentControllerITest {
         mongoTemplate = new MongoTemplate(new SimpleMongoClientDatabaseFactory(mongoDBContainer.getReplicaSetUrl()));
         mongoTemplate.createCollection("appointments");
         mongoTemplate.insert(Document.parse(IOUtils.resourceToString("/appointment-data.json", StandardCharsets.UTF_8)), "appointments");
+        mongoTemplate.insert(Document.parse(IOUtils.resourceToString("/appointment-data2.json", StandardCharsets.UTF_8)), "appointments");
+
     }
 
     @Test
@@ -90,6 +92,52 @@ public class CompanyAppointmentControllerITest {
 
         // then
         result.andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    void testReturn200OKIfAllOfficersAreFound() throws Exception {
+        //when
+        ResultActions result = mockMvc.perform(get("/company/{company_number}/officers", "12345678")
+                .header("ERIC-Identity", "123")
+                .header("ERIC-Identity-Type", "key")
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.APPLICATION_JSON));
+
+        //then
+        result.andExpect(status().isOk())
+                .andExpect(jsonPath("$.items.[0].name", is("Doe, John Forename")))
+                .andExpect(jsonPath("$.items.[1].name", is("NOSURNAME, Noname1 Noname2")))
+                .andExpect(jsonPath("$.active_count", is(1)))
+                .andExpect(jsonPath("$.resigned_count", is(1)))
+                .andExpect(jsonPath("$.total_results", is(2)));
+    }
+    @Test
+    void testReturn404IfOfficersForCompanyIsNotFound() throws Exception {
+        // when
+        ResultActions result = mockMvc
+                .perform(get("/company/{company_number}/officers", "87654321")
+                        .header("ERIC-Identity", "123").header("ERIC-Identity-Type", "oauth2")
+                        .contentType(MediaType.APPLICATION_JSON).accept(MediaType.APPLICATION_JSON));
+
+        // then
+        result.andExpect(status().isNotFound());
+    }
+
+    @Test
+    void testReturn200OKIfAllOfficersAreFoundWithFilter() throws Exception {
+        //when
+        ResultActions result = mockMvc.perform(get("/company/{company_number}/officers?filter=active", "12345678")
+                .header("ERIC-Identity", "123")
+                .header("ERIC-Identity-Type", "key")
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.APPLICATION_JSON));
+
+        //then
+        result.andExpect(status().isOk())
+                .andExpect(jsonPath("$.items.[0].name", is("Doe, John Forename")))
+                .andExpect(jsonPath("$.active_count", is(1)))
+                .andExpect(jsonPath("$.resigned_count", is(0)))
+                .andExpect(jsonPath("$.total_results", is(1)));
     }
 
 }

--- a/src/it/java/uk/gov/companieshouse/company_appointments/CompanyAppointmentControllerITest.java
+++ b/src/it/java/uk/gov/companieshouse/company_appointments/CompanyAppointmentControllerITest.java
@@ -48,7 +48,6 @@ public class CompanyAppointmentControllerITest {
         mongoTemplate.createCollection("appointments");
         mongoTemplate.insert(Document.parse(IOUtils.resourceToString("/appointment-data.json", StandardCharsets.UTF_8)), "appointments");
         mongoTemplate.insert(Document.parse(IOUtils.resourceToString("/appointment-data2.json", StandardCharsets.UTF_8)), "appointments");
-
     }
 
     @Test

--- a/src/main/java/uk/gov/companieshouse/company_appointments/CompanyAppointmentComparator.java
+++ b/src/main/java/uk/gov/companieshouse/company_appointments/CompanyAppointmentComparator.java
@@ -1,0 +1,32 @@
+package uk.gov.companieshouse.company_appointments;
+
+import uk.gov.companieshouse.company_appointments.model.view.CompanyAppointmentView;
+
+import java.util.Comparator;
+
+public class CompanyAppointmentComparator implements Comparator<CompanyAppointmentView> {
+
+
+    private boolean isSecretary(CompanyAppointmentView companyAppointmentView) {
+        return SecretarialRoles.stream().anyMatch(s -> s.getRole().equals(companyAppointmentView.getOfficerRole()));
+    }
+
+    @Override
+    public int compare(CompanyAppointmentView o1, CompanyAppointmentView o2) {
+
+        if (o1.getResignedOn() == null && o2.getResignedOn() != null) {
+            return 1;
+        } else if (o1.getResignedOn() != null && o2.getResignedOn() == null) {
+            return -1;
+        } else if (isSecretary(o1) && !isSecretary(o2)) {
+            return 1;
+        } else if(!isSecretary(o1) && isSecretary(o2)) {
+            return -1;
+        } else {
+            return o1.getName().compareTo(o2.getName());
+        }
+    }
+
+}
+
+

--- a/src/main/java/uk/gov/companieshouse/company_appointments/CompanyAppointmentComparator.java
+++ b/src/main/java/uk/gov/companieshouse/company_appointments/CompanyAppointmentComparator.java
@@ -19,7 +19,7 @@ public class CompanyAppointmentComparator implements Comparator<CompanyAppointme
             return 1;
         } else if (isSecretary(o1) && !isSecretary(o2)) {
             return -1;
-        } else if(!isSecretary(o1) && isSecretary(o2)) {
+        } else if (!isSecretary(o1) && isSecretary(o2)) {
             return 1;
         } else {
             return o1.getName().compareTo(o2.getName());

--- a/src/main/java/uk/gov/companieshouse/company_appointments/CompanyAppointmentComparator.java
+++ b/src/main/java/uk/gov/companieshouse/company_appointments/CompanyAppointmentComparator.java
@@ -11,17 +11,19 @@ public class CompanyAppointmentComparator implements Comparator<CompanyAppointme
         return SecretarialRoles.stream().anyMatch(s -> s.getRole().equals(companyAppointmentView.getOfficerRole()));
     }
 
+
+
     @Override
     public int compare(CompanyAppointmentView o1, CompanyAppointmentView o2) {
 
         if (o1.getResignedOn() == null && o2.getResignedOn() != null) {
-            return 1;
+            return -1;
         } else if (o1.getResignedOn() != null && o2.getResignedOn() == null) {
-            return -1;
-        } else if (isSecretary(o1) && !isSecretary(o2)) {
             return 1;
-        } else if(!isSecretary(o1) && isSecretary(o2)) {
+        } else if (isSecretary(o1) && !isSecretary(o2)) {
             return -1;
+        } else if(!isSecretary(o1) && isSecretary(o2)) {
+            return 1;
         } else {
             return o1.getName().compareTo(o2.getName());
         }

--- a/src/main/java/uk/gov/companieshouse/company_appointments/CompanyAppointmentComparator.java
+++ b/src/main/java/uk/gov/companieshouse/company_appointments/CompanyAppointmentComparator.java
@@ -6,12 +6,9 @@ import java.util.Comparator;
 
 public class CompanyAppointmentComparator implements Comparator<CompanyAppointmentView> {
 
-
     private boolean isSecretary(CompanyAppointmentView companyAppointmentView) {
         return SecretarialRoles.stream().anyMatch(s -> s.getRole().equals(companyAppointmentView.getOfficerRole()));
     }
-
-
 
     @Override
     public int compare(CompanyAppointmentView o1, CompanyAppointmentView o2) {
@@ -28,7 +25,6 @@ public class CompanyAppointmentComparator implements Comparator<CompanyAppointme
             return o1.getName().compareTo(o2.getName());
         }
     }
-
 }
 
 

--- a/src/main/java/uk/gov/companieshouse/company_appointments/CompanyAppointmentController.java
+++ b/src/main/java/uk/gov/companieshouse/company_appointments/CompanyAppointmentController.java
@@ -13,7 +13,7 @@ import uk.gov.companieshouse.logging.Logger;
 import uk.gov.companieshouse.logging.LoggerFactory;
 
 @Controller
-@RequestMapping(path = "/company/{company_number}/", produces = "application/json")
+@RequestMapping(path = "/company/{company_number}", produces = "application/json")
 public class CompanyAppointmentController {
 
     private CompanyAppointmentService companyAppointmentService;
@@ -25,7 +25,7 @@ public class CompanyAppointmentController {
         this.companyAppointmentService = companyAppointmentService;
     }
 
-    @GetMapping(path = "appointments/{appointment_id}")
+    @GetMapping(path = "/appointments/{appointment_id}")
     public ResponseEntity<CompanyAppointmentView> fetchAppointment(@PathVariable("company_number") String companyNumber, @PathVariable("appointment_id") String appointmentID) {
         try {
             return ResponseEntity.ok(companyAppointmentService.fetchAppointment(companyNumber, appointmentID));
@@ -35,9 +35,9 @@ public class CompanyAppointmentController {
         }
     }
 
-    @GetMapping(path = "officers")
+    @GetMapping(path = "/officers")
     public ResponseEntity<AllCompanyAppointmentsView> fetchAppointmentsForCompany(@PathVariable("company_number") String companyNumber, @RequestParam(required = false) String filter) {
-        try{
+        try {
             return ResponseEntity.ok(companyAppointmentService.fetchAppointmentsForCompany(companyNumber, filter));
         } catch(NotFoundException e) {
             LOGGER.info(e.getMessage());

--- a/src/main/java/uk/gov/companieshouse/company_appointments/CompanyAppointmentController.java
+++ b/src/main/java/uk/gov/companieshouse/company_appointments/CompanyAppointmentController.java
@@ -12,8 +12,6 @@ import uk.gov.companieshouse.company_appointments.model.view.CompanyAppointmentV
 import uk.gov.companieshouse.logging.Logger;
 import uk.gov.companieshouse.logging.LoggerFactory;
 
-import java.util.List;
-
 @Controller
 @RequestMapping(path = "/company/{company_number}/", produces = "application/json")
 public class CompanyAppointmentController {
@@ -46,7 +44,4 @@ public class CompanyAppointmentController {
             return ResponseEntity.notFound().build();
         }
     }
-
-
-
 }

--- a/src/main/java/uk/gov/companieshouse/company_appointments/CompanyAppointmentController.java
+++ b/src/main/java/uk/gov/companieshouse/company_appointments/CompanyAppointmentController.java
@@ -6,6 +6,8 @@ import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import uk.gov.companieshouse.company_appointments.model.view.AllCompanyAppointmentsView;
 import uk.gov.companieshouse.company_appointments.model.view.CompanyAppointmentView;
 import uk.gov.companieshouse.logging.Logger;
 import uk.gov.companieshouse.logging.LoggerFactory;
@@ -25,7 +27,7 @@ public class CompanyAppointmentController {
         this.companyAppointmentService = companyAppointmentService;
     }
 
-    @GetMapping(path = "appointment/{appointment_id}")
+    @GetMapping(path = "appointments/{appointment_id}")
     public ResponseEntity<CompanyAppointmentView> fetchAppointment(@PathVariable("company_number") String companyNumber, @PathVariable("appointment_id") String appointmentID) {
         try {
             return ResponseEntity.ok(companyAppointmentService.fetchAppointment(companyNumber, appointmentID));
@@ -36,13 +38,15 @@ public class CompanyAppointmentController {
     }
 
     @GetMapping(path = "officers")
-    public ResponseEntity<List<CompanyAppointmentView>> fetchAppointmentsForCompany(@PathVariable("company_number") String companyNumber) {
+    public ResponseEntity<AllCompanyAppointmentsView> fetchAppointmentsForCompany(@PathVariable("company_number") String companyNumber, @RequestParam(required = false) String filter) {
         try{
-            return ResponseEntity.ok(companyAppointmentService.fetchAppointmentsForCompany(companyNumber));
+            return ResponseEntity.ok(companyAppointmentService.fetchAppointmentsForCompany(companyNumber, filter));
         } catch(NotFoundException e) {
             LOGGER.info(e.getMessage());
             return ResponseEntity.notFound().build();
         }
     }
+
+
 
 }

--- a/src/main/java/uk/gov/companieshouse/company_appointments/CompanyAppointmentController.java
+++ b/src/main/java/uk/gov/companieshouse/company_appointments/CompanyAppointmentController.java
@@ -10,8 +10,10 @@ import uk.gov.companieshouse.company_appointments.model.view.CompanyAppointmentV
 import uk.gov.companieshouse.logging.Logger;
 import uk.gov.companieshouse.logging.LoggerFactory;
 
+import java.util.List;
+
 @Controller
-@RequestMapping(path = "/company/{company_number}/appointments/{appointment_id}", produces = "application/json")
+@RequestMapping(path = "/company/{company_number}/", produces = "application/json")
 public class CompanyAppointmentController {
 
     private CompanyAppointmentService companyAppointmentService;
@@ -23,11 +25,21 @@ public class CompanyAppointmentController {
         this.companyAppointmentService = companyAppointmentService;
     }
 
-    @GetMapping
+    @GetMapping(path = "appointment/{appointment_id}")
     public ResponseEntity<CompanyAppointmentView> fetchAppointment(@PathVariable("company_number") String companyNumber, @PathVariable("appointment_id") String appointmentID) {
         try {
             return ResponseEntity.ok(companyAppointmentService.fetchAppointment(companyNumber, appointmentID));
         } catch (NotFoundException e) {
+            LOGGER.info(e.getMessage());
+            return ResponseEntity.notFound().build();
+        }
+    }
+
+    @GetMapping(path = "officers")
+    public ResponseEntity<List<CompanyAppointmentView>> fetchAppointmentsForCompany(@PathVariable("company_number") String companyNumber) {
+        try{
+            return ResponseEntity.ok(companyAppointmentService.fetchAppointmentsForCompany(companyNumber));
+        } catch(NotFoundException e) {
             LOGGER.info(e.getMessage());
             return ResponseEntity.notFound().build();
         }

--- a/src/main/java/uk/gov/companieshouse/company_appointments/CompanyAppointmentRepository.java
+++ b/src/main/java/uk/gov/companieshouse/company_appointments/CompanyAppointmentRepository.java
@@ -9,8 +9,6 @@ import org.springframework.stereotype.Repository;
 
 import uk.gov.companieshouse.company_appointments.model.data.CompanyAppointmentData;
 
-import javax.swing.text.html.Option;
-
 @Repository
 public interface CompanyAppointmentRepository extends MongoRepository<CompanyAppointmentData, String> {
 

--- a/src/main/java/uk/gov/companieshouse/company_appointments/CompanyAppointmentRepository.java
+++ b/src/main/java/uk/gov/companieshouse/company_appointments/CompanyAppointmentRepository.java
@@ -1,5 +1,6 @@
 package uk.gov.companieshouse.company_appointments;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.mongodb.repository.MongoRepository;
@@ -13,5 +14,8 @@ public interface CompanyAppointmentRepository extends MongoRepository<CompanyApp
 
     @Query("{'company_number' : '?0', '_id' : '?1'}")
     Optional<CompanyAppointmentData> readByCompanyNumberAndAppointmentID(String companyNumber, String appointmentId);
+
+    @Query("{'company_number' : '?0'}")
+    Optional<List<CompanyAppointmentData>> readAllByCompanyNumber(String companyNumber);
 
 }

--- a/src/main/java/uk/gov/companieshouse/company_appointments/CompanyAppointmentRepository.java
+++ b/src/main/java/uk/gov/companieshouse/company_appointments/CompanyAppointmentRepository.java
@@ -9,6 +9,8 @@ import org.springframework.stereotype.Repository;
 
 import uk.gov.companieshouse.company_appointments.model.data.CompanyAppointmentData;
 
+import javax.swing.text.html.Option;
+
 @Repository
 public interface CompanyAppointmentRepository extends MongoRepository<CompanyAppointmentData, String> {
 
@@ -16,6 +18,10 @@ public interface CompanyAppointmentRepository extends MongoRepository<CompanyApp
     Optional<CompanyAppointmentData> readByCompanyNumberAndAppointmentID(String companyNumber, String appointmentId);
 
     @Query("{'company_number' : '?0'}")
-    Optional<List<CompanyAppointmentData>> readAllByCompanyNumber(String companyNumber);
+    List<CompanyAppointmentData> readAllByCompanyNumber(String companyNumber);
+
+    @Query("{'company_number' : '?0', 'data.resigned_on' : {$exists : false}}")
+    List<CompanyAppointmentData> readAllByCompanyNumberForNotResigned(String companyNumber);
+
 
 }

--- a/src/main/java/uk/gov/companieshouse/company_appointments/CompanyAppointmentService.java
+++ b/src/main/java/uk/gov/companieshouse/company_appointments/CompanyAppointmentService.java
@@ -3,10 +3,13 @@ package uk.gov.companieshouse.company_appointments;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import uk.gov.companieshouse.company_appointments.model.data.CompanyAppointmentData;
+import uk.gov.companieshouse.company_appointments.model.view.AllCompanyAppointmentsView;
 import uk.gov.companieshouse.company_appointments.model.view.CompanyAppointmentView;
 import uk.gov.companieshouse.logging.Logger;
 import uk.gov.companieshouse.logging.LoggerFactory;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -33,15 +36,27 @@ public class CompanyAppointmentService {
         return companyAppointmentMapper.map(appointmentData.orElseThrow(() -> new NotFoundException(String.format("Appointment [%s] for company [%s] not found", appointmentID, companyNumber))));
     }
 
-
-    public List<CompanyAppointmentView> fetchAppointmentsForCompany(String companyNumber) throws NotFoundException {
+    public AllCompanyAppointmentsView fetchAppointmentsForCompany(String companyNumber, String filter) throws NotFoundException {
         LOGGER.debug(String.format("Fetching appointments for company [%s]", companyNumber));
-        Optional<List<CompanyAppointmentData>> allAppointmentData = companyAppointmentRepository.readAllByCompanyNumber(companyNumber);
-        if (!allAppointmentData.isPresent()) {
+        List<CompanyAppointmentData> allAppointmentData;
+
+        if(filter != null && filter.equals("active")){
+            allAppointmentData = companyAppointmentRepository.readAllByCompanyNumberForNotResigned(companyNumber);
+        } else {
+            allAppointmentData = companyAppointmentRepository.readAllByCompanyNumber(companyNumber);
+        }
+
+        if (allAppointmentData.isEmpty()) {
             throw new NotFoundException(String.format("Appointments for company [%s] not found", companyNumber));
         }
-        List<CompanyAppointmentView> companyAppointmentViews = allAppointmentData.get().stream().map(companyAppointmentMapper :: map ).collect(Collectors.toList());
+
+        List<CompanyAppointmentView> companyAppointmentViews = allAppointmentData.stream().map(companyAppointmentMapper :: map ).collect(Collectors.toList());
         companyAppointmentViews.sort(new CompanyAppointmentComparator());
-        return companyAppointmentViews;
+        int activeCount = (int)companyAppointmentViews.stream().filter(officer -> officer.getResignedOn() == null).count();
+        int inactiveCount = 0;
+        int resignedCount = (int)companyAppointmentViews.stream().filter(officer -> officer.getResignedOn() !=null && officer.getResignedOn().isBefore(LocalDate.now().atStartOfDay())).count();
+
+        return new AllCompanyAppointmentsView(companyAppointmentViews.size(), companyAppointmentViews, activeCount, inactiveCount, resignedCount);
+
     }
 }

--- a/src/main/java/uk/gov/companieshouse/company_appointments/CompanyAppointmentService.java
+++ b/src/main/java/uk/gov/companieshouse/company_appointments/CompanyAppointmentService.java
@@ -52,10 +52,10 @@ public class CompanyAppointmentService {
         List<CompanyAppointmentView> companyAppointmentViews = allAppointmentData.stream().map(companyAppointmentMapper :: map ).collect(Collectors.toList());
         companyAppointmentViews.sort(new CompanyAppointmentComparator());
         int activeCount = (int)companyAppointmentViews.stream().filter(officer -> officer.getResignedOn() == null).count();
-        int inactiveCount = 0;
+
         int resignedCount = (int)companyAppointmentViews.stream().filter(officer -> officer.getResignedOn() !=null && officer.getResignedOn().isBefore(LocalDate.now().atStartOfDay())).count();
 
-        return new AllCompanyAppointmentsView(companyAppointmentViews.size(), companyAppointmentViews, activeCount, inactiveCount, resignedCount);
+        return new AllCompanyAppointmentsView(companyAppointmentViews.size(), companyAppointmentViews, activeCount, 0, resignedCount);
 
     }
 }

--- a/src/main/java/uk/gov/companieshouse/company_appointments/CompanyAppointmentService.java
+++ b/src/main/java/uk/gov/companieshouse/company_appointments/CompanyAppointmentService.java
@@ -7,7 +7,9 @@ import uk.gov.companieshouse.company_appointments.model.view.CompanyAppointmentV
 import uk.gov.companieshouse.logging.Logger;
 import uk.gov.companieshouse.logging.LoggerFactory;
 
+import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
 
 @Service
 public class CompanyAppointmentService {
@@ -31,4 +33,15 @@ public class CompanyAppointmentService {
         return companyAppointmentMapper.map(appointmentData.orElseThrow(() -> new NotFoundException(String.format("Appointment [%s] for company [%s] not found", appointmentID, companyNumber))));
     }
 
+
+    public List<CompanyAppointmentView> fetchAppointmentsForCompany(String companyNumber) throws NotFoundException {
+        LOGGER.debug(String.format("Fetching appointments for company [%s]", companyNumber));
+        Optional<List<CompanyAppointmentData>> allAppointmentData = companyAppointmentRepository.readAllByCompanyNumber(companyNumber);
+        if (!allAppointmentData.isPresent()) {
+            throw new NotFoundException(String.format("Appointments for company [%s] not found", companyNumber));
+        }
+        List<CompanyAppointmentView> companyAppointmentViews = allAppointmentData.get().stream().map(companyAppointmentMapper :: map ).collect(Collectors.toList());
+        companyAppointmentViews.sort(new CompanyAppointmentComparator());
+        return companyAppointmentViews;
+    }
 }

--- a/src/main/java/uk/gov/companieshouse/company_appointments/CompanyAppointmentService.java
+++ b/src/main/java/uk/gov/companieshouse/company_appointments/CompanyAppointmentService.java
@@ -9,7 +9,6 @@ import uk.gov.companieshouse.logging.Logger;
 import uk.gov.companieshouse.logging.LoggerFactory;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;

--- a/src/main/java/uk/gov/companieshouse/company_appointments/model/view/AllCompanyAppointmentsView.java
+++ b/src/main/java/uk/gov/companieshouse/company_appointments/model/view/AllCompanyAppointmentsView.java
@@ -7,6 +7,7 @@ import java.util.List;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class AllCompanyAppointmentsView {
+
     @JsonProperty("total_results")
     private int totalResults;
 

--- a/src/main/java/uk/gov/companieshouse/company_appointments/model/view/AllCompanyAppointmentsView.java
+++ b/src/main/java/uk/gov/companieshouse/company_appointments/model/view/AllCompanyAppointmentsView.java
@@ -1,0 +1,74 @@
+package uk.gov.companieshouse.company_appointments.model.view;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class AllCompanyAppointmentsView {
+    @JsonProperty("total_results")
+    private int totalResults;
+
+    @JsonProperty("items")
+    private List<CompanyAppointmentView> items;
+
+    @JsonProperty("active_count")
+    private int activeCount;
+
+    @JsonProperty("inactive_count")
+    private int inactiveCount;
+
+    @JsonProperty("resigned_count")
+    private int resignedCount;
+
+
+    public AllCompanyAppointmentsView(int totalResults, List<CompanyAppointmentView> items, int activeCount, int inactiveCount, int resignedCount) {
+        this.totalResults = totalResults;
+        this.items = items;
+        this.activeCount = activeCount;
+        this.inactiveCount = inactiveCount;
+        this.resignedCount = resignedCount;
+
+    }
+
+    public int getTotalResults() {
+        return totalResults;
+    }
+
+    public void setTotalResults(int totalResults) {
+        this.totalResults = totalResults;
+    }
+
+    public List<CompanyAppointmentView> getItems() {
+        return items;
+    }
+
+    public void setItems(List<CompanyAppointmentView> items) {
+        this.items = items;
+    }
+
+    public int getActiveCount() {
+        return activeCount;
+    }
+
+    public void setActiveCount(int activeCount) {
+        this.activeCount = activeCount;
+    }
+
+    public int getInactiveCount() {
+        return inactiveCount;
+    }
+
+    public void setInactiveCount(int inactiveCount) {
+        this.inactiveCount = inactiveCount;
+    }
+
+    public int getResignedCount() {
+        return resignedCount;
+    }
+
+    public void setResignedCount(int resignedCount) {
+        this.resignedCount = resignedCount;
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/company_appointments/model/view/CompanyAppointmentView.java
+++ b/src/main/java/uk/gov/companieshouse/company_appointments/model/view/CompanyAppointmentView.java
@@ -3,12 +3,14 @@ package uk.gov.companieshouse.company_appointments.model.view;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import uk.gov.companieshouse.company_appointments.CompanyAppointmentRepository;
+
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Objects;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
-public class CompanyAppointmentView {
+public class CompanyAppointmentView{
 
     @JsonProperty("address")
     private ServiceAddressView serviceAddress;
@@ -203,7 +205,8 @@ public class CompanyAppointmentView {
     public static Builder builder() {
         return new Builder();
     }
-    
+
+
     public static class Builder {
 
         private ServiceAddressView serviceAddress;

--- a/src/main/java/uk/gov/companieshouse/company_appointments/model/view/CompanyAppointmentView.java
+++ b/src/main/java/uk/gov/companieshouse/company_appointments/model/view/CompanyAppointmentView.java
@@ -9,7 +9,7 @@ import java.util.List;
 import java.util.Objects;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
-public class CompanyAppointmentView{
+public class CompanyAppointmentView {
 
     @JsonProperty("address")
     private ServiceAddressView serviceAddress;
@@ -206,7 +206,6 @@ public class CompanyAppointmentView{
     public static Builder builder() {
         return new Builder();
     }
-
 
     public static class Builder {
 

--- a/src/main/java/uk/gov/companieshouse/company_appointments/model/view/CompanyAppointmentView.java
+++ b/src/main/java/uk/gov/companieshouse/company_appointments/model/view/CompanyAppointmentView.java
@@ -3,7 +3,6 @@ package uk.gov.companieshouse.company_appointments.model.view;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import uk.gov.companieshouse.company_appointments.CompanyAppointmentRepository;
 
 import java.time.LocalDateTime;
 import java.util.List;

--- a/src/main/java/uk/gov/companieshouse/company_appointments/model/view/CompanyAppointmentView.java
+++ b/src/main/java/uk/gov/companieshouse/company_appointments/model/view/CompanyAppointmentView.java
@@ -80,6 +80,8 @@ public class CompanyAppointmentView{
         this.contactDetails = contactDetails;
     }
 
+    public CompanyAppointmentView() {}
+
     public ServiceAddressView getServiceAddress() {
         return serviceAddress;
     }

--- a/src/test/java/uk/gov/companieshouse/company_appointments/CompanyAppointmentComparatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/company_appointments/CompanyAppointmentComparatorTest.java
@@ -13,7 +13,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 @ExtendWith(MockitoExtension.class)
-public class CompanyAppointmentComparatorTest {
+class CompanyAppointmentComparatorTest {
 
     CompanyAppointmentView companyAppointmentView1;
 

--- a/src/test/java/uk/gov/companieshouse/company_appointments/CompanyAppointmentComparatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/company_appointments/CompanyAppointmentComparatorTest.java
@@ -1,0 +1,107 @@
+package uk.gov.companieshouse.company_appointments;
+
+import org.junit.Before;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.companieshouse.company_appointments.model.view.CompanyAppointmentView;
+
+import java.time.LocalDateTime;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class CompanyAppointmentComparatorTest {
+
+    CompanyAppointmentView companyAppointmentView1;
+
+    CompanyAppointmentView companyAppointmentView2;
+
+
+    CompanyAppointmentComparator companyAppointmentComparator;
+
+    @BeforeEach
+    void setUp() {
+        companyAppointmentComparator = new CompanyAppointmentComparator();
+        companyAppointmentView1 = new CompanyAppointmentView();
+        companyAppointmentView2 = new CompanyAppointmentView();
+    }
+
+    @Test
+    public void testPositiveValueIsReturnedWhenFirstResigned(){
+        companyAppointmentView1.setResignedOn(LocalDateTime.of(2020, 12, 22, 0, 0));
+        companyAppointmentView2.setResignedOn(null);
+
+        int result = companyAppointmentComparator.compare(companyAppointmentView1, companyAppointmentView2);
+        assertEquals(1, result);
+    }
+
+    @Test
+    public void testNegativeValueIsReturnedWhenSecondResigned(){
+        companyAppointmentView1.setResignedOn(null);
+        companyAppointmentView2.setResignedOn(LocalDateTime.of(2020, 12, 22, 0, 0));
+
+        int result = companyAppointmentComparator.compare(companyAppointmentView1, companyAppointmentView2);
+        assertEquals(-1, result);
+    }
+
+    @Test
+    public void testNegativeValueIsReturnedWhenFirstIsSecretary(){
+        companyAppointmentView1.setOfficerRole("secretary");
+        companyAppointmentView2.setOfficerRole("director");
+
+        int result = companyAppointmentComparator.compare(companyAppointmentView1, companyAppointmentView2);
+        assertEquals(-1, result);
+    }
+
+    @Test
+    public void testPositiveValueIsReturnedWhenSecondIsSecretary(){
+        companyAppointmentView1.setOfficerRole("director");
+        companyAppointmentView2.setOfficerRole("secretary");
+
+        int result = companyAppointmentComparator.compare(companyAppointmentView1, companyAppointmentView2);
+        assertEquals(1, result);
+    }
+
+    @Test
+    public void testGetNameIsCalledZeroWhenTwoResignedAndSameName(){
+        companyAppointmentView1.setResignedOn(LocalDateTime.of(2020, 12, 22, 0, 0));
+        companyAppointmentView2.setResignedOn(LocalDateTime.of(2020, 12, 22, 0, 0));
+        companyAppointmentView1.setName("ABC");
+        companyAppointmentView2.setName("ABC");
+
+        int result = companyAppointmentComparator.compare(companyAppointmentView1, companyAppointmentView2);
+        assertEquals(0, result);
+    }
+
+    @Test
+    public void testGetNameIsCalledZeroWhenTwoSecretaryAndSameName(){
+        companyAppointmentView1.setOfficerRole("secretary");
+        companyAppointmentView2.setOfficerRole("secretary");
+        companyAppointmentView1.setName("ABC");
+        companyAppointmentView2.setName("ABC");
+
+        int result = companyAppointmentComparator.compare(companyAppointmentView1, companyAppointmentView2);
+        assertEquals(0, result);
+    }
+
+
+    @Test
+    public void testGetNameIsCalledZeroWhenTwoSecretaryAndTwoResignedAndDifferentName(){
+        companyAppointmentView1.setResignedOn(LocalDateTime.of(2020, 12, 22, 0, 0));
+        companyAppointmentView2.setResignedOn(LocalDateTime.of(2020, 12, 22, 0, 0));
+        companyAppointmentView1.setOfficerRole("secretary");
+        companyAppointmentView2.setOfficerRole("secretary");
+        companyAppointmentView1.setName("ABC");
+        companyAppointmentView2.setName("DEF");
+
+        int result = companyAppointmentComparator.compare(companyAppointmentView1, companyAppointmentView2);
+        assertTrue(result<0);
+    }
+
+
+}

--- a/src/test/java/uk/gov/companieshouse/company_appointments/CompanyAppointmentComparatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/company_appointments/CompanyAppointmentComparatorTest.java
@@ -88,7 +88,7 @@ class CompanyAppointmentComparatorTest {
 
 
     @Test
-    void testGetNameIsCalledZeroWhenTwoSecretaryAndTwoResignedAndDifferentName(){
+    void testGetNameIsCalledNegativeWhenTwoSecretaryAndTwoResignedAndDifferentName(){
         companyAppointmentView1.setResignedOn(LocalDateTime.of(2020, 12, 22, 0, 0));
         companyAppointmentView2.setResignedOn(LocalDateTime.of(2020, 12, 22, 0, 0));
         companyAppointmentView1.setOfficerRole("secretary");

--- a/src/test/java/uk/gov/companieshouse/company_appointments/CompanyAppointmentComparatorTest.java
+++ b/src/test/java/uk/gov/companieshouse/company_appointments/CompanyAppointmentComparatorTest.java
@@ -1,10 +1,9 @@
 package uk.gov.companieshouse.company_appointments;
 
-import org.junit.Before;
+
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.companieshouse.company_appointments.model.view.CompanyAppointmentView;
 
@@ -12,7 +11,6 @@ import java.time.LocalDateTime;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 public class CompanyAppointmentComparatorTest {
@@ -20,7 +18,6 @@ public class CompanyAppointmentComparatorTest {
     CompanyAppointmentView companyAppointmentView1;
 
     CompanyAppointmentView companyAppointmentView2;
-
 
     CompanyAppointmentComparator companyAppointmentComparator;
 
@@ -32,7 +29,7 @@ public class CompanyAppointmentComparatorTest {
     }
 
     @Test
-    public void testPositiveValueIsReturnedWhenFirstResigned(){
+    void testPositiveValueIsReturnedWhenFirstResigned(){
         companyAppointmentView1.setResignedOn(LocalDateTime.of(2020, 12, 22, 0, 0));
         companyAppointmentView2.setResignedOn(null);
 
@@ -41,7 +38,7 @@ public class CompanyAppointmentComparatorTest {
     }
 
     @Test
-    public void testNegativeValueIsReturnedWhenSecondResigned(){
+    void testNegativeValueIsReturnedWhenSecondResigned(){
         companyAppointmentView1.setResignedOn(null);
         companyAppointmentView2.setResignedOn(LocalDateTime.of(2020, 12, 22, 0, 0));
 
@@ -50,7 +47,7 @@ public class CompanyAppointmentComparatorTest {
     }
 
     @Test
-    public void testNegativeValueIsReturnedWhenFirstIsSecretary(){
+    void testNegativeValueIsReturnedWhenFirstIsSecretary(){
         companyAppointmentView1.setOfficerRole("secretary");
         companyAppointmentView2.setOfficerRole("director");
 
@@ -59,7 +56,7 @@ public class CompanyAppointmentComparatorTest {
     }
 
     @Test
-    public void testPositiveValueIsReturnedWhenSecondIsSecretary(){
+    void testPositiveValueIsReturnedWhenSecondIsSecretary(){
         companyAppointmentView1.setOfficerRole("director");
         companyAppointmentView2.setOfficerRole("secretary");
 
@@ -68,7 +65,7 @@ public class CompanyAppointmentComparatorTest {
     }
 
     @Test
-    public void testGetNameIsCalledZeroWhenTwoResignedAndSameName(){
+    void testGetNameIsCalledZeroWhenTwoResignedAndSameName(){
         companyAppointmentView1.setResignedOn(LocalDateTime.of(2020, 12, 22, 0, 0));
         companyAppointmentView2.setResignedOn(LocalDateTime.of(2020, 12, 22, 0, 0));
         companyAppointmentView1.setName("ABC");
@@ -79,7 +76,7 @@ public class CompanyAppointmentComparatorTest {
     }
 
     @Test
-    public void testGetNameIsCalledZeroWhenTwoSecretaryAndSameName(){
+    void testGetNameIsCalledZeroWhenTwoSecretaryAndSameName(){
         companyAppointmentView1.setOfficerRole("secretary");
         companyAppointmentView2.setOfficerRole("secretary");
         companyAppointmentView1.setName("ABC");
@@ -91,7 +88,7 @@ public class CompanyAppointmentComparatorTest {
 
 
     @Test
-    public void testGetNameIsCalledZeroWhenTwoSecretaryAndTwoResignedAndDifferentName(){
+    void testGetNameIsCalledZeroWhenTwoSecretaryAndTwoResignedAndDifferentName(){
         companyAppointmentView1.setResignedOn(LocalDateTime.of(2020, 12, 22, 0, 0));
         companyAppointmentView2.setResignedOn(LocalDateTime.of(2020, 12, 22, 0, 0));
         companyAppointmentView1.setOfficerRole("secretary");
@@ -102,6 +99,4 @@ public class CompanyAppointmentComparatorTest {
         int result = companyAppointmentComparator.compare(companyAppointmentView1, companyAppointmentView2);
         assertTrue(result<0);
     }
-
-
 }

--- a/src/test/java/uk/gov/companieshouse/company_appointments/CompanyAppointmentControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/company_appointments/CompanyAppointmentControllerTest.java
@@ -13,6 +13,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 
+import uk.gov.companieshouse.company_appointments.model.view.AllCompanyAppointmentsView;
 import uk.gov.companieshouse.company_appointments.model.view.CompanyAppointmentView;
 
 @ExtendWith(MockitoExtension.class)
@@ -25,6 +26,9 @@ public class CompanyAppointmentControllerTest {
 
     @Mock
     private CompanyAppointmentView companyAppointmentView;
+
+    @Mock
+    private AllCompanyAppointmentsView allCompanyAppointmentsView;
 
     private final static String COMPANY_NUMBER = "123456";
     private final static String APPOINTMENT_ID = "345678";
@@ -61,4 +65,33 @@ public class CompanyAppointmentControllerTest {
         assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
         verify(companyAppointmentService).fetchAppointment(any(), any());
     }
+
+    @Test //check what the filter needs to be
+    void testControllerReturns200StatusAndAppointmentsForCompany() throws NotFoundException {
+        // given
+        when(companyAppointmentService.fetchAppointmentsForCompany(COMPANY_NUMBER, "false")).thenReturn(allCompanyAppointmentsView);
+
+        // when
+        ResponseEntity<AllCompanyAppointmentsView> response = companyAppointmentController.fetchAppointmentsForCompany(COMPANY_NUMBER,
+                "false");
+
+        // then
+        assertEquals(HttpStatus.OK, response.getStatusCode());
+        assertEquals(allCompanyAppointmentsView, response.getBody());
+        verify(companyAppointmentService).fetchAppointmentsForCompany(COMPANY_NUMBER, "false");
+    }
+
+    @Test
+    void testControllerReturns404StatusIfAppointmentForCompanyNotFound() throws NotFoundException {
+        // given
+        when(companyAppointmentService.fetchAppointmentsForCompany(any(), any())).thenThrow(NotFoundException.class);
+
+        // when
+        ResponseEntity<AllCompanyAppointmentsView> response = companyAppointmentController.fetchAppointmentsForCompany(COMPANY_NUMBER,
+                "false");
+
+        assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
+        verify(companyAppointmentService).fetchAppointmentsForCompany(any(), any());
+    }
+
 }

--- a/src/test/java/uk/gov/companieshouse/company_appointments/CompanyAppointmentControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/company_appointments/CompanyAppointmentControllerTest.java
@@ -66,7 +66,7 @@ public class CompanyAppointmentControllerTest {
         verify(companyAppointmentService).fetchAppointment(any(), any());
     }
 
-    @Test //check what the filter needs to be
+    @Test
     void testControllerReturns200StatusAndAppointmentsForCompany() throws NotFoundException {
         // given
         when(companyAppointmentService.fetchAppointmentsForCompany(COMPANY_NUMBER, "false")).thenReturn(allCompanyAppointmentsView);

--- a/src/test/java/uk/gov/companieshouse/company_appointments/CompanyAppointmentServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/company_appointments/CompanyAppointmentServiceTest.java
@@ -3,8 +3,7 @@ package uk.gov.companieshouse.company_appointments;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -12,10 +11,16 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.function.Executable;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import uk.gov.companieshouse.company_appointments.model.data.CompanyAppointmentData;
+import uk.gov.companieshouse.company_appointments.model.data.*;
+import uk.gov.companieshouse.company_appointments.model.view.AllCompanyAppointmentsView;
 import uk.gov.companieshouse.company_appointments.model.view.CompanyAppointmentView;
 
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 @ExtendWith(MockitoExtension.class)
 class CompanyAppointmentServiceTest {
@@ -25,7 +30,7 @@ class CompanyAppointmentServiceTest {
     @Mock
     private CompanyAppointmentRepository companyAppointmentRepository;
 
-    @Mock
+
     private CompanyAppointmentMapper companyAppointmentMapper;
 
     @Mock
@@ -34,29 +39,34 @@ class CompanyAppointmentServiceTest {
     @Mock
     private CompanyAppointmentView companyAppointmentView;
 
+
+
+
+
     private final static String COMPANY_NUMBER = "123456";
     private final static String APPOINTMENT_ID = "345678";
+    private final static String filter = "active";
 
     @BeforeEach
     void setUp() {
+        companyAppointmentMapper = new CompanyAppointmentMapper();
         companyAppointmentService = new CompanyAppointmentService(companyAppointmentRepository, companyAppointmentMapper);
     }
 
     @Test
     void testFetchAppointmentReturnsMappedAppointmentData() throws NotFoundException {
+        CompanyAppointmentData officerData = new CompanyAppointmentData("1", officerData().build());
+
         // given
         when(companyAppointmentRepository.readByCompanyNumberAndAppointmentID(COMPANY_NUMBER, APPOINTMENT_ID))
-                .thenReturn(Optional.of(companyAppointmentData));
-
-        when(companyAppointmentMapper.map(companyAppointmentData)).thenReturn(companyAppointmentView);
+                .thenReturn(Optional.of(officerData));
 
         // when
         CompanyAppointmentView result = companyAppointmentService.fetchAppointment(COMPANY_NUMBER, APPOINTMENT_ID);
 
         // then
-        assertEquals(companyAppointmentView, result);
+        assertEquals(CompanyAppointmentView.class, result.getClass());
         verify(companyAppointmentRepository).readByCompanyNumberAndAppointmentID(COMPANY_NUMBER, APPOINTMENT_ID);
-        verify(companyAppointmentMapper).map(companyAppointmentData);
     }
 
     @Test
@@ -67,6 +77,94 @@ class CompanyAppointmentServiceTest {
         Executable result = () -> companyAppointmentService.fetchAppointment(COMPANY_NUMBER, APPOINTMENT_ID);
 
         assertThrows(NotFoundException.class, result);
+    }
+
+    @Test
+    void testFetchAppointmentForCompanyNumberForNotResignedReturnsMappedAppointmentData() throws NotFoundException{
+        CompanyAppointmentData officerData = new CompanyAppointmentData("1", officerData().build());
+
+        List<CompanyAppointmentData> allAppointmentData = new ArrayList<>();
+        allAppointmentData.add(officerData);
+
+
+        when(companyAppointmentRepository.readAllByCompanyNumberForNotResigned(COMPANY_NUMBER))
+                .thenReturn(allAppointmentData);
+
+
+        AllCompanyAppointmentsView result = companyAppointmentService.fetchAppointmentsForCompany(COMPANY_NUMBER, filter);
+
+        assertEquals(1, result.getTotalResults());
+        assertEquals(AllCompanyAppointmentsView.class, result.getClass());
+        verify(companyAppointmentRepository).readAllByCompanyNumberForNotResigned(COMPANY_NUMBER);
+    }
+
+
+
+    @Test
+    void testFetchAppointmentForCompanyThrowsNotFoundExceptionIfAppointmentDoesntExist() {
+        when(companyAppointmentRepository.readAllByCompanyNumber(any()))
+                .thenReturn(new ArrayList<>());
+
+        Executable result = () -> companyAppointmentService.fetchAppointmentsForCompany(COMPANY_NUMBER, "filter");
+
+        assertThrows(NotFoundException.class, result);
+    }
+
+    @Test
+    void testFetchAppointmentForCompanyNumberReturnsMappedAppointmentData() throws NotFoundException{
+        CompanyAppointmentData officerData = new CompanyAppointmentData("1", officerData().build());
+
+        List<CompanyAppointmentData> allAppointmentData = new ArrayList<>();
+        allAppointmentData.add(officerData);
+
+
+        when(companyAppointmentRepository.readAllByCompanyNumber(COMPANY_NUMBER))
+                .thenReturn(allAppointmentData);
+
+
+        AllCompanyAppointmentsView result = companyAppointmentService.fetchAppointmentsForCompany(COMPANY_NUMBER, "filter");
+
+        assertEquals(1, result.getTotalResults());
+        assertEquals(AllCompanyAppointmentsView.class, result.getClass());
+        verify(companyAppointmentRepository).readAllByCompanyNumber(COMPANY_NUMBER);
+    }
+
+    private OfficerData.Builder officerData() {
+        return OfficerData.builder()
+                .withAppointedOn(LocalDateTime.of(2020, 8, 26, 12, 0))
+                .withResignedOn(LocalDateTime.of(2020, 8, 26, 13, 0))
+                .withCountryOfResidence("Country")
+                .withDateOfBirth(LocalDateTime.of(1980, 1, 1, 12, 0))
+                .withLinks(new LinksData("/company/12345678/appointment/123", "/officers/abc", "/officers/abc/appointments"))
+                .withNationality("Nationality")
+                .withOccupation("Occupation")
+                .withOfficerRole("Role")
+                .withServiceAddress(ServiceAddressData.builder()
+                        .withAddressLine1("Address 1")
+                        .withAddressLine2("Address 2")
+                        .withCareOf("Care of")
+                        .withCountry("Country")
+                        .withLocality("Locality")
+                        .withPostcode("AB01 9XY")
+                        .withPoBox("PO Box")
+                        .withPremises("Premises")
+                        .withRegion("Region")
+                        .build())
+                .withResponsibilities("responsibilities")
+                .withPrincipalOfficeAddress(ServiceAddressData.builder()
+                        .withAddressLine1("Address 1")
+                        .withAddressLine2("Address 2")
+                        .withCareOf("Care of")
+                        .withCountry("Country")
+                        .withLocality("Locality")
+                        .withPostcode("AB01 9XY")
+                        .withPoBox("PO Box")
+                        .withPremises("Premises")
+                        .withRegion("Region")
+                        .build())
+                .withContactDetails(ContactDetailsData.builder()
+                        .withContactName("Name")
+                        .build());
     }
 
 }

--- a/src/test/java/uk/gov/companieshouse/company_appointments/CompanyAppointmentServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/company_appointments/CompanyAppointmentServiceTest.java
@@ -3,7 +3,8 @@ package uk.gov.companieshouse.company_appointments;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -11,7 +12,11 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.function.Executable;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import uk.gov.companieshouse.company_appointments.model.data.*;
+import uk.gov.companieshouse.company_appointments.model.data.CompanyAppointmentData;
+import uk.gov.companieshouse.company_appointments.model.data.ContactDetailsData;
+import uk.gov.companieshouse.company_appointments.model.data.LinksData;
+import uk.gov.companieshouse.company_appointments.model.data.OfficerData;
+import uk.gov.companieshouse.company_appointments.model.data.ServiceAddressData;
 import uk.gov.companieshouse.company_appointments.model.view.AllCompanyAppointmentsView;
 import uk.gov.companieshouse.company_appointments.model.view.CompanyAppointmentView;
 
@@ -19,8 +24,6 @@ import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 @ExtendWith(MockitoExtension.class)
 class CompanyAppointmentServiceTest {
@@ -30,21 +33,12 @@ class CompanyAppointmentServiceTest {
     @Mock
     private CompanyAppointmentRepository companyAppointmentRepository;
 
-
     private CompanyAppointmentMapper companyAppointmentMapper;
 
-    @Mock
-    private CompanyAppointmentData companyAppointmentData;
-
-    @Mock
-    private CompanyAppointmentView companyAppointmentView;
-
-
-
-
-
     private final static String COMPANY_NUMBER = "123456";
+
     private final static String APPOINTMENT_ID = "345678";
+
     private final static String filter = "active";
 
     @BeforeEach
@@ -97,8 +91,6 @@ class CompanyAppointmentServiceTest {
         assertEquals(AllCompanyAppointmentsView.class, result.getClass());
         verify(companyAppointmentRepository).readAllByCompanyNumberForNotResigned(COMPANY_NUMBER);
     }
-
-
 
     @Test
     void testFetchAppointmentForCompanyThrowsNotFoundExceptionIfAppointmentDoesntExist() {
@@ -166,5 +158,4 @@ class CompanyAppointmentServiceTest {
                         .withContactName("Name")
                         .build());
     }
-
 }

--- a/src/test/resources/appointment-data2.json
+++ b/src/test/resources/appointment-data2.json
@@ -1,0 +1,47 @@
+{
+  "_id" : "abc123",
+  "appointment_id" : "abc123",
+  "company_name" : "TEST COMPANY LIMITED",
+  "company_number" : "12345678",
+  "company_status" : "active",
+  "created" : {
+    "at" : ISODate("2020-08-26T12:00:00.000Z")
+  },
+  "data" : {
+    "officer_role" : "secretary",
+    "title" : "Mrs",
+    "date_of_birth" : ISODate("1980-01-01T00:00:00.000Z"),
+    "country_of_residence" : "United Kingdom",
+    "links" : {
+      "officer" : {
+        "self" : "/officers/abc123",
+        "appointments" : "/officers/abc123/appointments"
+      },
+      "self" : "/company/12345678/appointments/abc123"
+    },
+    "nationality" : "British",
+    "forename" : "John",
+    "surname" : "Doe",
+    "company_number" : "12345678",
+    "updated_at" : ISODate("2020-08-26T13:00:00.000Z"),
+    "other_forenames" : "Forename",
+    "appointed_on" : ISODate("2020-08-26T12:00:00.000Z"),
+    "etag" : "8f58a770d34f982a1b2a5a29fcde12528e82f903",
+    "occupation" : "Company Director",
+    "service_address" : {
+      "region" : "Cardiff",
+      "address_line_1" : "1 Crown Way",
+      "postal_code" : "CF14 3UZ",
+      "address_line_2" : "Pavement",
+      "locality" : "Cardiff"
+    }
+  },
+  "delta_at" : "20200623121303006153",
+  "internal_id" : "2500085646",
+  "officer_id" : "5VEOBB4a9dlB_iugw_vieHjWpCk",
+  "officer_role_sort_order" : 200,
+  "updated" : {
+    "at" : ISODate("2020-08-26T13:00:00.000Z")
+  },
+  "previous_officer_id" : "5VEOBB4a9dlB_iugw_vieHjWpCk"
+}


### PR DESCRIPTION
Added new endpoint for company officers in company_appointments_api.
Added the sorting points: resigned/not resigned, secretary/directors, alphabetical order.
Added getmapping in CompanyAppointmentController.
Added queries in CompanyAppointmentRepository.
Added sort and filter by active officers in CompanyAppointmentService.
Added integration test.

Resolves:
-DSND-1329 https://companieshouse.atlassian.net/browse/DSND-1329