### PR TITLE
order natural before corporate officers

### DIFF
--- a/src/main/java/uk/gov/companieshouse/company_appointments/SortMapper.java
+++ b/src/main/java/uk/gov/companieshouse/company_appointments/SortMapper.java
@@ -11,11 +11,11 @@ class SortMapper {
     private static final String RESIGNED_ON = "resigned_on";
 
     private static final Sort DEFAULT_SORT = Sort.by(Sort.Direction.ASC, "officer_role_sort_order")
-            .and(Sort.by(Sort.Direction.ASC, "data.surname", "data.company_name"))
+            .and(Sort.by(Sort.Direction.ASC, "data.company_name", "data.surname"))
             .and(Sort.by(Sort.Direction.ASC, "data.forename"))
             .and(Sort.by(Sort.Direction.DESC, "data.appointed_on", "data.appointed_before"));
     private static final Sort APPOINTED_ON_SORT = Sort.by(Sort.Direction.DESC, "data.appointed_on", "data.appointed_before");
-    private static final Sort SURNAME_SORT =  Sort.by(Sort.Direction.ASC, "data.surname", "data.company_name");
+    private static final Sort SURNAME_SORT =  Sort.by(Sort.Direction.ASC, "data.company_name", "data.surname");
     private static final Sort RESIGNED_ON_SORT =  Sort.by(Sort.Direction.DESC, "data.resigned_on");
 
     public Sort getSort(String orderBy) throws BadRequestException {

--- a/src/test/java/uk/gov/companieshouse/company_appointments/SortMapperTest.java
+++ b/src/test/java/uk/gov/companieshouse/company_appointments/SortMapperTest.java
@@ -20,7 +20,7 @@ public class SortMapperTest {
     void testOfficerRoleSortOrder() throws Exception {
 
         Sort expected = Sort.by(Sort.Direction.ASC, "officer_role_sort_order")
-                .and(Sort.by(Sort.Direction.ASC,  "data.company_name", "data.surname"))
+                .and(Sort.by(Sort.Direction.ASC, "data.company_name", "data.surname"))
                 .and(Sort.by(Sort.Direction.ASC, "data.forename"))
                 .and(Sort.by(Sort.Direction.DESC, "data.appointed_on", "data.appointed_before"));
 
@@ -43,7 +43,7 @@ public class SortMapperTest {
     @Test
     void testOfficerRoleSortBySurname() throws Exception {
 
-        Sort expected = Sort.by(Sort.Direction.ASC,  "data.company_name", "data.surname");
+        Sort expected = Sort.by(Sort.Direction.ASC, "data.company_name", "data.surname");
 
         Sort actual = sortMapper.getSort("surname");
 

--- a/src/test/java/uk/gov/companieshouse/company_appointments/SortMapperTest.java
+++ b/src/test/java/uk/gov/companieshouse/company_appointments/SortMapperTest.java
@@ -20,7 +20,7 @@ public class SortMapperTest {
     void testOfficerRoleSortOrder() throws Exception {
 
         Sort expected = Sort.by(Sort.Direction.ASC, "officer_role_sort_order")
-                .and(Sort.by(Sort.Direction.ASC, "data.surname", "data.company_name"))
+                .and(Sort.by(Sort.Direction.ASC,  "data.company_name", "data.surname"))
                 .and(Sort.by(Sort.Direction.ASC, "data.forename"))
                 .and(Sort.by(Sort.Direction.DESC, "data.appointed_on", "data.appointed_before"));
 
@@ -43,7 +43,7 @@ public class SortMapperTest {
     @Test
     void testOfficerRoleSortBySurname() throws Exception {
 
-        Sort expected = Sort.by(Sort.Direction.ASC, "data.surname", "data.company_name");
+        Sort expected = Sort.by(Sort.Direction.ASC,  "data.company_name", "data.surname");
 
         Sort actual = sortMapper.getSort("surname");
 


### PR DESCRIPTION
This pr fixes ordering for the default and surname order by options. Natural officers will now be ordered before corporate officers in the list, to match the api.ch.gov.uk solution.

The order "data.company_name", "data.surname" is used as the order direction is ascending and null values come at the top, so null company_names (naturals) will come first.

**Required for**
- DSND-1359
