### PR TITLE
Add name fields and pre1992 flag to GET requests

### DIFF
--- a/src/main/java/uk/gov/companieshouse/company_appointments/CompanyAppointmentMapper.java
+++ b/src/main/java/uk/gov/companieshouse/company_appointments/CompanyAppointmentMapper.java
@@ -47,7 +47,7 @@ public class CompanyAppointmentMapper {
                 .withPrincipalOfficeAddress(mapPrincipalOfficeAddress(companyAppointmentData))
                 .withContactDetails(mapContactDetails(companyAppointmentData))
                 .withEtag(companyAppointmentData.getData().getEtag())
-                .withIsPre1992Appointment(companyAppointmentData.getData().isPre1992Appointment())
+                .withIsPre1992Appointment(companyAppointmentData.getData().getIsPre1992Appointment())
                 .build();
         LOGGER.debug("Mapped data for appointment: " + companyAppointmentData.getId());
         return result;

--- a/src/main/java/uk/gov/companieshouse/company_appointments/CompanyAppointmentMapper.java
+++ b/src/main/java/uk/gov/companieshouse/company_appointments/CompanyAppointmentMapper.java
@@ -47,8 +47,10 @@ public class CompanyAppointmentMapper {
                 .withPrincipalOfficeAddress(mapPrincipalOfficeAddress(companyAppointmentData))
                 .withContactDetails(mapContactDetails(companyAppointmentData))
                 .withEtag(companyAppointmentData.getData().getEtag())
+                .withIsPre1992Appointment(companyAppointmentData.getData().isPre1992Appointment())
                 .build();
         LOGGER.debug("Mapped data for appointment: " + companyAppointmentData.getId());
+        LOGGER.debug("IsPre1992Appointment " + companyAppointmentData.getData().isPre1992Appointment());
         return result;
     }
 

--- a/src/main/java/uk/gov/companieshouse/company_appointments/CompanyAppointmentMapper.java
+++ b/src/main/java/uk/gov/companieshouse/company_appointments/CompanyAppointmentMapper.java
@@ -50,7 +50,6 @@ public class CompanyAppointmentMapper {
                 .withIsPre1992Appointment(companyAppointmentData.getData().isPre1992Appointment())
                 .build();
         LOGGER.debug("Mapped data for appointment: " + companyAppointmentData.getId());
-        LOGGER.debug("IsPre1992Appointment " + companyAppointmentData.getData().isPre1992Appointment());
         return result;
     }
 

--- a/src/main/java/uk/gov/companieshouse/company_appointments/model/data/OfficerData.java
+++ b/src/main/java/uk/gov/companieshouse/company_appointments/model/data/OfficerData.java
@@ -268,7 +268,7 @@ public class OfficerData {
         this.etag = etag;
     }
 
-    public Boolean isPre1992Appointment() {
+    public Boolean getIsPre1992Appointment() {
         return isPre1992Appointment;
     }
 
@@ -450,7 +450,7 @@ public class OfficerData {
                 Objects.equals(getPrincipalOfficeAddress(), that.getPrincipalOfficeAddress()) &&
                 Objects.equals(getContactDetails(), that.getContactDetails()) &&
                 Objects.equals(getEtag(), that.getEtag()) &&
-                Objects.equals(isPre1992Appointment(), that.isPre1992Appointment());
+                Objects.equals(getIsPre1992Appointment(), that.getIsPre1992Appointment());
     }
 
     @Override
@@ -463,6 +463,6 @@ public class OfficerData {
                         getSurname(),
                         getForename(), getOtherForenames(), getTitle(), getCompanyName(),
                         getResponsibilities(), getPrincipalOfficeAddress(), getContactDetails(),
-                        getEtag(), isPre1992Appointment());
+                        getEtag(), getIsPre1992Appointment());
     }
 }

--- a/src/main/java/uk/gov/companieshouse/company_appointments/model/data/OfficerData.java
+++ b/src/main/java/uk/gov/companieshouse/company_appointments/model/data/OfficerData.java
@@ -63,6 +63,9 @@ public class OfficerData {
 
     private String etag;
 
+    @Field("is_pre_1992_appointment")
+    private Boolean isPre1992Appointment;
+
     public OfficerData(
             ServiceAddressData serviceAddress, LocalDateTime appointedOn, String appointedBefore,
             LocalDateTime resignedOn, String countryOfResidence,
@@ -71,7 +74,8 @@ public class OfficerData {
             IdentificationData identificationData,
             List<FormerNamesData> formerNameData, String surname, String forename,
             String otherForenames, String title, String companyName, String responsibilities,
-            ServiceAddressData principalOfficeAddress, ContactDetailsData contactDetails, String etag) {
+            ServiceAddressData principalOfficeAddress, ContactDetailsData contactDetails, String etag,
+            Boolean isPre1992Appointment) {
         this.serviceAddress = serviceAddress;
         this.appointedOn = appointedOn;
         this.appointedBefore = appointedBefore;
@@ -93,6 +97,7 @@ public class OfficerData {
         this.principalOfficeAddress = principalOfficeAddress;
         this.contactDetails = contactDetails;
         this.etag = etag;
+        this.isPre1992Appointment = isPre1992Appointment;
     }
 
     public ServiceAddressData getServiceAddress() {
@@ -263,6 +268,14 @@ public class OfficerData {
         this.etag = etag;
     }
 
+    public Boolean isPre1992Appointment() {
+        return isPre1992Appointment;
+    }
+
+    public void setIsPre1992Appointment(Boolean isPre1992Appointment) {
+        isPre1992Appointment = isPre1992Appointment;
+    }
+
     public static Builder builder() {
         return new Builder();
     }
@@ -289,6 +302,7 @@ public class OfficerData {
         private ServiceAddressData principalOfficeAddress;
         private ContactDetailsData contactDetailsData;
         private String etag;
+        private Boolean isPre1992Appointment;
 
         public Builder withServiceAddress(ServiceAddressData serviceAddress) {
             this.serviceAddress = serviceAddress;
@@ -395,11 +409,16 @@ public class OfficerData {
             return this;
         }
 
+        public Builder withIsPre1992Appointment(Boolean isPre1992Appointment) {
+            this.isPre1992Appointment = isPre1992Appointment;
+            return this;
+        }
+
         public OfficerData build() {
             return new OfficerData(serviceAddress, appointedOn, appointedBefore, resignedOn, countryOfResidence, linksData, nationality,
                     occupation, officerRole, dateOfBirth, identificationData, formerNameData, surname, forename,
                     otherForenames, title, companyName, responsibilities, principalOfficeAddress,
-                    contactDetailsData, etag);
+                    contactDetailsData, etag, isPre1992Appointment);
         }
     }
 
@@ -430,7 +449,8 @@ public class OfficerData {
                 Objects.equals(getResponsibilities(), that.getResponsibilities()) &&
                 Objects.equals(getPrincipalOfficeAddress(), that.getPrincipalOfficeAddress()) &&
                 Objects.equals(getContactDetails(), that.getContactDetails()) &&
-                Objects.equals(getEtag(), that.getEtag());
+                Objects.equals(getEtag(), that.getEtag()) &&
+                Objects.equals(isPre1992Appointment(), that.isPre1992Appointment());
     }
 
     @Override
@@ -443,6 +463,6 @@ public class OfficerData {
                         getSurname(),
                         getForename(), getOtherForenames(), getTitle(), getCompanyName(),
                         getResponsibilities(), getPrincipalOfficeAddress(), getContactDetails(),
-                        getEtag());
+                        getEtag(), isPre1992Appointment());
     }
 }

--- a/src/main/java/uk/gov/companieshouse/company_appointments/model/data/OfficerData.java
+++ b/src/main/java/uk/gov/companieshouse/company_appointments/model/data/OfficerData.java
@@ -273,7 +273,7 @@ public class OfficerData {
     }
 
     public void setIsPre1992Appointment(Boolean isPre1992Appointment) {
-        isPre1992Appointment = isPre1992Appointment;
+        this.isPre1992Appointment = isPre1992Appointment;
     }
 
     public static Builder builder() {

--- a/src/main/java/uk/gov/companieshouse/company_appointments/model/view/CompanyAppointmentFullRecordView.java
+++ b/src/main/java/uk/gov/companieshouse/company_appointments/model/view/CompanyAppointmentFullRecordView.java
@@ -62,6 +62,15 @@ public class CompanyAppointmentFullRecordView {
     @JsonProperty("name")
     private String name;
 
+    @JsonProperty("forename")
+    private String forename;
+
+    @JsonProperty("surname")
+    private String surname;
+
+    @JsonProperty("other_forenames")
+    private String otherForenames;
+
     @JsonProperty("nationality")
     private String nationality;
 
@@ -76,6 +85,9 @@ public class CompanyAppointmentFullRecordView {
 
     @JsonProperty("person_number")
     private String personNumber;
+
+    @JsonProperty("is_pre_1992_appointment")
+    private Boolean isPre1992Appointment;
 
     public AddressAPI getServiceAddress() {
         return serviceAddress;
@@ -121,6 +133,18 @@ public class CompanyAppointmentFullRecordView {
         return name;
     }
 
+    public String getForename() {
+        return forename;
+    }
+
+    public String getSurname() {
+        return surname;
+    }
+
+    public String getOtherForenames() {
+        return otherForenames;
+    }
+
     public String getNationality() {
         return nationality;
     }
@@ -141,6 +165,10 @@ public class CompanyAppointmentFullRecordView {
         return personNumber;
     }
 
+    public Boolean getIsPre1992Appointment() {
+        return isPre1992Appointment;
+    }
+
     public static class Builder {
 
         public static final ZoneId UTC_ZONE = ZoneId.of("UTC");
@@ -156,21 +184,25 @@ public class CompanyAppointmentFullRecordView {
             Builder builder = new Builder();
 
             return builder.withServiceAddress(data.getServiceAddress())
-                .withUsualResidentialAddress(sensitiveData.getUsualResidentialAddress())
-                .withAppointedOn(data.getAppointedOn())
-                .withAppointedBefore(data.getAppointedBefore())
-                .withCountryOfResidence(data.getCountryOfResidence())
-                .withDateOfBirth(builder.mapDateOfBirth(sensitiveData.getDateOfBirth()))
-                .withFormerNames(data.getFormerNameData())
-                .withIdentification(data.getIdentificationData())
-                .withLinks(data.getLinksData())
-                .withName(builder.individualOfficerName(data))
-                .withNationality(data.getNationality())
-                .withOccupation(data.getOccupation())
-                .withOfficerRole(data.getOfficerRole())
-                .withResignedOn(data.getResignedOn())
-                .withEtag(data.getEtag())
-                .withPersonNumber(data.getPersonNumber());
+                    .withUsualResidentialAddress(sensitiveData.getUsualResidentialAddress())
+                    .withAppointedOn(data.getAppointedOn())
+                    .withAppointedBefore(data.getAppointedBefore())
+                    .withCountryOfResidence(data.getCountryOfResidence())
+                    .withDateOfBirth(builder.mapDateOfBirth(sensitiveData.getDateOfBirth()))
+                    .withFormerNames(data.getFormerNameData())
+                    .withIdentification(data.getIdentificationData())
+                    .withLinks(data.getLinksData())
+                    .withName(builder.individualOfficerName(data))
+                    .withForename(data.getForename())
+                    .withSurname(data.getSurname())
+                    .withOtherForenames(data.getOtherForenames())
+                    .withNationality(data.getNationality())
+                    .withOccupation(data.getOccupation())
+                    .withOfficerRole(data.getOfficerRole())
+                    .withResignedOn(data.getResignedOn())
+                    .withEtag(data.getEtag())
+                    .withPersonNumber(data.getPersonNumber())
+                    .withIsPre1992Appointment(data.isPre1992Appointment());
         }
 
         private static void appendSelfLinkFullRecord(CompanyAppointmentFullRecordView view) {
@@ -258,6 +290,27 @@ public class CompanyAppointmentFullRecordView {
             return this;
         }
 
+        public Builder withForename(String forename) {
+
+            buildSteps.add(view -> view.forename = forename);
+
+            return this;
+        }
+
+        public Builder withSurname(String surname) {
+
+            buildSteps.add(view -> view.surname = surname);
+
+            return this;
+        }
+
+        public Builder withOtherForenames(String otherForenames) {
+
+            buildSteps.add(view -> view.otherForenames = otherForenames);
+
+            return this;
+        }
+
         public Builder withNationality(String nationality) {
 
             buildSteps.add(view -> view.nationality = nationality);
@@ -296,6 +349,13 @@ public class CompanyAppointmentFullRecordView {
         public Builder withPersonNumber(String personNumber) {
 
             buildSteps.add(view -> view.personNumber = personNumber);
+
+            return this;
+        }
+
+        public Builder withIsPre1992Appointment(Boolean isPre1992Appointment) {
+
+            buildSteps.add(view -> view.isPre1992Appointment = isPre1992Appointment);
 
             return this;
         }

--- a/src/main/java/uk/gov/companieshouse/company_appointments/model/view/CompanyAppointmentView.java
+++ b/src/main/java/uk/gov/companieshouse/company_appointments/model/view/CompanyAppointmentView.java
@@ -238,7 +238,7 @@ public class CompanyAppointmentView {
     }
 
     public void setIsPre1992Appointment(Boolean isPre1992Appointment) {
-        isPre1992Appointment = isPre1992Appointment;
+        this.isPre1992Appointment = isPre1992Appointment;
     }
 
     public static Builder builder() {

--- a/src/main/java/uk/gov/companieshouse/company_appointments/model/view/CompanyAppointmentView.java
+++ b/src/main/java/uk/gov/companieshouse/company_appointments/model/view/CompanyAppointmentView.java
@@ -58,6 +58,9 @@ public class CompanyAppointmentView {
     @JsonProperty("etag")
     private String etag;
 
+    @JsonProperty("is_pre_1992_appointment")
+    private Boolean isPre1992Appointment;
+
     public CompanyAppointmentView(
             ServiceAddressView serviceAddress, LocalDateTime appointedOn,
             String appointedBefore,
@@ -68,7 +71,8 @@ public class CompanyAppointmentView {
             LinksView links, String name, String nationality, String occupation,
             String officerRole, String responsibilities,
             ServiceAddressView principalOfficeAddress,
-            ContactDetailsView contactDetails, String etag) {
+            ContactDetailsView contactDetails, String etag,
+            Boolean isPre1992Appointment) {
         this.serviceAddress = serviceAddress;
         this.appointedOn = appointedOn;
         this.appointedBefore = appointedBefore;
@@ -86,6 +90,7 @@ public class CompanyAppointmentView {
         this.principalOfficeAddress = principalOfficeAddress;
         this.contactDetails = contactDetails;
         this.etag = etag;
+        this.isPre1992Appointment = isPre1992Appointment;
     }
 
     public CompanyAppointmentView() {}
@@ -228,6 +233,14 @@ public class CompanyAppointmentView {
         this.etag = etag;
     }
 
+    public Boolean getIsPre1992Appointment() {
+        return isPre1992Appointment;
+    }
+
+    public void setIsPre1992Appointment(Boolean isPre1992Appointment) {
+        isPre1992Appointment = isPre1992Appointment;
+    }
+
     public static Builder builder() {
         return new Builder();
     }
@@ -250,8 +263,8 @@ public class CompanyAppointmentView {
         private String responsibilities;
         private ServiceAddressView principalOfficeAddress;
         private ContactDetailsView contactDetails;
-
         private String etag;
+        private Boolean isPre1992Appointment;
 
         public Builder withServiceAddress(ServiceAddressView serviceAddress) {
             this.serviceAddress = serviceAddress;
@@ -338,10 +351,15 @@ public class CompanyAppointmentView {
             return this;
         }
 
+        public Builder withIsPre1992Appointment(Boolean isPre1992Appointment) {
+            this.isPre1992Appointment = isPre1992Appointment;
+            return this;
+        }
+
         public CompanyAppointmentView build() {
             return new CompanyAppointmentView(serviceAddress, appointedOn, appointedBefore, resignedOn, countryOfResidence, dateOfBirth,
                     formerNames, identification, links, name, nationality, occupation, officerRole, responsibilities,
-                    principalOfficeAddress, contactDetails, etag);
+                    principalOfficeAddress, contactDetails, etag, isPre1992Appointment);
         }
     }
 
@@ -366,7 +384,8 @@ public class CompanyAppointmentView {
                 Objects.equals(getResponsibilities(), that.getResponsibilities()) &&
                 Objects.equals(getPrincipalOfficeAddress(), that.getPrincipalOfficeAddress()) &&
                 Objects.equals(getContactDetails(), that.getContactDetails()) &&
-                Objects.equals(getEtag(), that.getEtag());
+                Objects.equals(getEtag(), that.getEtag()) &&
+                Objects.equals(getIsPre1992Appointment(), that.getIsPre1992Appointment());
     }
 
     @Override
@@ -375,6 +394,7 @@ public class CompanyAppointmentView {
                 .hash(getServiceAddress(), getAppointedOn(), getAppointedBefore(), getResignedOn(),
                         getCountryOfResidence(), getDateOfBirth(), getFormerNames(), getIdentification(),
                         getLinks(), getName(), getNationality(), getOccupation(), getOfficerRole(),
-                        getResponsibilities(), getPrincipalOfficeAddress(), getContactDetails(), getEtag());
+                        getResponsibilities(), getPrincipalOfficeAddress(), getContactDetails(), getEtag(),
+                        getIsPre1992Appointment());
     }
 }


### PR DESCRIPTION
This pr adds individual name fields and the is_pre_1992_appointment flag to the full record GET request. This is to make data work easier in services that call this.

Also added the is_pre_1992_appointment flag to the appointment GET and officer listing get, in order that users know whether to reference appointed_on or appointed_before.