### PR TITLE
Feature/return inactive/active count in company/officers get depending on company status

### DIFF
--- a/src/main/java/uk/gov/companieshouse/company_appointments/CompanyAppointmentService.java
+++ b/src/main/java/uk/gov/companieshouse/company_appointments/CompanyAppointmentService.java
@@ -55,13 +55,21 @@ public class CompanyAppointmentService {
         }
 
         List<CompanyAppointmentView> companyAppointmentViews = allAppointmentData.stream().map(companyAppointmentMapper::map).collect(Collectors.toList());
-        int activeCount = (int) companyAppointmentViews.stream().filter(officer -> officer.getResignedOn() == null).count();
+
+        int activeCount = 0;
+        int inactiveCount = 0;
+
+        if (allAppointmentData.get(0).getCompany_status().equals("active")){
+            activeCount = (int) companyAppointmentViews.stream().filter(officer -> officer.getResignedOn() == null).count();
+        } else {
+            inactiveCount = (int) companyAppointmentViews.stream().filter(officer -> officer.getResignedOn() == null).count();
+        }
 
         int resignedCount = (int) companyAppointmentViews.stream().filter(officer -> officer.getResignedOn() != null && officer.getResignedOn().isBefore(LocalDate.now().atStartOfDay())).count();
 
         companyAppointmentViews = addPagingAndStartIndex(companyAppointmentViews, startIndex, itemsPerPage);
 
-        return new AllCompanyAppointmentsView(companyAppointmentViews.size(), companyAppointmentViews, activeCount, 0, resignedCount);
+        return new AllCompanyAppointmentsView(companyAppointmentViews.size(), companyAppointmentViews, activeCount, inactiveCount, resignedCount);
     }
 
     private List<CompanyAppointmentView> addPagingAndStartIndex(List<CompanyAppointmentView> companyAppointmentViews, Integer startIndex, Integer itemsPerPage) throws NotFoundException {

--- a/src/main/java/uk/gov/companieshouse/company_appointments/CompanyAppointmentService.java
+++ b/src/main/java/uk/gov/companieshouse/company_appointments/CompanyAppointmentService.java
@@ -55,14 +55,14 @@ public class CompanyAppointmentService {
         }
 
         List<CompanyAppointmentView> companyAppointmentViews = allAppointmentData.stream().map(companyAppointmentMapper::map).collect(Collectors.toList());
-
+        int count = (int) companyAppointmentViews.stream().filter(officer -> officer.getResignedOn() == null).count();
         int activeCount = 0;
         int inactiveCount = 0;
-
-        if (allAppointmentData.get(0).getCompany_status().equals("active")){
-            activeCount = (int) companyAppointmentViews.stream().filter(officer -> officer.getResignedOn() == null).count();
+        String appointmentStatus = allAppointmentData.get(0).getCompanyStatus();
+        if (appointmentStatus.equals("removed") || appointmentStatus.equals("dissolved") || appointmentStatus.equals("converted-closed")){
+            inactiveCount = count;
         } else {
-            inactiveCount = (int) companyAppointmentViews.stream().filter(officer -> officer.getResignedOn() == null).count();
+            activeCount = count;
         }
 
         int resignedCount = (int) companyAppointmentViews.stream().filter(officer -> officer.getResignedOn() != null && officer.getResignedOn().isBefore(LocalDate.now().atStartOfDay())).count();

--- a/src/main/java/uk/gov/companieshouse/company_appointments/model/data/CompanyAppointmentData.java
+++ b/src/main/java/uk/gov/companieshouse/company_appointments/model/data/CompanyAppointmentData.java
@@ -2,6 +2,7 @@ package uk.gov.companieshouse.company_appointments.model.data;
 
 import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.mapping.Document;
+import org.springframework.data.mongodb.core.mapping.Field;
 
 import java.util.Objects;
 
@@ -13,12 +14,13 @@ public class CompanyAppointmentData {
 
 	private OfficerData data;
 
-	private String company_status;
+	@Field("company_status")
+	private String companyStatus;
 
-	public CompanyAppointmentData(String id, OfficerData data, String company_status) {
+	public CompanyAppointmentData(String id, OfficerData data, String companyStatus) {
 		this.id = id;
 		this.data = data;
-		this.company_status = company_status;
+		this.companyStatus = companyStatus;
 	}
 
 	public String getId() {
@@ -37,9 +39,9 @@ public class CompanyAppointmentData {
 		this.data = data;
 	}
 
-	public String getCompany_status(){return company_status;}
+	public String getCompanyStatus(){return companyStatus;}
 
-	public void setCompany_status(String company_status){this.company_status = company_status;}
+	public void setCompanyStatus(String companyStatus){this.companyStatus = companyStatus;}
 
 	@Override
 	public boolean equals(Object o) {

--- a/src/main/java/uk/gov/companieshouse/company_appointments/model/data/CompanyAppointmentData.java
+++ b/src/main/java/uk/gov/companieshouse/company_appointments/model/data/CompanyAppointmentData.java
@@ -13,9 +13,12 @@ public class CompanyAppointmentData {
 
 	private OfficerData data;
 
-	public CompanyAppointmentData(String id, OfficerData data) {
+	private String company_status;
+
+	public CompanyAppointmentData(String id, OfficerData data, String company_status) {
 		this.id = id;
 		this.data = data;
+		this.company_status = company_status;
 	}
 
 	public String getId() {
@@ -33,6 +36,10 @@ public class CompanyAppointmentData {
 	public void setData(OfficerData data) {
 		this.data = data;
 	}
+
+	public String getCompany_status(){return company_status;}
+
+	public void setCompany_status(String company_status){this.company_status = company_status;}
 
 	@Override
 	public boolean equals(Object o) {

--- a/src/test/java/uk/gov/companieshouse/company_appointments/CompanyAppointmentMapperTest.java
+++ b/src/test/java/uk/gov/companieshouse/company_appointments/CompanyAppointmentMapperTest.java
@@ -177,7 +177,7 @@ public class CompanyAppointmentMapperTest {
     }
 
     private CompanyAppointmentData companyAppointmentData(OfficerData officerData) {
-        return new CompanyAppointmentData("123", officerData);
+        return new CompanyAppointmentData("123", officerData, "active");
     }
 
     private OfficerData.Builder officerData() {

--- a/src/test/java/uk/gov/companieshouse/company_appointments/CompanyAppointmentServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/company_appointments/CompanyAppointmentServiceTest.java
@@ -279,6 +279,46 @@ class CompanyAppointmentServiceTest {
                 });
     }
 
+    @Test
+    void testFetchAppointmentForCompanyReturnInactiveOrActiveCountInCompanyOfficersGETDependingOnCompanyStatusReturnsActive() throws Exception{
+        OfficerData officer = officerData().build();
+        officer.setResignedOn(null);
+        CompanyAppointmentData officerData = new CompanyAppointmentData("1", officer, "active");
+
+        List<CompanyAppointmentData> allAppointmentData = new ArrayList<>();
+        allAppointmentData.add(officerData);
+
+        when(sortMapper.getSort(ORDER_BY)).thenReturn(SORT);
+        when(companyAppointmentRepository.readAllByCompanyNumber(COMPANY_NUMBER, SORT))
+                .thenReturn(allAppointmentData);
+
+        AllCompanyAppointmentsView result = companyAppointmentService.fetchAppointmentsForCompany(COMPANY_NUMBER, "filter", ORDER_BY, null, null);
+        System.out.println(officerData.getCompany_status());
+        assertEquals(1, result.getActiveCount());
+        assertEquals(0, result.getInactiveCount());
+
+    }
+
+    @Test
+    void testFetchAppointmentForCompanyReturnInactiveOrActiveCountInCompanyOfficersGETDependingOnCompanyStatusReturnsInactive() throws Exception{
+        OfficerData officer = officerData().build();
+        officer.setResignedOn(null);
+        CompanyAppointmentData officerData = new CompanyAppointmentData("1", officer, "removed");
+
+        List<CompanyAppointmentData> allAppointmentData = new ArrayList<>();
+        allAppointmentData.add(officerData);
+
+        when(sortMapper.getSort(ORDER_BY)).thenReturn(SORT);
+        when(companyAppointmentRepository.readAllByCompanyNumber(COMPANY_NUMBER, SORT))
+                .thenReturn(allAppointmentData);
+
+        AllCompanyAppointmentsView result = companyAppointmentService.fetchAppointmentsForCompany(COMPANY_NUMBER, "filter", ORDER_BY, null, null);
+        System.out.println(officerData.getCompany_status());
+        assertEquals(1, result.getInactiveCount());
+        assertEquals(0, result.getActiveCount());
+
+    }
+
     private OfficerData.Builder officerData() {
         return OfficerData.builder()
                 .withAppointedOn(LocalDateTime.of(2020, 8, 26, 12, 0))

--- a/src/test/java/uk/gov/companieshouse/company_appointments/CompanyAppointmentServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/company_appointments/CompanyAppointmentServiceTest.java
@@ -63,7 +63,7 @@ class CompanyAppointmentServiceTest {
 
     @Test
     void testFetchAppointmentReturnsMappedAppointmentData() throws NotFoundException {
-        CompanyAppointmentData officerData = new CompanyAppointmentData("1", officerData().build());
+        CompanyAppointmentData officerData = new CompanyAppointmentData("1", officerData().build(), "active");
 
         // given
         when(companyAppointmentRepository.readByCompanyNumberAndAppointmentID(COMPANY_NUMBER, APPOINTMENT_ID))
@@ -89,7 +89,7 @@ class CompanyAppointmentServiceTest {
 
     @Test
     void testFetchAppointmentForCompanyNumberForNotResignedReturnsMappedAppointmentData() throws Exception{
-        CompanyAppointmentData officerData = new CompanyAppointmentData("1", officerData().build());
+        CompanyAppointmentData officerData = new CompanyAppointmentData("1", officerData().build(), "active");
 
         List<CompanyAppointmentData> allAppointmentData = new ArrayList<>();
         allAppointmentData.add(officerData);
@@ -118,7 +118,7 @@ class CompanyAppointmentServiceTest {
 
     @Test
     void testFetchAppointmentForCompanyNumberReturnsMappedAppointmentData() throws Exception{
-        CompanyAppointmentData officerData = new CompanyAppointmentData("1", officerData().build());
+        CompanyAppointmentData officerData = new CompanyAppointmentData("1", officerData().build(), "active");
 
         List<CompanyAppointmentData> allAppointmentData = new ArrayList<>();
         allAppointmentData.add(officerData);
@@ -137,7 +137,7 @@ class CompanyAppointmentServiceTest {
 
     @Test
     void testFetchAppointmentForCompanyWhenNoParametersThenReturnsFirstThirtyFiveOfficers() throws Exception {
-        CompanyAppointmentData officerData = new CompanyAppointmentData("1", officerData().build());
+        CompanyAppointmentData officerData = new CompanyAppointmentData("1", officerData().build(), "active");
 
         List<CompanyAppointmentData> allAppointmentData = new ArrayList<>();
         for (int i = 0; i < 200; i++){
@@ -156,7 +156,7 @@ class CompanyAppointmentServiceTest {
 
     @Test
     void testFetchAppointmentForCompanyWhenItemsPerPageIsLargerThanOneHundredThenReturnsOneHundredBack() throws Exception {
-        CompanyAppointmentData officerData = new CompanyAppointmentData("1", officerData().build());
+        CompanyAppointmentData officerData = new CompanyAppointmentData("1", officerData().build(), "active");
 
         List<CompanyAppointmentData> allAppointmentData = new ArrayList<>();
         for (int i = 0; i < 200; i++){
@@ -177,7 +177,7 @@ class CompanyAppointmentServiceTest {
     void testFetchAppointmentForCompanyWhenItemsPerPageIsFiveThenReturnsFirstFiveOfficers() throws Exception {
         List<CompanyAppointmentData> allAppointmentData = new ArrayList<>();
         for (int i = 0; i < 200; i++){
-            CompanyAppointmentData officerData = new CompanyAppointmentData("1", officerData().build());
+            CompanyAppointmentData officerData = new CompanyAppointmentData("1", officerData().build(), "active");
             officerData.getData().setOccupation(String.valueOf(i));
             allAppointmentData.add(officerData);
         }
@@ -198,7 +198,7 @@ class CompanyAppointmentServiceTest {
 
         List<CompanyAppointmentData> allAppointmentData = new ArrayList<>();
         for (int i = 0; i < 200; i++) {
-            CompanyAppointmentData officerData = new CompanyAppointmentData("1", officerData().build());
+            CompanyAppointmentData officerData = new CompanyAppointmentData("1", officerData().build(), "active");
             officerData.getData().setOccupation(String.valueOf(i));
             allAppointmentData.add(officerData);
         }
@@ -220,7 +220,7 @@ class CompanyAppointmentServiceTest {
 
         List<CompanyAppointmentData> allAppointmentData = new ArrayList<>();
         for (int i = 0; i < 200; i++) {
-            CompanyAppointmentData officerData = new CompanyAppointmentData("1", officerData().build());
+            CompanyAppointmentData officerData = new CompanyAppointmentData("1", officerData().build(), "active");
             officerData.getData().setOccupation(String.valueOf(i));
             allAppointmentData.add(officerData);
         }
@@ -242,7 +242,7 @@ class CompanyAppointmentServiceTest {
 
         List<CompanyAppointmentData> allAppointmentData = new ArrayList<>();
         for (int i = 0; i < 200; i++) {
-            CompanyAppointmentData officerData = new CompanyAppointmentData("1", officerData().build());
+            CompanyAppointmentData officerData = new CompanyAppointmentData("1", officerData().build(), "active");
             officerData.getData().setOccupation(String.valueOf(i));
             allAppointmentData.add(officerData);
         }
@@ -264,7 +264,7 @@ class CompanyAppointmentServiceTest {
 
         List<CompanyAppointmentData> allAppointmentData = new ArrayList<>();
         for (int i = 0; i < 200; i++) {
-            CompanyAppointmentData officerData = new CompanyAppointmentData("1", officerData().build());
+            CompanyAppointmentData officerData = new CompanyAppointmentData("1", officerData().build(), "active");
             allAppointmentData.add(officerData);
         }
 

--- a/src/test/java/uk/gov/companieshouse/company_appointments/CompanyAppointmentServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/company_appointments/CompanyAppointmentServiceTest.java
@@ -293,7 +293,7 @@ class CompanyAppointmentServiceTest {
                 .thenReturn(allAppointmentData);
 
         AllCompanyAppointmentsView result = companyAppointmentService.fetchAppointmentsForCompany(COMPANY_NUMBER, "filter", ORDER_BY, null, null);
-        System.out.println(officerData.getCompany_status());
+
         assertEquals(1, result.getActiveCount());
         assertEquals(0, result.getInactiveCount());
 
@@ -313,7 +313,7 @@ class CompanyAppointmentServiceTest {
                 .thenReturn(allAppointmentData);
 
         AllCompanyAppointmentsView result = companyAppointmentService.fetchAppointmentsForCompany(COMPANY_NUMBER, "filter", ORDER_BY, null, null);
-        System.out.println(officerData.getCompany_status());
+
         assertEquals(1, result.getInactiveCount());
         assertEquals(0, result.getActiveCount());
 


### PR DESCRIPTION
Added in the new code that will ensure that it Returns the inactive/active count in company/officers GET depending on company status. New code does this a appears correctly.

Added in company_status to CompanyAppointmentData to get the status later on

Changed Tests to ensure they had the status added. and added two new tests to ensure the active and inactive count came out correctly.