### PR TITLE
DSND-1454 Fix route that conflicts with company-profile-api

### DIFF
--- a/routes.yaml
+++ b/routes.yaml
@@ -3,4 +3,4 @@ group: api
 weight: 900
 routes:
   1: ^/company/.*?/appointments/.*?$
-  2: ^/company/.*?/officers$
+  2: ^/company/(.){0,10}/officers$


### PR DESCRIPTION
* Takes in a set number of characters for company_number, rather than any length.
* Changes passed on local dev environment testing.

Resolves [DSND-1454](https://companieshouse.atlassian.net/browse/DSND-1454)

[DSND-1454]: https://companieshouse.atlassian.net/browse/DSND-1454?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ