### PR TITLE
Change officer list endpoint to flag off in the release

### DIFF
--- a/routes.yaml
+++ b/routes.yaml
@@ -3,4 +3,4 @@ group: api
 weight: 900
 routes:
   1: ^/company/.*?/appointments/.*?$
-  2: ^/company/(.){0,10}/officers$
+  2: ^/company/(.){0,10}/officers-test$

--- a/src/it/java/uk/gov/companieshouse/company_appointments/CompanyAppointmentControllerITest.java
+++ b/src/it/java/uk/gov/companieshouse/company_appointments/CompanyAppointmentControllerITest.java
@@ -97,7 +97,7 @@ public class CompanyAppointmentControllerITest {
     @Test
     void testReturn200OKIfAllOfficersAreFound() throws Exception {
         //when
-        ResultActions result = mockMvc.perform(get("/company/{company_number}/officers", "12345678")
+        ResultActions result = mockMvc.perform(get("/company/{company_number}/officers-test", "12345678")
                 .header("ERIC-Identity", "123")
                 .header("ERIC-Identity-Type", "key")
                 .contentType(MediaType.APPLICATION_JSON)
@@ -115,7 +115,7 @@ public class CompanyAppointmentControllerITest {
     void testReturn404IfOfficersForCompanyIsNotFound() throws Exception {
         // when
         ResultActions result = mockMvc
-                .perform(get("/company/{company_number}/officers", "87654321")
+                .perform(get("/company/{company_number}/officers-test", "87654321")
                         .header("ERIC-Identity", "123").header("ERIC-Identity-Type", "oauth2")
                         .contentType(MediaType.APPLICATION_JSON).accept(MediaType.APPLICATION_JSON));
 
@@ -126,7 +126,7 @@ public class CompanyAppointmentControllerITest {
     @Test
     void testReturn200OKIfAllOfficersAreFoundWithFilter() throws Exception {
         //when
-        ResultActions result = mockMvc.perform(get("/company/{company_number}/officers?filter=active", "12345678")
+        ResultActions result = mockMvc.perform(get("/company/{company_number}/officers-test?filter=active", "12345678")
                 .header("ERIC-Identity", "123")
                 .header("ERIC-Identity-Type", "key")
                 .contentType(MediaType.APPLICATION_JSON)
@@ -142,7 +142,7 @@ public class CompanyAppointmentControllerITest {
 
     @Test
     void testReturn200OkWithOfficersOrderedByAppointedOn() throws Exception {
-        ResultActions result = mockMvc.perform(get("/company/{company_number}/officers?order_by=appointed_on", "12345678")
+        ResultActions result = mockMvc.perform(get("/company/{company_number}/officers-test?order_by=appointed_on", "12345678")
                 .header("ERIC-Identity", "123")
                 .header("ERIC-Identity-Type", "key")
                 .contentType(MediaType.APPLICATION_JSON)
@@ -155,7 +155,7 @@ public class CompanyAppointmentControllerITest {
 
     @Test
     void testReturn200OkWithOfficersOrderedBySurname() throws Exception {
-        ResultActions result = mockMvc.perform(get("/company/{company_number}/officers?order_by=surname", "12345678")
+        ResultActions result = mockMvc.perform(get("/company/{company_number}/officers-test?order_by=surname", "12345678")
                 .header("ERIC-Identity", "123")
                 .header("ERIC-Identity-Type", "key")
                 .contentType(MediaType.APPLICATION_JSON)
@@ -168,7 +168,7 @@ public class CompanyAppointmentControllerITest {
 
     @Test
     void testReturn400BadRequestWithIncorrectOrderBy() throws Exception {
-        ResultActions result = mockMvc.perform(get("/company/{company_number}/officers?order_by=invalid", "12345678")
+        ResultActions result = mockMvc.perform(get("/company/{company_number}/officers-test?order_by=invalid", "12345678")
                 .header("ERIC-Identity", "123")
                 .header("ERIC-Identity-Type", "key")
                 .contentType(MediaType.APPLICATION_JSON)

--- a/src/main/java/uk/gov/companieshouse/company_appointments/CompanyAppointmentController.java
+++ b/src/main/java/uk/gov/companieshouse/company_appointments/CompanyAppointmentController.java
@@ -36,7 +36,7 @@ public class CompanyAppointmentController {
         }
     }
 
-    @GetMapping(path = "/officers")
+    @GetMapping(path = "/officers-test")
     public ResponseEntity<AllCompanyAppointmentsView> fetchAppointmentsForCompany(
             @PathVariable("company_number") String companyNumber,
             @RequestParam(required = false) String filter,


### PR DESCRIPTION
This pr changes the uri for the officer listing endpoint to a test value. This is so when it is released it does not overwrite the current perl url, due to the endpoint not being finished.