### PR TITLE
DSND-1447 Implement officer appointment list sorting

### DIFF
--- a/docs/mongo_sort_query.txt
+++ b/docs/mongo_sort_query.txt
@@ -1,0 +1,48 @@
+db.getCollection("appointments").aggregate([
+
+    {
+        $match: {'officer_id': '_c2mqo8zkGw2VgK4wETDargF8x4'}
+    },
+    {
+        $addFields: {
+            'sort_active': { $ifNull: ['$data.appointed_on', '$data.appointed_before']}
+        }
+    },
+    {
+        $facet: {
+            'active': [
+            {
+                $match: {'data.resigned_on': {$exists: false}}
+            },
+            {
+                $sort: {
+                    'sort_active': -1
+                }
+            }
+            ],
+            'resigned': [
+            {
+                $match: {'data.resigned_on': {$exists: true}}
+            },
+            {
+                $sort: {
+                    'data.resigned_on': -1
+                }
+            }
+            ],
+            'total_results': [{ '$count': 'count' }]
+            }
+        },
+    {
+        $unwind: {
+            'path': '$total_results',
+            'preserveNullAndEmptyArrays': true
+        }
+    },
+    {
+        $project: {
+            'total_results': { '$ifNull': ['$total_results.count', NumberInt(0)] },
+            'officer_appointments':  {$concatArrays: ['$active', '$resigned']}
+        }
+    }
+])

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>uk.gov.companieshouse</groupId>
         <artifactId>companies-house-parent</artifactId>
-        <version>1.3.0</version>
+        <version>1.3.1</version>
         <relativePath />
     </parent>
     <artifactId>company-appointments.api.ch.gov.uk</artifactId>
@@ -16,7 +16,7 @@
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
-        <spring-boot-dependencies.version>2.5.6</spring-boot-dependencies.version>
+        <spring-boot-dependencies.version>2.7.9</spring-boot-dependencies.version>
         <testcontainers.version>1.16.2</testcontainers.version>
         <commons-io.version>2.6</commons-io.version>
         <commons-lang.version>2.6</commons-lang.version>
@@ -33,7 +33,6 @@
         <io-cucumber.version>7.2.3</io-cucumber.version>
 
         <api-helper-java-library.version>1.4.5</api-helper-java-library.version>
-        <log4j.version>2.16.0</log4j.version>
 
         <!--sonar configuration-->
         <sonar.coverage.jacoco.xmlReportPaths>${project.basedir}/target/site/jacoco/jacoco.xml,
@@ -44,13 +43,6 @@
 
     <dependencyManagement>
         <dependencies>
-            <dependency>
-                <groupId>org.apache.logging.log4j</groupId>
-                <artifactId>log4j-bom</artifactId>
-                <version>${log4j.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
             <dependency>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-dependencies</artifactId>
@@ -178,7 +170,7 @@
             <plugin>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
-                <version>2.5.6</version>
+                <version>${spring-boot-dependencies.version}</version>
                 <executions>
                     <execution>
                         <goals>

--- a/src/it/java/uk/gov/companieshouse/company_appointments/CucumberFeaturesRunnerITest.java
+++ b/src/it/java/uk/gov/companieshouse/company_appointments/CucumberFeaturesRunnerITest.java
@@ -7,7 +7,7 @@ import org.junit.runner.RunWith;
 import uk.gov.companieshouse.company_appointments.config.AbstractIntegrationTest;
 
 @RunWith(Cucumber.class)
-@CucumberOptions(features = "src/itest/resources/features",
+@CucumberOptions(features = "src/it/resources/features",
         plugin = {"pretty", "json:target/cucumber-report.json"})
 @CucumberContextConfiguration
 public class CucumberFeaturesRunnerITest extends AbstractIntegrationTest {

--- a/src/it/java/uk/gov/companieshouse/company_appointments/officerappointments/OfficerAppointmentsRepositoryITest.java
+++ b/src/it/java/uk/gov/companieshouse/company_appointments/officerappointments/OfficerAppointmentsRepositoryITest.java
@@ -49,10 +49,6 @@ class OfficerAppointmentsRepositoryITest {
         System.setProperty("company-metrics-api.endpoint", "localhost");
     }
 
-    /**
-     * Correct sorting: A list of, first, active officers sorted by appointed_on date in descending order (or appointed_before
-     * if appointed_on is null), followed by resigned officers sorted by resigned_on date in descending order.
-     */
     @DisplayName("Repository returns officer appointments aggregate")
     @Test
     void findOfficerAppointments() {

--- a/src/it/java/uk/gov/companieshouse/company_appointments/officerappointments/OfficerAppointmentsRepositoryITest.java
+++ b/src/it/java/uk/gov/companieshouse/company_appointments/officerappointments/OfficerAppointmentsRepositoryITest.java
@@ -43,9 +43,16 @@ class OfficerAppointmentsRepositoryITest {
         mongoTemplate.insert(Document.parse(IOUtils.resourceToString("/appointment-data.json", StandardCharsets.UTF_8)), "appointments");
         mongoTemplate.insert(Document.parse(IOUtils.resourceToString("/appointment-data2.json", StandardCharsets.UTF_8)), "appointments");
         mongoTemplate.insert(Document.parse(IOUtils.resourceToString("/appointment-data3.json", StandardCharsets.UTF_8)), "appointments");
+        mongoTemplate.insert(Document.parse(IOUtils.resourceToString("/appointment-data4.json", StandardCharsets.UTF_8)), "appointments");
+        mongoTemplate.insert(Document.parse(IOUtils.resourceToString("/appointment-data5.json", StandardCharsets.UTF_8)), "appointments");
+        mongoTemplate.insert(Document.parse(IOUtils.resourceToString("/appointment-data6.json", StandardCharsets.UTF_8)), "appointments");
         System.setProperty("company-metrics-api.endpoint", "localhost");
     }
 
+    /**
+     * Correct sorting: A list of, first, active officers sorted by appointed_on date in descending order (or appointed_before
+     * if appointed_on is null), followed by resigned officers sorted by resigned_on date in descending order.
+     */
     @DisplayName("Repository returns officer appointments aggregate")
     @Test
     void findOfficerAppointments() {
@@ -55,9 +62,23 @@ class OfficerAppointmentsRepositoryITest {
         OfficerAppointmentsAggregate officerAppointmentsAggregate = repository.findOfficerAppointments(OFFICER_ID);
 
         // then
-        assertEquals(2, officerAppointmentsAggregate.getTotalResults());
+        assertEquals(5, officerAppointmentsAggregate.getTotalResults());
         assertEquals(OFFICER_ID, officerAppointmentsAggregate.getOfficerAppointments().get(0).getOfficerId());
         assertEquals(OFFICER_ID, officerAppointmentsAggregate.getOfficerAppointments().get(1).getOfficerId());
+        assertEquals(OFFICER_ID, officerAppointmentsAggregate.getOfficerAppointments().get(2).getOfficerId());
+        assertEquals(OFFICER_ID, officerAppointmentsAggregate.getOfficerAppointments().get(3).getOfficerId());
+        assertEquals(OFFICER_ID, officerAppointmentsAggregate.getOfficerAppointments().get(4).getOfficerId());
+
+        assertEquals("active_1",
+                officerAppointmentsAggregate.getOfficerAppointments().get(0).getId());
+        assertEquals("active_2",
+                officerAppointmentsAggregate.getOfficerAppointments().get(1).getId());
+        assertEquals("active_3",
+                officerAppointmentsAggregate.getOfficerAppointments().get(2).getId());
+        assertEquals("resigned_1",
+                officerAppointmentsAggregate.getOfficerAppointments().get(3).getId());
+        assertEquals("resigned_2",
+                officerAppointmentsAggregate.getOfficerAppointments().get(4).getId());
     }
 
     @DisplayName("Repository returns no appointments when there are no matches")

--- a/src/it/java/uk/gov/companieshouse/company_appointments/tests/CompanyAppointmentControllerITest.java
+++ b/src/it/java/uk/gov/companieshouse/company_appointments/tests/CompanyAppointmentControllerITest.java
@@ -53,7 +53,7 @@ class CompanyAppointmentControllerITest {
     @Test
     void testReturn200OKIfOfficerIsFound() throws Exception {
         //when
-        ResultActions result = mockMvc.perform(get("/company/{company_number}/appointments/{appointment_id}", "12345678", "7IjxamNGLlqtIingmTZJJ42Hw9Q")
+        ResultActions result = mockMvc.perform(get("/company/{company_number}/appointments/{appointment_id}", "12345678", "resigned_1")
                 .header("ERIC-Identity", "123")
                 .header("ERIC-Identity-Type", "key")
                 .contentType(MediaType.APPLICATION_JSON)

--- a/src/it/java/uk/gov/companieshouse/company_appointments/tests/CompanyAppointmentControllerITest.java
+++ b/src/it/java/uk/gov/companieshouse/company_appointments/tests/CompanyAppointmentControllerITest.java
@@ -53,7 +53,7 @@ class CompanyAppointmentControllerITest {
     @Test
     void testReturn200OKIfOfficerIsFound() throws Exception {
         //when
-        ResultActions result = mockMvc.perform(get("/company/{company_number}/appointments/{appointment_id}", "12345678", "resigned_1")
+        ResultActions result = mockMvc.perform(get("/company/{company_number}/appointments/{appointment_id}", "12345678", "active_1")
                 .header("ERIC-Identity", "123")
                 .header("ERIC-Identity-Type", "key")
                 .contentType(MediaType.APPLICATION_JSON)
@@ -63,7 +63,6 @@ class CompanyAppointmentControllerITest {
         result.andExpect(status().isOk())
                 .andExpect(jsonPath("$.name", is("NOSURNAME, Noname1 Noname2")))
                 .andExpect(jsonPath("$.appointed_on", is("2020-08-26")))
-                .andExpect(jsonPath("$.resigned_on", is("2020-08-26")))
                 .andExpect(jsonPath("$.date_of_birth", not(contains("day"))))
                 .andExpect(jsonPath("$.date_of_birth.year", is(1980)))
                 .andExpect(jsonPath("$.date_of_birth.month", is(1)));
@@ -133,7 +132,7 @@ class CompanyAppointmentControllerITest {
 
         //then
         result.andExpect(status().isOk())
-                .andExpect(jsonPath("$.items.[0].name", is("Doe, John Forename")))
+                .andExpect(jsonPath("$.items.[0].name", is("NOSURNAME, Noname1 Noname2")))
                 .andExpect(jsonPath("$.active_count", is(1)))
                 .andExpect(jsonPath("$.resigned_count", is(0)))
                 .andExpect(jsonPath("$.total_results", is(1)));

--- a/src/main/java/uk/gov/companieshouse/company_appointments/officerappointments/OfficerAppointmentsRepository.java
+++ b/src/main/java/uk/gov/companieshouse/company_appointments/officerappointments/OfficerAppointmentsRepository.java
@@ -5,37 +5,41 @@ import org.springframework.data.mongodb.repository.MongoRepository;
 import org.springframework.stereotype.Repository;
 import uk.gov.companieshouse.company_appointments.model.data.CompanyAppointmentData;
 
+/**
+ * Correct sorting: A list of, first, active officers sorted by appointed_on date in descending order (or appointed_before
+ * if appointed_on is null), followed by resigned officers sorted by resigned_on date in descending order.
+ */
 @Repository
 public interface OfficerAppointmentsRepository extends MongoRepository<CompanyAppointmentData, String> {
 
     @Aggregation(pipeline = {
             "{ '$match': { 'officer_id': ?0 } }",
             "{ $addFields: {"
-                    + "'sort_active': { $ifNull: ['$data.appointed_on', '$data.appointed_before']}"
-                    + "}"
-        + "}",
+        +           "'sort_active': { $ifNull: ['$data.appointed_on', '$data.appointed_before']}"
+        +                 "}"
+        +   "}",
             "{ '$facet': {"
-                    + "'active': ["
-                        + "{ $match: {'data.resigned_on': {$exists: false}} },"
-                        + "{ $sort:  {'sort_active': -1} }"
-                    + "],"
-                    + "'resigned': ["
-                        + "{ $match: {'data.resigned_on': {$exists: true}} },"
-                        + "{ $sort:  {'data.resigned_on': -1} }"
-                    + "],"
-                    + "'total_results': [{ '$count': 'count' }]"
-                    + "}"
-        + "}",
+        +           "'active': ["
+        +               "{ $match: {'data.resigned_on': {$exists: false}} },"
+        +               "{ $sort:  {'sort_active': -1} }"
+        +                   "],"
+        +           "'resigned': ["
+        +               "{ $match: {'data.resigned_on': {$exists: true}} },"
+        +               "{ $sort:  {'data.resigned_on': -1} }"
+        +                       "],"
+        +           "'total_results': [{ '$count': 'count' }]"
+        +               "}"
+        +   "}",
             "{ '$unwind': {"
-                    + "'path': '$total_results',"
-                    + "'preserveNullAndEmptyArrays': true"
-                    + "}"
-        + "}",
+        +           "'path': '$total_results',"
+        +           "'preserveNullAndEmptyArrays': true"
+        +                 "}"
+        +   "}",
             "{ '$project': {"
-                    + "'total_results': { '$ifNull': ['$total_results.count', NumberInt(0)] },"
-                    + "'officer_appointments': {$concatArrays: ['$active', '$resigned']}"
-                    + "}"
-        + "}"
+        +           "'total_results': { '$ifNull': ['$total_results.count', NumberInt(0)] },"
+        +           "'officer_appointments': {$concatArrays: ['$active', '$resigned']}"
+        + "                }"
+        +   "}"
     })
     OfficerAppointmentsAggregate findOfficerAppointments(String officerId);
 }

--- a/src/test/resources/appointment-data.json
+++ b/src/test/resources/appointment-data.json
@@ -1,6 +1,6 @@
 {
-  "_id" : "resigned_1",
-  "appointment_id" : "resigned_1",
+  "_id" : "active_1",
+  "appointment_id" : "active_1",
   "company_name" : "TEST COMPANY LIMITED",
   "company_number" : "12345678",
   "company_status" : "active",
@@ -22,7 +22,6 @@
     "nationality" : "British",
     "forename" : "Noname1",
     "surname" : "NOSURNAME",
-    "resigned_on" : ISODate("2020-08-26T13:00:00.000Z"),
     "company_number" : "12345678",
     "updated_at" : ISODate("2020-08-26T13:00:00.000Z"),
     "other_forenames" : "Noname2",

--- a/src/test/resources/appointment-data2.json
+++ b/src/test/resources/appointment-data2.json
@@ -1,6 +1,6 @@
 {
-  "_id" : "abc123",
-  "appointment_id" : "abc123",
+  "_id" : "active_1",
+  "appointment_id" : "active_1",
   "company_name" : "TEST COMPANY LIMITED",
   "company_number" : "12345678",
   "company_status" : "active",

--- a/src/test/resources/appointment-data2.json
+++ b/src/test/resources/appointment-data2.json
@@ -1,6 +1,6 @@
 {
-  "_id" : "active_1",
-  "appointment_id" : "active_1",
+  "_id" : "resigned_1",
+  "appointment_id" : "resigned_1",
   "company_name" : "TEST COMPANY LIMITED",
   "company_number" : "12345678",
   "company_status" : "active",
@@ -25,6 +25,7 @@
     "company_number" : "12345678",
     "updated_at" : ISODate("2020-08-26T13:00:00.000Z"),
     "other_forenames" : "Forename",
+    "resigned_on": ISODate("2020-08-26T12:00:00.000Z"),
     "appointed_on" : ISODate("2019-08-26T12:00:00.000Z"),
     "etag" : "8f58a770d34f982a1b2a5a29fcde12528e82f903",
     "occupation" : "Company Director",

--- a/src/test/resources/appointment-data4.json
+++ b/src/test/resources/appointment-data4.json
@@ -1,6 +1,6 @@
 {
-  "_id" : "resigned_1",
-  "appointment_id" : "resigned_1",
+  "_id" : "resigned_2",
+  "appointment_id" : "resigned_2",
   "company_name" : "TEST COMPANY LIMITED",
   "company_number" : "12345678",
   "company_status" : "active",
@@ -22,11 +22,11 @@
     "nationality" : "British",
     "forename" : "Noname1",
     "surname" : "NOSURNAME",
-    "resigned_on" : ISODate("2020-08-26T13:00:00.000Z"),
+    "resigned_on" : ISODate("2019-08-26T13:00:00.000Z"),
     "company_number" : "12345678",
     "updated_at" : ISODate("2020-08-26T13:00:00.000Z"),
     "other_forenames" : "Noname2",
-    "appointed_on" : ISODate("2020-08-26T12:00:00.000Z"),
+    "appointed_on" : ISODate("2017-08-26T12:00:00.000Z"),
     "etag" : "8f58a770d34f982a1b2a5a29fcde12528e82f903",
     "occupation" : "Company Director",
     "service_address" : {

--- a/src/test/resources/appointment-data5.json
+++ b/src/test/resources/appointment-data5.json
@@ -1,6 +1,6 @@
 {
-  "_id" : "resigned_1",
-  "appointment_id" : "resigned_1",
+  "_id" : "active_2",
+  "appointment_id" : "active_2",
   "company_name" : "TEST COMPANY LIMITED",
   "company_number" : "12345678",
   "company_status" : "active",
@@ -22,11 +22,10 @@
     "nationality" : "British",
     "forename" : "Noname1",
     "surname" : "NOSURNAME",
-    "resigned_on" : ISODate("2020-08-26T13:00:00.000Z"),
     "company_number" : "12345678",
     "updated_at" : ISODate("2020-08-26T13:00:00.000Z"),
     "other_forenames" : "Noname2",
-    "appointed_on" : ISODate("2020-08-26T12:00:00.000Z"),
+    "appointed_on" : ISODate("2017-08-26T12:00:00.000Z"),
     "etag" : "8f58a770d34f982a1b2a5a29fcde12528e82f903",
     "occupation" : "Company Director",
     "service_address" : {

--- a/src/test/resources/appointment-data6.json
+++ b/src/test/resources/appointment-data6.json
@@ -1,6 +1,6 @@
 {
-  "_id" : "resigned_1",
-  "appointment_id" : "resigned_1",
+  "_id" : "active_3",
+  "appointment_id" : "active_3",
   "company_name" : "TEST COMPANY LIMITED",
   "company_number" : "12345678",
   "company_status" : "active",
@@ -22,11 +22,10 @@
     "nationality" : "British",
     "forename" : "Noname1",
     "surname" : "NOSURNAME",
-    "resigned_on" : ISODate("2020-08-26T13:00:00.000Z"),
     "company_number" : "12345678",
     "updated_at" : ISODate("2020-08-26T13:00:00.000Z"),
     "other_forenames" : "Noname2",
-    "appointed_on" : ISODate("2020-08-26T12:00:00.000Z"),
+    "appointed_before" : ISODate("2016-08-26T12:00:00.000Z"),
     "etag" : "8f58a770d34f982a1b2a5a29fcde12528e82f903",
     "occupation" : "Company Director",
     "service_address" : {


### PR DESCRIPTION
* Mongo aggregation now sorts by appointed_on/appointed_before (if the former is null) for active roles and resigned_on or resigned roles. Active roles are listed first. All sorted in descending order.
* Updated the integration test to test the mongo aggregation. 
* Updated the id of a test appointments data json files to make the repository itest easier to organise and read. This broke one other itest - simple fix was to update the broken itest with the new id string - see `CompanyAppointmentControllerItest`.
* The reason for testing five documents in the repository itest was because I needed at least two valid active and two valid resigned roles to test plus a third valid active role that had an `appointed_before` field and did not have an `appointed_on` field as per the acceptance criteria. This was to ensure the sorting was working in the way we want.
* Tested locally both in mongo and on chs-local.

[DSND-1447](https://companieshouse.atlassian.net/browse/DSND-1447)

[DSND-1447]: https://companieshouse.atlassian.net/browse/DSND-1447?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ