### PR TITLE
DSND-1449 Implement paging for officer appointments list

### DIFF
--- a/docs/mongo_sort_with_filter_aggregation.txt
+++ b/docs/mongo_sort_with_filter_aggregation.txt
@@ -6,8 +6,8 @@ db.getCollection("appointments").aggregate([
                 { 'officer_id': '_c2mqo8zkGw2VgK4wETDargF8x4' },
                 {
                     $or: [
-                        { 'data.resigned_on': { $not: { $exists: false } } },
-                        { 'data.resigned_on': { $exists: false } }
+                        { 'data.resigned_on': { $exists: false } },
+                        { 'data.resigned_on': { $not: { $exists: false } } }
                     ]
                 }
 
@@ -53,7 +53,7 @@ db.getCollection("appointments").aggregate([
     {
         $project: {
             'total_results': { '$ifNull': ['$total_results.count', NumberInt(0)] },
-            'officer_appointments': { $concatArrays: ['$active', '$resigned'] }
+            'officer_appointments': { $slice: [{ $concatArrays: ['$active', '$resigned']},  0, 35] }
         }
     }
 ])

--- a/src/main/java/uk/gov/companieshouse/company_appointments/officerappointments/OfficerAppointmentsMapper.java
+++ b/src/main/java/uk/gov/companieshouse/company_appointments/officerappointments/OfficerAppointmentsMapper.java
@@ -11,8 +11,6 @@ import uk.gov.companieshouse.api.officer.OfficerLinkTypes;
 @Component
 public class OfficerAppointmentsMapper {
 
-    private static final int ITEMS_PER_PAGE = 35;
-    private static final int START_INDEX = 0;
     private final ItemsMapper itemsMapper;
     private final NameMapper nameMapper;
     private final DateOfBirthMapper dobMapper;
@@ -35,7 +33,7 @@ public class OfficerAppointmentsMapper {
      * @param aggregate The count and appointments list pairing returned by the repository.
      * @return The optional OfficerAppointmentsApi for the response body.
      */
-    protected Optional<AppointmentList> mapOfficerAppointments(OfficerAppointmentsAggregate aggregate) {
+    protected Optional<AppointmentList> mapOfficerAppointments(Integer startIndex, Integer itemsPerPage, OfficerAppointmentsAggregate aggregate) {
         return aggregate.getOfficerAppointments().stream()
                 .findFirst()
                 .flatMap(firstAppointment -> ofNullable(firstAppointment.getData())
@@ -43,13 +41,13 @@ public class OfficerAppointmentsMapper {
                                 .dateOfBirth(dobMapper.map(data.getDateOfBirth(), data.getOfficerRole()))
                                 .etag(data.getEtag())
                                 .isCorporateOfficer(roleMapper.mapIsCorporateOfficer(data.getOfficerRole()))
-                                .itemsPerPage(ITEMS_PER_PAGE)
+                                .itemsPerPage(itemsPerPage)
                                 .kind(KindEnum.PERSONAL_APPOINTMENT)
                                 .links(new OfficerLinkTypes().self(
                                         String.format("/officers/%s/appointments", firstAppointment.getOfficerId())))
                                 .items(itemsMapper.map(aggregate.getOfficerAppointments()))
                                 .name(nameMapper.map(data))
-                                .startIndex(START_INDEX)
+                                .startIndex(startIndex)
                                 .totalResults(aggregate.getTotalResults())
                         ));
     }

--- a/src/main/java/uk/gov/companieshouse/company_appointments/officerappointments/OfficerAppointmentsRepository.java
+++ b/src/main/java/uk/gov/companieshouse/company_appointments/officerappointments/OfficerAppointmentsRepository.java
@@ -22,15 +22,15 @@ public interface OfficerAppointmentsRepository extends MongoRepository<CompanyAp
     @Aggregation(pipeline = {
             "{ $match: { "
         +           "$and: [ "
-        +                "{'officer_id': ?0 }, "
+        +                "{'officer_id': ?0 },"
         +                "{ $or: [ "
-        +                    "{ 'data.resigned_on': { $exists: false } }, "
-        +                    "{ 'data.resigned_on': { $not: { $exists: ?1 } } } "
-        +                   "] "
+        +                    "{ 'data.resigned_on': { $exists: false } },"
+        +                    "{ 'data.resigned_on': { $not: { $exists: ?1 } } }"
+        +                   "]"
         +                "}"
-        +             "] "
-        +         "}"
-        +     "}",
+        +           "]"
+        +       "}"
+        +   "}",
             "{"
         +       "$addFields: {"
         +           "'__sort_active__': { $ifNull: ['$data.appointed_on', { $toDate: '$data.appointed_before' } ] }"
@@ -38,26 +38,26 @@ public interface OfficerAppointmentsRepository extends MongoRepository<CompanyAp
         +   "}",
             "{ $facet: {"
         +           "'active': ["
-        +               "{ $match: {'data.resigned_on': {$exists: false}} },"
+        +               "{ $match: {'data.resigned_on': {$exists: false} } },"
         +               "{ $sort:  {'__sort_active__': -1 } }"
-        +                   "],"
+        +               "],"
         +           "'resigned': ["
         +               "{ $match: {'data.resigned_on': {$exists: true} } },"
         +               "{ $sort:  {'data.resigned_on': -1} }"
-        +                       "],"
+        +               "],"
         +           "'total_results': [{ '$count': 'count' }]"
-        +               "}"
+        +       "}"
         +   "}",
             "{ $unwind: {"
         +           "'path': '$total_results',"
         +           "'preserveNullAndEmptyArrays': true"
-        +                 "}"
+        +       "}"
         +   "}",
             "{ $project: {"
         +           "'total_results': { '$ifNull': ['$total_results.count', NumberInt(0)] },"
-        +           "'officer_appointments': {$concatArrays: ['$active', '$resigned']}"
-        + "                }"
+        +           "'officer_appointments': { $slice: [{ $concatArrays: ['$active', '$resigned'] },  ?2, ?3] }"
+        +       "}"
         +   "}"
     })
-    OfficerAppointmentsAggregate findOfficerAppointments(String officerId, boolean filter);
+    OfficerAppointmentsAggregate findOfficerAppointments(String officerId, boolean filter, int startIndex, int pageSize);
 }

--- a/src/main/java/uk/gov/companieshouse/company_appointments/officerappointments/OfficerAppointmentsService.java
+++ b/src/main/java/uk/gov/companieshouse/company_appointments/officerappointments/OfficerAppointmentsService.java
@@ -19,10 +19,21 @@ public class OfficerAppointmentsService {
     }
 
     protected Optional<AppointmentList> getOfficerAppointments(OfficerAppointmentsRequest request) {
-        boolean filter = "active".equals(request.getFilter());
-        int startIndex = request.getStartIndex() == null ? START_INDEX : request.getStartIndex();
-        int itemsPerPage = request.getItemsPerPage() == null ? ITEMS_PER_PAGE : request.getItemsPerPage();
+        int startIndex;
+        if (request.getStartIndex() == null) {
+            startIndex = START_INDEX;
+        } else {
+            startIndex = Math.abs(request.getStartIndex());
+        }
 
+        int itemsPerPage;
+        if (request.getItemsPerPage() == null || request.getItemsPerPage() == 0) {
+            itemsPerPage = ITEMS_PER_PAGE;
+        } else {
+            itemsPerPage = Math.abs(request.getItemsPerPage());
+        }
+
+        boolean filter = "active".equals(request.getFilter());
         return mapper.mapOfficerAppointments(startIndex, itemsPerPage,
                 repository.findOfficerAppointments(request.getOfficerId(), filter, startIndex, itemsPerPage));
     }

--- a/src/main/java/uk/gov/companieshouse/company_appointments/officerappointments/OfficerAppointmentsService.java
+++ b/src/main/java/uk/gov/companieshouse/company_appointments/officerappointments/OfficerAppointmentsService.java
@@ -7,6 +7,9 @@ import uk.gov.companieshouse.api.officer.AppointmentList;
 @Service
 public class OfficerAppointmentsService {
 
+    private static final int ITEMS_PER_PAGE = 35;
+    private static final int START_INDEX = 0;
+
     private final OfficerAppointmentsRepository repository;
     private final OfficerAppointmentsMapper mapper;
 
@@ -17,6 +20,10 @@ public class OfficerAppointmentsService {
 
     protected Optional<AppointmentList> getOfficerAppointments(OfficerAppointmentsRequest request) {
         boolean filter = "active".equals(request.getFilter());
-        return mapper.mapOfficerAppointments(repository.findOfficerAppointments(request.getOfficerId(), filter));
+        int startIndex = request.getStartIndex() == null ? START_INDEX : request.getStartIndex();
+        int itemsPerPage = request.getItemsPerPage() == null ? ITEMS_PER_PAGE : request.getItemsPerPage();
+
+        return mapper.mapOfficerAppointments(startIndex, itemsPerPage,
+                repository.findOfficerAppointments(request.getOfficerId(), filter, startIndex, itemsPerPage));
     }
 }

--- a/src/test/java/uk/gov/companieshouse/company_appointments/officerappointments/OfficerAppointmentsMapperTest.java
+++ b/src/test/java/uk/gov/companieshouse/company_appointments/officerappointments/OfficerAppointmentsMapperTest.java
@@ -28,6 +28,9 @@ import uk.gov.companieshouse.company_appointments.model.data.OfficerData;
 @ExtendWith(MockitoExtension.class)
 class OfficerAppointmentsMapperTest {
 
+    private static final int START_INDEX = 0;
+    private static final int ITEMS_PER_PAGE = 35;
+
     @InjectMocks
     private OfficerAppointmentsMapper mapper;
     @Mock
@@ -53,10 +56,10 @@ class OfficerAppointmentsMapperTest {
         when(dobMapper.map(any(), anyString())).thenReturn(dateOfBirth);
         when(roleMapper.mapIsCorporateOfficer(anyString())).thenReturn(false);
         OfficerAppointmentsAggregate officerAppointmentsAggregate = getOfficerAppointmentsAggregate(role);
-        AppointmentList expected = getExpectedOfficerAppointments(false, OfficerAppointmentSummary.OfficerRoleEnum.DIRECTOR);
+        AppointmentList expected = getExpectedOfficerAppointments(false);
 
         // when
-        Optional<AppointmentList> actual = mapper.mapOfficerAppointments(officerAppointmentsAggregate);
+        Optional<AppointmentList> actual = mapper.mapOfficerAppointments(START_INDEX, ITEMS_PER_PAGE, officerAppointmentsAggregate);
 
         // then
         assertTrue(actual.isPresent());
@@ -78,9 +81,9 @@ class OfficerAppointmentsMapperTest {
         when(roleMapper.mapIsCorporateOfficer(anyString())).thenReturn(true);
         OfficerAppointmentsAggregate officerAppointmentsAggregate = getOfficerAppointmentsAggregate(role);
 
-        AppointmentList expected = getExpectedOfficerAppointments(true, OfficerAppointmentSummary.OfficerRoleEnum.CORPORATE_MANAGING_OFFICER);
+        AppointmentList expected = getExpectedOfficerAppointments(true);
         // when
-        Optional<AppointmentList> actual = mapper.mapOfficerAppointments(officerAppointmentsAggregate);
+        Optional<AppointmentList> actual = mapper.mapOfficerAppointments(START_INDEX, ITEMS_PER_PAGE, officerAppointmentsAggregate);
 
         // then
         assertTrue(actual.isPresent());
@@ -98,7 +101,7 @@ class OfficerAppointmentsMapperTest {
         OfficerAppointmentsAggregate aggregate = new OfficerAppointmentsAggregate();
 
         // when
-        Optional<AppointmentList> actual = mapper.mapOfficerAppointments(aggregate);
+        Optional<AppointmentList> actual = mapper.mapOfficerAppointments(START_INDEX, ITEMS_PER_PAGE, aggregate);
 
         // then
         assertFalse(actual.isPresent());
@@ -116,7 +119,7 @@ class OfficerAppointmentsMapperTest {
         aggregate.getOfficerAppointments().add(new CompanyAppointmentData());
 
         // when
-        Optional<AppointmentList> actual = mapper.mapOfficerAppointments(aggregate);
+        Optional<AppointmentList> actual = mapper.mapOfficerAppointments(START_INDEX, ITEMS_PER_PAGE, aggregate);
 
         // then
         assertFalse(actual.isPresent());
@@ -154,17 +157,17 @@ class OfficerAppointmentsMapperTest {
                 .build();
     }
 
-    private AppointmentList getExpectedOfficerAppointments(boolean isCorporateOfficer, OfficerAppointmentSummary.OfficerRoleEnum role) {
+    private AppointmentList getExpectedOfficerAppointments(boolean isCorporateOfficer) {
         return new AppointmentList()
                 .dateOfBirth(dateOfBirth)
                 .etag("etag")
                 .isCorporateOfficer(isCorporateOfficer)
-                .itemsPerPage(35)
+                .itemsPerPage(ITEMS_PER_PAGE)
                 .kind(AppointmentList.KindEnum.PERSONAL_APPOINTMENT)
                 .links(new OfficerLinkTypes().self("/officers/officerId/appointments"))
                 .items(singletonList(officerAppointmentSummary))
                 .name("forename secondForename surname")
-                .startIndex(0)
+                .startIndex(START_INDEX)
                 .totalResults(1);
     }
 }

--- a/src/test/java/uk/gov/companieshouse/company_appointments/officerappointments/OfficerAppointmentsServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/company_appointments/officerappointments/OfficerAppointmentsServiceTest.java
@@ -4,14 +4,18 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.Optional;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Named;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -22,6 +26,8 @@ import uk.gov.companieshouse.api.officer.AppointmentList;
 class OfficerAppointmentsServiceTest {
 
     private static final String OFFICER_ID = "officerId";
+    private static final int START_INDEX = 0;
+    private static final int ITEMS_PER_PAGE = 35;
 
     @InjectMocks
     private OfficerAppointmentsService service;
@@ -41,57 +47,137 @@ class OfficerAppointmentsServiceTest {
     @Mock
     private AppointmentApi appointmentApi;
 
-    @Test
-    @DisplayName("Get officer appointments returns an officer appointments api")
-    void getOfficerAppointments() {
-        // given
-        OfficerAppointmentsRequest request = new OfficerAppointmentsRequest(OFFICER_ID, "", null, null);
-        when(repository.findOfficerAppointments(anyString(), anyBoolean())).thenReturn(officerAppointmentsAggregate);
-        when(mapper.mapOfficerAppointments(any())).thenReturn(Optional.of(officerAppointments));
-
-        // when
-        Optional<AppointmentList> actual = service.getOfficerAppointments(request);
-
-        // then
-        assertTrue(actual.isPresent());
-        assertEquals(officerAppointments, actual.get());
-        verify(repository).findOfficerAppointments(OFFICER_ID, false);
-        verify(mapper).mapOfficerAppointments(officerAppointmentsAggregate);
+    private static Stream<Arguments> serviceTestParameters() {
+        return Stream.of(
+                Arguments.of(
+                        Named.of("Get officer appointments returns an officer appointments api",
+                                ServiceTestArgument.ServiceTestArgumentBuilder()
+                                        .withRequest(new OfficerAppointmentsRequest(OFFICER_ID, "", null, null))
+                                        .withOfficerId(OFFICER_ID)
+                                        .withFilter(false)
+                                        .withStartIndex(START_INDEX)
+                                        .withItemsPerPage(ITEMS_PER_PAGE)
+                                        .build())),
+                Arguments.of(
+                        Named.of("Get officer appointments returns an officer appointments api when filter is null",
+                                ServiceTestArgument.ServiceTestArgumentBuilder()
+                                        .withRequest(new OfficerAppointmentsRequest(OFFICER_ID, null, null, null))
+                                        .withOfficerId(OFFICER_ID)
+                                        .withFilter(false)
+                                        .withStartIndex(START_INDEX)
+                                        .withItemsPerPage(ITEMS_PER_PAGE)
+                                        .build())),
+                Arguments.of(
+                        Named.of("Get officer appointments returns an officer appointments api when filter is active",
+                                ServiceTestArgument.ServiceTestArgumentBuilder()
+                                        .withRequest(new OfficerAppointmentsRequest(OFFICER_ID, "active", null, null))
+                                        .withOfficerId(OFFICER_ID)
+                                        .withFilter(true)
+                                        .withStartIndex(START_INDEX)
+                                        .withItemsPerPage(ITEMS_PER_PAGE)
+                                        .build())),
+                Arguments.of(
+                        Named.of("Get officer appointments returns a paged officer appointments api when paging is provided",
+                                ServiceTestArgument.ServiceTestArgumentBuilder()
+                                        .withRequest(new OfficerAppointmentsRequest(OFFICER_ID, "active", 3, 3))
+                                        .withOfficerId(OFFICER_ID)
+                                        .withFilter(true)
+                                        .withStartIndex(3)
+                                        .withItemsPerPage(3)
+                                        .build())));
     }
 
-    @Test
-    @DisplayName("Get officer appointments returns an officer appointments api when filter is null")
-    void getOfficerAppointmentsWithNullFilter() {
+    @ParameterizedTest
+    @MethodSource("serviceTestParameters")
+    void getOfficerAppointments(ServiceTestArgument argument) {
         // given
-        OfficerAppointmentsRequest request = new OfficerAppointmentsRequest(OFFICER_ID, null, null, null);
-        when(repository.findOfficerAppointments(anyString(), anyBoolean())).thenReturn(officerAppointmentsAggregate);
-        when(mapper.mapOfficerAppointments(any())).thenReturn(Optional.of(officerAppointments));
+        when(repository.findOfficerAppointments(anyString(), anyBoolean(), anyInt(), anyInt())).thenReturn(officerAppointmentsAggregate);
+        when(mapper.mapOfficerAppointments(anyInt(), anyInt(), any())).thenReturn(Optional.of(officerAppointments));
 
         // when
-        Optional<AppointmentList> actual = service.getOfficerAppointments(request);
+        Optional<AppointmentList> actual = service.getOfficerAppointments(argument.getRequest());
 
         // then
         assertTrue(actual.isPresent());
         assertEquals(officerAppointments, actual.get());
-        verify(repository).findOfficerAppointments(OFFICER_ID, false);
-        verify(mapper).mapOfficerAppointments(officerAppointmentsAggregate);
+        verify(repository).findOfficerAppointments(argument.getOfficerId(), argument.isFilter(), argument.getStartIndex(), argument.getItemsPerPage());
+        verify(mapper).mapOfficerAppointments(argument.getStartIndex(), argument.getItemsPerPage(), officerAppointmentsAggregate);
     }
 
-    @Test
-    @DisplayName("Get officer appointments returns an officer appointments api when filter is active")
-    void getOfficerAppointmentsWithActiveFilter() {
-        // given
-        OfficerAppointmentsRequest request = new OfficerAppointmentsRequest(OFFICER_ID, "active", null, null);
-        when(repository.findOfficerAppointments(anyString(), anyBoolean())).thenReturn(officerAppointmentsAggregate);
-        when(mapper.mapOfficerAppointments(any())).thenReturn(Optional.of(officerAppointments));
+    private static class ServiceTestArgument {
+        private final OfficerAppointmentsRequest request;
+        private final String officerId;
+        private final boolean filter;
+        private final int startIndex;
+        private final int itemsPerPage;
 
-        // when
-        Optional<AppointmentList> actual = service.getOfficerAppointments(request);
+        public ServiceTestArgument(OfficerAppointmentsRequest request, String officerId, boolean filter, int startIndex, int itemsPerPage) {
+            this.request = request;
+            this.officerId = officerId;
+            this.filter = filter;
+            this.startIndex = startIndex;
+            this.itemsPerPage = itemsPerPage;
+        }
 
-        // then
-        assertTrue(actual.isPresent());
-        assertEquals(officerAppointments, actual.get());
-        verify(repository).findOfficerAppointments(OFFICER_ID, true);
-        verify(mapper).mapOfficerAppointments(officerAppointmentsAggregate);
+        public static ServiceTestArgumentBuilder ServiceTestArgumentBuilder() {
+            return new ServiceTestArgumentBuilder();
+        }
+
+        public OfficerAppointmentsRequest getRequest() {
+            return request;
+        }
+
+        public String getOfficerId() {
+            return officerId;
+        }
+
+        public boolean isFilter() {
+            return filter;
+        }
+
+        public int getStartIndex() {
+            return startIndex;
+        }
+
+        public int getItemsPerPage() {
+            return itemsPerPage;
+        }
+
+        private static class ServiceTestArgumentBuilder {
+            private OfficerAppointmentsRequest request;
+            private String officerId;
+            private boolean filter;
+            private int startIndex;
+            private int itemsPerPage;
+
+            public ServiceTestArgumentBuilder withRequest(OfficerAppointmentsRequest request) {
+                this.request = request;
+                return this;
+            }
+
+            public ServiceTestArgumentBuilder withOfficerId(String officerId) {
+                this.officerId = officerId;
+                return this;
+            }
+
+            public ServiceTestArgumentBuilder withFilter(boolean filter) {
+                this.filter = filter;
+                return this;
+            }
+
+            public ServiceTestArgumentBuilder withStartIndex(int startIndex) {
+                this.startIndex = startIndex;
+                return this;
+            }
+
+            public ServiceTestArgumentBuilder withItemsPerPage(int itemsPerPage) {
+                this.itemsPerPage = itemsPerPage;
+                return this;
+            }
+
+            public ServiceTestArgument build() {
+                return new ServiceTestArgument(request, officerId, filter, startIndex, itemsPerPage);
+            }
+        }
     }
 }

--- a/src/test/java/uk/gov/companieshouse/company_appointments/officerappointments/OfficerAppointmentsServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/company_appointments/officerappointments/OfficerAppointmentsServiceTest.java
@@ -84,6 +84,25 @@ class OfficerAppointmentsServiceTest {
                                         .withFilter(true)
                                         .withStartIndex(3)
                                         .withItemsPerPage(3)
+                                        .build())),
+                Arguments.of(
+                        Named.of("Get officer appointments returns default paging when itemsPerPage is 0",
+                                ServiceTestArgument.ServiceTestArgumentBuilder()
+                                        .withRequest(new OfficerAppointmentsRequest(OFFICER_ID, "", null, 0))
+                                        .withOfficerId(OFFICER_ID)
+                                        .withFilter(false)
+                                        .withStartIndex(0)
+                                        .withItemsPerPage(35)
+                                        .build())),
+
+                Arguments.of(
+                        Named.of("Get officer appointments successfully handles negative paging values",
+                                ServiceTestArgument.ServiceTestArgumentBuilder()
+                                        .withRequest(new OfficerAppointmentsRequest(OFFICER_ID, "", -1, -5))
+                                        .withOfficerId(OFFICER_ID)
+                                        .withFilter(false)
+                                        .withStartIndex(1)
+                                        .withItemsPerPage(5)
                                         .build())));
     }
 


### PR DESCRIPTION
* Update aggregation query to slice the result set using the paging parameters if specified, otherwise, defaults to 0 and 35.
* Update mapper to set start index and items per page in the response body.

[DSND-1449](https://companieshouse.atlassian.net/browse/DSND-1449)



[DSND-1449]: https://companieshouse.atlassian.net/browse/DSND-1449?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ