### PR TITLE
DSND-1449 Implement pagination when items per page is over 50

### DIFF
--- a/src/main/java/uk/gov/companieshouse/company_appointments/officerappointments/OfficerAppointmentsService.java
+++ b/src/main/java/uk/gov/companieshouse/company_appointments/officerappointments/OfficerAppointmentsService.java
@@ -8,6 +8,7 @@ import uk.gov.companieshouse.api.officer.AppointmentList;
 public class OfficerAppointmentsService {
 
     private static final int ITEMS_PER_PAGE = 35;
+    private static final int MAX_ITEMS_PER_PAGE = 50;
     private static final int START_INDEX = 0;
 
     private final OfficerAppointmentsRepository repository;
@@ -29,6 +30,8 @@ public class OfficerAppointmentsService {
         int itemsPerPage;
         if (request.getItemsPerPage() == null || request.getItemsPerPage() == 0) {
             itemsPerPage = ITEMS_PER_PAGE;
+        } else if (Math.abs(request.getItemsPerPage()) > 50) {
+            itemsPerPage = MAX_ITEMS_PER_PAGE;
         } else {
             itemsPerPage = Math.abs(request.getItemsPerPage());
         }

--- a/src/test/java/uk/gov/companieshouse/company_appointments/officerappointments/OfficerAppointmentsServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/company_appointments/officerappointments/OfficerAppointmentsServiceTest.java
@@ -28,6 +28,7 @@ class OfficerAppointmentsServiceTest {
     private static final String OFFICER_ID = "officerId";
     private static final int START_INDEX = 0;
     private static final int ITEMS_PER_PAGE = 35;
+    private static final int MAX_ITEMS_PER_PAGE = 50;
 
     @InjectMocks
     private OfficerAppointmentsService service;
@@ -103,6 +104,26 @@ class OfficerAppointmentsServiceTest {
                                         .withFilter(false)
                                         .withStartIndex(1)
                                         .withItemsPerPage(5)
+                                        .build())),
+
+                Arguments.of(
+                        Named.of("Get officer appointments successfully handles paging values over 50",
+                                ServiceTestArgument.ServiceTestArgumentBuilder()
+                                        .withRequest(new OfficerAppointmentsRequest(OFFICER_ID, "", 1, 55))
+                                        .withOfficerId(OFFICER_ID)
+                                        .withFilter(false)
+                                        .withStartIndex(1)
+                                        .withItemsPerPage(MAX_ITEMS_PER_PAGE)
+                                        .build())),
+
+                Arguments.of(
+                        Named.of("Get officer appointments successfully handles negative paging values over 50",
+                                ServiceTestArgument.ServiceTestArgumentBuilder()
+                                        .withRequest(new OfficerAppointmentsRequest(OFFICER_ID, "", -1, -55))
+                                        .withOfficerId(OFFICER_ID)
+                                        .withFilter(false)
+                                        .withStartIndex(1)
+                                        .withItemsPerPage(MAX_ITEMS_PER_PAGE)
                                         .build())));
     }
 


### PR DESCRIPTION
* Missed requirement: When the query param `items_per_page` is set to any number above 50, we should revert the items_per_page in java to 50.
* Itest now uses a for loop to add over 50 appointments to an additional officer so we can test the total results and list of appointments size are returned correctly.
* Tested locally.

[DSND-1449](https://companieshouse.atlassian.net/browse/DSND-1449)

[DSND-1449]: https://companieshouse.atlassian.net/browse/DSND-1449?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ