### PR TITLE
DSND-1448 Implement correct filtering when no active appointments

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,8 +14,8 @@
     <description>Company Appointments API</description>
 
     <properties>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
         <spring-boot-dependencies.version>2.7.9</spring-boot-dependencies.version>
         <testcontainers.version>1.16.2</testcontainers.version>
         <commons-io.version>2.6</commons-io.version>

--- a/src/it/java/uk/gov/companieshouse/company_appointments/officerappointments/OfficerAppointmentsRepositoryITest.java
+++ b/src/it/java/uk/gov/companieshouse/company_appointments/officerappointments/OfficerAppointmentsRepositoryITest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.util.Optional;
 import org.apache.commons.io.IOUtils;
 import org.bson.Document;
 import org.junit.jupiter.api.BeforeAll;
@@ -191,7 +192,7 @@ class OfficerAppointmentsRepositoryITest {
         assertTrue(officerAppointmentsAggregate.getOfficerAppointments().isEmpty());
     }
 
-    @DisplayName("Repository returns a paged officer appointments aggregate with 50 appointments when items per page is set to over 50")
+    @DisplayName("Repository returns a paged officer appointments aggregate with correct total results items per page is set to over 50")
     @Test
     void findOfficerAppointmentsWithPagingOver50() {
         // given
@@ -202,5 +203,30 @@ class OfficerAppointmentsRepositoryITest {
         // then
         assertEquals(SECOND_OFFICER_TOTAL_RESULTS, officerAppointmentsAggregate.getTotalResults());
         assertEquals(MAX_ITEMS_PER_PAGE, officerAppointmentsAggregate.getOfficerAppointments().size());
+    }
+
+    @DisplayName("Repository should return the first appointment for the given officer ID")
+    @Test
+    void findFirstByOfficerId() {
+        // given
+
+        // when
+        Optional<CompanyAppointmentData> actual = repository.findFirstByOfficerId(OFFICER_ID);
+
+        // then
+        assertTrue(actual.isPresent());
+        assertEquals(OFFICER_ID, actual.get().getOfficerId());
+    }
+
+    @DisplayName("Repository should return no appointment for the given officer ID")
+    @Test
+    void findFirstByOfficerIdEmpty() {
+        // given
+
+        // when
+        Optional<CompanyAppointmentData> actual = repository.findFirstByOfficerId("not an officer id");
+
+        // then
+        assertTrue(actual.isEmpty());
     }
 }

--- a/src/main/java/uk/gov/companieshouse/company_appointments/officerappointments/DateOfBirthMapper.java
+++ b/src/main/java/uk/gov/companieshouse/company_appointments/officerappointments/DateOfBirthMapper.java
@@ -10,8 +10,15 @@ import uk.gov.companieshouse.company_appointments.roles.SecretarialRoles;
 @Component
 public class DateOfBirthMapper {
 
+    private final OfficerRoleMapper officerRoleMapper;
+
+    public DateOfBirthMapper(OfficerRoleMapper officerRoleMapper) {
+        this.officerRoleMapper = officerRoleMapper;
+    }
+
     protected DateOfBirth map(LocalDateTime dateOfBirth, String officerRole) {
-        if (SecretarialRoles.stream().anyMatch(roles -> roles.getRole().equals(officerRole))) {
+        if (SecretarialRoles.stream().anyMatch(roles -> roles.getRole().equals(officerRole))
+                || officerRoleMapper.mapIsCorporateOfficer(officerRole)) {
             return null;
         } else {
             return ofNullable(dateOfBirth)

--- a/src/main/java/uk/gov/companieshouse/company_appointments/officerappointments/OfficerAppointmentsMapper.java
+++ b/src/main/java/uk/gov/companieshouse/company_appointments/officerappointments/OfficerAppointmentsMapper.java
@@ -7,6 +7,7 @@ import java.util.Optional;
 import org.springframework.stereotype.Component;
 import uk.gov.companieshouse.api.officer.AppointmentList;
 import uk.gov.companieshouse.api.officer.OfficerLinkTypes;
+import uk.gov.companieshouse.company_appointments.model.data.CompanyAppointmentData;
 
 @Component
 public class OfficerAppointmentsMapper {
@@ -17,9 +18,9 @@ public class OfficerAppointmentsMapper {
     private final OfficerRoleMapper roleMapper;
 
     public OfficerAppointmentsMapper(ItemsMapper itemsMapper,
-            NameMapper nameMapper,
-            DateOfBirthMapper dobMapper,
-            OfficerRoleMapper roleMapper) {
+                                     NameMapper nameMapper,
+                                     DateOfBirthMapper dobMapper,
+                                     OfficerRoleMapper roleMapper) {
         this.itemsMapper = itemsMapper;
         this.nameMapper = nameMapper;
         this.dobMapper = dobMapper;
@@ -30,13 +31,12 @@ public class OfficerAppointmentsMapper {
      * Maps the appointments returned from MongoDB to a list of officer appointments
      * alongside top level fields, relating to the first appointment found.
      *
-     * @param aggregate The count and appointments list pairing returned by the repository.
+     * @param firstAppointment The first appointment found in the db.
+     * @param aggregate        The count and appointments list pairing returned by the repository.
      * @return The optional OfficerAppointmentsApi for the response body.
      */
-    protected Optional<AppointmentList> mapOfficerAppointments(Integer startIndex, Integer itemsPerPage, OfficerAppointmentsAggregate aggregate) {
-        return aggregate.getOfficerAppointments().stream()
-                .findFirst()
-                .flatMap(firstAppointment -> ofNullable(firstAppointment.getData())
+    protected Optional<AppointmentList> mapOfficerAppointments(Integer startIndex, Integer itemsPerPage, CompanyAppointmentData firstAppointment, OfficerAppointmentsAggregate aggregate) {
+        return ofNullable(firstAppointment.getData())
                         .map(data -> new AppointmentList()
                                 .dateOfBirth(dobMapper.map(data.getDateOfBirth(), data.getOfficerRole()))
                                 .etag(data.getEtag())
@@ -48,7 +48,6 @@ public class OfficerAppointmentsMapper {
                                 .items(itemsMapper.map(aggregate.getOfficerAppointments()))
                                 .name(nameMapper.map(data))
                                 .startIndex(startIndex)
-                                .totalResults(aggregate.getTotalResults())
-                        ));
+                                .totalResults(aggregate.getTotalResults()));
     }
 }

--- a/src/main/java/uk/gov/companieshouse/company_appointments/officerappointments/OfficerAppointmentsRepository.java
+++ b/src/main/java/uk/gov/companieshouse/company_appointments/officerappointments/OfficerAppointmentsRepository.java
@@ -5,6 +5,8 @@ import org.springframework.data.mongodb.repository.MongoRepository;
 import org.springframework.stereotype.Repository;
 import uk.gov.companieshouse.company_appointments.model.data.CompanyAppointmentData;
 
+import java.util.Optional;
+
 /**
  * Correct sorting: A list of, first, active officers sorted by appointed_on date in descending order (or appointed_before
  * if appointed_on is null), followed by resigned officers sorted by resigned_on date in descending order.
@@ -60,4 +62,6 @@ public interface OfficerAppointmentsRepository extends MongoRepository<CompanyAp
         +   "}"
     })
     OfficerAppointmentsAggregate findOfficerAppointments(String officerId, boolean filter, int startIndex, int pageSize);
+
+    Optional<CompanyAppointmentData> findFirstByOfficerId(String officerId);
 }

--- a/src/main/java/uk/gov/companieshouse/company_appointments/officerappointments/OfficerAppointmentsService.java
+++ b/src/main/java/uk/gov/companieshouse/company_appointments/officerappointments/OfficerAppointmentsService.java
@@ -3,6 +3,7 @@ package uk.gov.companieshouse.company_appointments.officerappointments;
 import java.util.Optional;
 import org.springframework.stereotype.Service;
 import uk.gov.companieshouse.api.officer.AppointmentList;
+import uk.gov.companieshouse.company_appointments.model.data.CompanyAppointmentData;
 
 @Service
 public class OfficerAppointmentsService {
@@ -20,6 +21,13 @@ public class OfficerAppointmentsService {
     }
 
     protected Optional<AppointmentList> getOfficerAppointments(OfficerAppointmentsRequest request) {
+        String officerId = request.getOfficerId();
+
+        Optional<CompanyAppointmentData> firstAppointment = repository.findFirstByOfficerId(officerId);
+        if (firstAppointment.isEmpty()) {
+            return Optional.empty();
+        }
+
         int startIndex;
         if (request.getStartIndex() == null) {
             startIndex = START_INDEX;
@@ -38,6 +46,6 @@ public class OfficerAppointmentsService {
 
         boolean filter = "active".equals(request.getFilter());
         return mapper.mapOfficerAppointments(startIndex, itemsPerPage,
-                repository.findOfficerAppointments(request.getOfficerId(), filter, startIndex, itemsPerPage));
+                firstAppointment.get(), repository.findOfficerAppointments(officerId, filter, startIndex, itemsPerPage));
     }
 }

--- a/src/test/java/uk/gov/companieshouse/company_appointments/officerappointments/DateOfBirthMapperTest.java
+++ b/src/test/java/uk/gov/companieshouse/company_appointments/officerappointments/DateOfBirthMapperTest.java
@@ -14,7 +14,7 @@ class DateOfBirthMapperTest {
 
     @BeforeEach
     void setUp() {
-        mapper = new DateOfBirthMapper();
+        mapper = new DateOfBirthMapper(new OfficerRoleMapper());
     }
 
     @Test
@@ -55,5 +55,33 @@ class DateOfBirthMapperTest {
 
         // then
         assertNull(actual);
+    }
+
+    @Test
+    void mapDateOfBirthCorporateOfficer() {
+        // given
+        LocalDateTime dateOfBirth = LocalDateTime.of(2000, 2, 5, 0, 0);
+
+        // when
+        DateOfBirth actual = mapper.map(dateOfBirth, "corporate-director");
+
+        // then
+        assertNull(actual);
+    }
+
+    @Test
+    void mapDateOfBirthNullOfficerRole() {
+        // given
+        LocalDateTime dateOfBirth = LocalDateTime.of(2000, 2, 5, 0, 0);
+
+        DateOfBirth expected = new DateOfBirth()
+                .month(2)
+                .year(2000);
+
+        // when
+        DateOfBirth actual = mapper.map(dateOfBirth, null);
+
+        // then
+        assertEquals(expected, actual);
     }
 }


### PR DESCRIPTION
* Change date of birth mapper to return null for coporate officer roles.
* Change pom to use java 11.
* Fetch the first appointment for the given officer id to be used to set top level fields.
* Return empty optional when no appointments are found for the given officer id.

[DSND-1448](https://companieshouse.atlassian.net/browse/DSND-1448)

[DSND-1448]: https://companieshouse.atlassian.net/browse/DSND-1448?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ