### PR TITLE
DSND-1531: Update company name/status for multiple existing appointments

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,21 +16,21 @@
     <properties>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
-        <spring-boot-dependencies.version>2.7.9</spring-boot-dependencies.version>
-        <testcontainers.version>1.16.2</testcontainers.version>
-        <commons-io.version>2.6</commons-io.version>
-        <commons-lang.version>2.6</commons-lang.version>
-        <maven-surefire-plugin.version>2.22.2</maven-surefire-plugin.version>
-        <maven-failsafe-plugin.version>2.22.2</maven-failsafe-plugin.version>
-        <jacoco-maven-plugin.version>0.8.5</jacoco-maven-plugin.version>
+        <spring-boot-dependencies.version>2.7.10</spring-boot-dependencies.version>
+        <testcontainers.version>1.18.0</testcontainers.version>
+        <maven-surefire-plugin.version>3.0.0</maven-surefire-plugin.version>
+        <maven-failsafe-plugin.version>3.0.0</maven-failsafe-plugin.version>
+        <jacoco-maven-plugin.version>0.8.9</jacoco-maven-plugin.version>
+        <jib-maven-plugin.version>3.3.1</jib-maven-plugin.version>
+
         <skip.integration.tests>false</skip.integration.tests>
         <skip.unit.tests>false</skip.unit.tests>
 
         <structured-logging.version>1.9.11</structured-logging.version>
-        <sdk-manager-java.version>1.5.1</sdk-manager-java.version>
-        <api-sdk-manager-java-library.version>1.0.4</api-sdk-manager-java-library.version>
+        <sdk-manager-java.version>1.5.16</sdk-manager-java.version>
+        <api-sdk-manager-java-library.version>1.0.6</api-sdk-manager-java-library.version>
         <private-api-sdk-java.version>2.0.241</private-api-sdk-java.version>
-        <io-cucumber.version>7.2.3</io-cucumber.version>
+        <io-cucumber.version>7.11.2</io-cucumber.version>
         <wiremock.version>2.35.0</wiremock.version>
 
         <api-helper-java-library.version>1.4.5</api-helper-java-library.version>
@@ -69,17 +69,6 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-tomcat</artifactId>
-            <version>${spring-boot-dependencies.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>commons-io</groupId>
-            <artifactId>commons-io</artifactId>
-            <version>${commons-io.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>commons-lang</groupId>
-            <artifactId>commons-lang</artifactId>
-            <version>${commons-lang.version}</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -124,6 +113,12 @@
             <groupId>uk.gov.companieshouse</groupId>
             <artifactId>sdk-manager-java</artifactId>
             <version>${sdk-manager-java.version}</version>
+            <exclusions>
+                <exclusion>
+                    <groupId>com.nimbusds</groupId>
+                    <artifactId>nimbus-jose-jwt</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>uk.gov.companieshouse</groupId>
@@ -186,6 +181,10 @@
                 <groupId>com.github.jknack</groupId>
                 <artifactId>handlebars-helpers</artifactId>
             </exclusion>
+            <exclusion>
+                <groupId>commons-fileupload</groupId>
+                <artifactId>commons-fileupload</artifactId>
+            </exclusion>
         </exclusions>
         </dependency>
     </dependencies>
@@ -207,7 +206,7 @@
             <plugin>
                 <groupId>com.google.cloud.tools</groupId>
                 <artifactId>jib-maven-plugin</artifactId>
-                <version>3.1.1</version>
+                <version>${jib-maven-plugin.version}</version>
             </plugin>
             <plugin>
                 <groupId>org.jacoco</groupId>

--- a/src/it/java/uk/gov/companieshouse/company_appointments/tests/CompanyAppointmentFullRecordRepositoryITest.java
+++ b/src/it/java/uk/gov/companieshouse/company_appointments/tests/CompanyAppointmentFullRecordRepositoryITest.java
@@ -115,7 +115,7 @@ class CompanyAppointmentFullRecordRepositoryITest {
         assertTrue(actual.isEmpty());
     }
 
-    @DisplayName("Repository successfully updates the company name and status of an appointment")
+    @DisplayName("Repository successfully updates the company name and status for all appointments in company")
     @Test
     void shouldPatchAllAppointmentsNameStatusInCompany() {
         // given

--- a/src/it/java/uk/gov/companieshouse/company_appointments/tests/CompanyAppointmentFullRecordRepositoryITest.java
+++ b/src/it/java/uk/gov/companieshouse/company_appointments/tests/CompanyAppointmentFullRecordRepositoryITest.java
@@ -8,17 +8,18 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
+import java.util.List;
 import java.util.Optional;
 import org.apache.commons.io.IOUtils;
 import org.bson.Document;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.mongodb.core.MongoTemplate;
-import org.springframework.data.mongodb.core.SimpleMongoClientDatabaseFactory;
 import org.springframework.test.annotation.DirtiesContext;
 import org.testcontainers.containers.MongoDBContainer;
 import org.testcontainers.junit.jupiter.Container;
@@ -34,21 +35,44 @@ import uk.gov.companieshouse.company_appointments.repository.CompanyAppointmentF
 class CompanyAppointmentFullRecordRepositoryITest {
 
     private static final String APPOINTMENT_ID = "7IjxamNGLlqtIingmTZJJ42Hw9Q";
+    private static final String APPOINTMENT_ID_2 = "app2";
+    private static final String APPOINTMENT_ID_3 = "app3";
+    private static final String COMPANY_NUMBER = "12345678";
+    private static final String COMPANY_NUMBER_2 = "anotherCompanyNumber";
     private static final String FAKE_APPOINTMENT_ID = "aBCdIdonotexistCD";
+    private static final String INITIAL_APPOINTMENT_ID = "fedb91fa70ce4ef335d6d2e24f2f7242c9360a69";
 
     @Autowired
     private CompanyAppointmentFullRecordRepository repository;
+
+    @Autowired
+    private MongoTemplate mongoTemplate;
 
     @Container
     private static final MongoDBContainer mongoDBContainer = new MongoDBContainer("mongo:4.4");
 
     @BeforeAll
-    static void start() throws IOException {
+    static void start() {
         System.setProperty("spring.data.mongodb.uri", mongoDBContainer.getReplicaSetUrl());
-        MongoTemplate mongoTemplate = new MongoTemplate(new SimpleMongoClientDatabaseFactory(mongoDBContainer.getReplicaSetUrl()));
-        mongoTemplate.createCollection("delta_appointments");
-        mongoTemplate.insert(Document.parse(IOUtils.resourceToString("/delta-appointment-data.json", StandardCharsets.UTF_8)), "delta_appointments");
         System.setProperty("company-metrics-api.endpoint", "localhost");
+    }
+
+    @BeforeEach
+    void setup() throws IOException {
+        mongoTemplate.dropCollection("delta_appointments");
+        mongoTemplate.createCollection("delta_appointments");
+        Document document = Document.parse(
+                IOUtils.resourceToString("/delta-appointment-data.json", StandardCharsets.UTF_8));
+        mongoTemplate.insert(document, "delta_appointments");
+
+        document.put("appointment_id", APPOINTMENT_ID_2);
+        document.put("_id", APPOINTMENT_ID_2);
+        mongoTemplate.insert(document, "delta_appointments");
+
+        document.put("appointment_id", APPOINTMENT_ID_3);
+        document.put("_id", APPOINTMENT_ID_3);
+        document.put("company_number", COMPANY_NUMBER_2);
+        mongoTemplate.insert(document, "delta_appointments");
     }
 
     @DisplayName("Repository successfully updates the company name and status of an appointment")
@@ -58,7 +82,8 @@ class CompanyAppointmentFullRecordRepositoryITest {
         Instant at = Instant.now().truncatedTo(ChronoUnit.SECONDS);
 
         // when
-        long result = repository.patchAppointmentNameStatus(APPOINTMENT_ID, "test name", "test status", at, "etag");
+        long result = repository.patchAppointmentNameStatus(APPOINTMENT_ID, "test name",
+                "test status", at, "etag");
 
         // then
         try {
@@ -81,12 +106,40 @@ class CompanyAppointmentFullRecordRepositoryITest {
         Instant at = Instant.now().truncatedTo(ChronoUnit.SECONDS);
 
         // when
-        long result = repository.patchAppointmentNameStatus(FAKE_APPOINTMENT_ID, "test name", "test status", at, "etag");
+        long result = repository.patchAppointmentNameStatus(FAKE_APPOINTMENT_ID, "test name",
+                "test status", at, "etag");
 
         // then
         assertEquals(0L, result);
         Optional<CompanyAppointmentDocument> actual = repository.findById(FAKE_APPOINTMENT_ID);
         assertTrue(actual.isEmpty());
+    }
+
+    @DisplayName("Repository successfully updates the company name and status of an appointment")
+    @Test
+    void shouldPatchAllAppointmentsNameStatusInCompany() {
+        // given
+        Instant at = Instant.now().truncatedTo(ChronoUnit.SECONDS);
+
+        // when
+        long result = repository.patchAppointmentNameStatusInCompany(COMPANY_NUMBER, "test name",
+                "test status", at, "etag");
+
+        // then
+        assertEquals(2L, result);
+
+        List.of(APPOINTMENT_ID, APPOINTMENT_ID_2).forEach(id -> {
+            Optional<CompanyAppointmentDocument> actual = repository.findById(id);
+            assertTrue(actual.isPresent());
+            assertEquals("test name", actual.get().getCompanyName());
+            assertEquals("test status", actual.get().getCompanyStatus());
+            assertEquals(at, actual.get().getUpdated().getAt());
+            assertEquals("etag", actual.get().getEtag());
+        });
+
+        Optional<CompanyAppointmentDocument> actual = repository.findById(APPOINTMENT_ID_3);
+        assertTrue(actual.isPresent());
+        assertEquals(INITIAL_APPOINTMENT_ID, actual.get().getEtag());
     }
 
     @DisplayName("Repository returns true when appointment exists")

--- a/src/main/java/uk/gov/companieshouse/company_appointments/controller/CompanyAppointmentController.java
+++ b/src/main/java/uk/gov/companieshouse/company_appointments/controller/CompanyAppointmentController.java
@@ -8,7 +8,6 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import uk.gov.companieshouse.api.appointment.PatchAppointmentNameStatusApi;
@@ -73,16 +72,20 @@ public class CompanyAppointmentController {
     @PatchMapping(path = "/appointments")
     public ResponseEntity<Void> patchCompanyNameStatus(
             @PathVariable("company_number") String companyNumber,
-            @RequestBody PatchAppointmentNameStatusApi requestBody,
-            @RequestHeader() String contextId) {
+            @RequestBody PatchAppointmentNameStatusApi requestBody) {
         try {
             companyAppointmentService.patchCompanyNameStatus(companyNumber,
                     requestBody.getCompanyName(), requestBody.getCompanyStatus());
             return ResponseEntity.ok().build();
+        } catch (BadRequestException e) {
+            LOGGER.info(e.getMessage());
+            return ResponseEntity.badRequest().build();
         } catch (NotFoundException e) {
-            LOGGER.info(String.format("No appointments found for companyNumber %s, contextId %s",
-                    companyNumber, contextId));
+            LOGGER.info(e.getMessage());
             return ResponseEntity.notFound().build();
+        } catch (ServiceUnavailableException e) {
+            LOGGER.info(e.getMessage());
+            return ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE).build();
         }
     }
 

--- a/src/main/java/uk/gov/companieshouse/company_appointments/repository/CompanyAppointmentFullRecordRepository.java
+++ b/src/main/java/uk/gov/companieshouse/company_appointments/repository/CompanyAppointmentFullRecordRepository.java
@@ -16,12 +16,19 @@ public interface CompanyAppointmentFullRecordRepository extends MongoRepository<
     }
 
     @Query("{'company_number' : '?0', '_id' : '?1'}")
-    Optional<CompanyAppointmentDocument> readByCompanyNumberAndID(String companyNumber, String appointmentId);
+    Optional<CompanyAppointmentDocument> readByCompanyNumberAndID(String companyNumber,
+            String appointmentId);
 
-    @Query(value="{'company_number' : '?0', '_id' : '?1'}", delete = true)
+    @Query(value = "{'company_number' : '?0', '_id' : '?1'}", delete = true)
     void deleteByCompanyNumberAndID(String companyNumber, String appointmentId);
 
     @Query("{ '_id': ?0 }")
     @Update("{ $set: { 'company_name': ?1, 'company_status': ?2, 'updated.at': ?3, 'etag': ?4 } }")
-    long patchAppointmentNameStatus(String id, String companyName, String companyStatus, Instant at, String etag);
+    long patchAppointmentNameStatus(String id, String companyName, String companyStatus, Instant at,
+            String etag);
+
+    @Query("{ 'company_number': ?0 }")
+    @Update("{ $set: { 'company_name': ?1, 'company_status': ?2, 'updated.at': ?3, 'etag': ?4 } }")
+    long patchAppointmentNameStatusInCompany(String companyId, String companyName,
+            String companyStatus, Instant at, String etag);
 }

--- a/src/test/java/uk/gov/companieshouse/company_appointments/CompanyAppointmentControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/company_appointments/CompanyAppointmentControllerTest.java
@@ -158,7 +158,7 @@ public class CompanyAppointmentControllerTest {
     }
 
     @Test
-    void shouldReturnNotFoundForMissingCompanyNumberWhenPatchingNameAndStatus() throws Exception {
+    void shouldThrowNotFoundForMissingCompanyNumberWhenPatchingNameAndStatus() throws Exception {
         // Given
         doThrow(NotFoundException.class)
                 .when(companyAppointmentService).patchCompanyNameStatus(any(), any(), any());
@@ -174,7 +174,7 @@ public class CompanyAppointmentControllerTest {
     }
 
     @Test
-    void shouldReturnNotFoundForMissingCompanyNameWhenPatchingNameAndStatus() throws Exception {
+    void shouldThrowBadRequestForMissingCompanyNameWhenPatchingNameAndStatus() throws Exception {
         // Given
         doThrow(BadRequestException.class)
                 .when(companyAppointmentService).patchCompanyNameStatus(any(), any(), any());
@@ -190,7 +190,7 @@ public class CompanyAppointmentControllerTest {
     }
 
     @Test
-    void shouldReturnServiceUnavailableForWhenPatchingNameAndStatusAndMongoUnavailable()
+    void shouldThrowServiceUnavailableForWhenPatchingNameAndStatusAndMongoUnavailable()
             throws Exception {
         // Given
         doThrow(ServiceUnavailableException.class)

--- a/src/test/java/uk/gov/companieshouse/company_appointments/CompanyAppointmentControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/company_appointments/CompanyAppointmentControllerTest.java
@@ -41,7 +41,6 @@ public class CompanyAppointmentControllerTest {
 
     private final static String COMPANY_NUMBER = "123456";
     private final static String APPOINTMENT_ID = "345678";
-    private final static String CONTEXT_ID = "ABC123";
 
     @BeforeEach
     void setUp() {
@@ -145,13 +144,13 @@ public class CompanyAppointmentControllerTest {
     }
 
     @Test
-    void shouldReturnOKForValidRequest() throws Exception {
+    void shouldReturnOKForValidRequestWhenPatchingNameAndStatus() throws Exception {
         // Given
 
         // When
         ResponseEntity<Void> response = companyAppointmentController.patchCompanyNameStatus(
                 COMPANY_NUMBER, new PatchAppointmentNameStatusApi()
-                        .companyName(COMPANY_NAME).companyStatus(COMPANY_STATUS_ACTIVE), CONTEXT_ID);
+                        .companyName(COMPANY_NAME).companyStatus(COMPANY_STATUS_ACTIVE));
         // Then
         verify(companyAppointmentService).patchCompanyNameStatus(COMPANY_NUMBER, COMPANY_NAME,
                 COMPANY_STATUS_ACTIVE);
@@ -159,7 +158,7 @@ public class CompanyAppointmentControllerTest {
     }
 
     @Test
-    void shouldReturnNotFoundForMissingCompanyNumber() throws Exception {
+    void shouldReturnNotFoundForMissingCompanyNumberWhenPatchingNameAndStatus() throws Exception {
         // Given
         doThrow(NotFoundException.class)
                 .when(companyAppointmentService).patchCompanyNameStatus(any(), any(), any());
@@ -167,11 +166,45 @@ public class CompanyAppointmentControllerTest {
         // When
         ResponseEntity<Void> response = companyAppointmentController.patchCompanyNameStatus(
                 COMPANY_NUMBER, new PatchAppointmentNameStatusApi()
-                        .companyName(COMPANY_NAME).companyStatus(COMPANY_STATUS_ACTIVE), CONTEXT_ID);
+                        .companyName(COMPANY_NAME).companyStatus(COMPANY_STATUS_ACTIVE));
         // Then
         verify(companyAppointmentService).patchCompanyNameStatus(COMPANY_NUMBER, COMPANY_NAME,
                 COMPANY_STATUS_ACTIVE);
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+    }
+
+    @Test
+    void shouldReturnNotFoundForMissingCompanyNameWhenPatchingNameAndStatus() throws Exception {
+        // Given
+        doThrow(BadRequestException.class)
+                .when(companyAppointmentService).patchCompanyNameStatus(any(), any(), any());
+
+        // When
+        ResponseEntity<Void> response = companyAppointmentController.patchCompanyNameStatus(
+                COMPANY_NUMBER, new PatchAppointmentNameStatusApi()
+                        .companyStatus(COMPANY_STATUS_ACTIVE));
+        // Then
+        verify(companyAppointmentService).patchCompanyNameStatus(COMPANY_NUMBER, null,
+                COMPANY_STATUS_ACTIVE);
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.BAD_REQUEST);
+    }
+
+    @Test
+    void shouldReturnServiceUnavailableForWhenPatchingNameAndStatusAndMongoUnavailable()
+            throws Exception {
+        // Given
+        doThrow(ServiceUnavailableException.class)
+                .when(companyAppointmentService).patchCompanyNameStatus(any(), any(), any());
+
+        // When
+        ResponseEntity<Void> response = companyAppointmentController.patchCompanyNameStatus(
+                COMPANY_NUMBER, new PatchAppointmentNameStatusApi()
+                        .companyName(COMPANY_NAME)
+                        .companyStatus(COMPANY_STATUS_ACTIVE));
+        // Then
+        verify(companyAppointmentService).patchCompanyNameStatus(COMPANY_NUMBER, COMPANY_NAME,
+                COMPANY_STATUS_ACTIVE);
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.SERVICE_UNAVAILABLE);
     }
 
     @Test
@@ -181,7 +214,8 @@ public class CompanyAppointmentControllerTest {
         // when
         ResponseEntity<Void> response = companyAppointmentController.patchNewAppointmentCompanyNameStatus(
                 COMPANY_NUMBER, APPOINTMENT_ID,
-                new PatchAppointmentNameStatusApi().companyName(COMPANY_NAME).companyStatus(COMPANY_STATUS_ACTIVE));
+                new PatchAppointmentNameStatusApi().companyName(COMPANY_NAME)
+                        .companyStatus(COMPANY_STATUS_ACTIVE));
 
         // then
         verify(companyAppointmentService).patchNewAppointmentCompanyNameStatus(COMPANY_NUMBER, APPOINTMENT_ID,

--- a/src/test/java/uk/gov/companieshouse/company_appointments/CompanyAppointmentServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/company_appointments/CompanyAppointmentServiceTest.java
@@ -473,7 +473,7 @@ class CompanyAppointmentServiceTest {
         verifyNoInteractions(fullRecordAppointmentRepository);
     }
 
-    @DisplayName("Test throw BadRequestException when updating a companies appointments when missing company status")
+    @DisplayName("Test throw BadRequestException when updating a companies appointments with invalid company status")
     @Test
     void shouldThrowBadRequestExceptionWhenUpdatingCompanyAppointmentsWithInvalidCompanyStatus() {
         // given

--- a/src/test/java/uk/gov/companieshouse/company_appointments/CompanyAppointmentServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/company_appointments/CompanyAppointmentServiceTest.java
@@ -5,10 +5,12 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
+import static uk.gov.companieshouse.logging.util.LogContextProperties.REQUEST_ID;
 
 import java.time.Clock;
 import java.time.LocalDateTime;
@@ -22,6 +24,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.function.Executable;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.slf4j.MDC;
 import org.springframework.dao.DataAccessResourceFailureException;
 import org.springframework.data.domain.Sort;
 import uk.gov.companieshouse.company_appointments.exception.BadRequestException;
@@ -79,8 +82,11 @@ class CompanyAppointmentServiceTest {
     @BeforeEach
     void setUp() {
         CompanyAppointmentMapper companyAppointmentMapper = new CompanyAppointmentMapper();
-        companyAppointmentService = new CompanyAppointmentService(companyAppointmentRepository, companyAppointmentMapper, sortMapper,
-                companyRegisterService, companyStatusValidator, fullRecordAppointmentRepository, clock);
+        companyAppointmentService = new CompanyAppointmentService(companyAppointmentRepository,
+                companyAppointmentMapper, sortMapper,
+                companyRegisterService, companyStatusValidator, fullRecordAppointmentRepository,
+                clock);
+        MDC.put(REQUEST_ID.value(), CONTEXT_ID);
     }
 
     @Test
@@ -416,15 +422,118 @@ class CompanyAppointmentServiceTest {
     }
 
     @Test
-    @DisplayName("Test patchCompanyNameStatus throws UnsupportedOperationException")
-    void testUnsupportedOperationException() {
+    @DisplayName("Test update a companies appointments")
+    void shouldUpdateCompanyAppointments() throws Exception {
         // given
+        when(companyStatusValidator.isValidCompanyStatus(anyString())).thenReturn(true);
+        when(fullRecordAppointmentRepository.patchAppointmentNameStatusInCompany(anyString(),
+                anyString(), anyString(), any(), anyString())).thenReturn(2L);
 
         // when
-        Executable executable = () -> companyAppointmentService.patchCompanyNameStatus(COMPANY_NUMBER, COMPANY_NAME, OPEN_STATUS);
+        companyAppointmentService.patchCompanyNameStatus(COMPANY_NUMBER, COMPANY_NAME, OPEN_STATUS);
 
         // then
-        assertThrows(UnsupportedOperationException.class, executable);
+        verify(companyStatusValidator).isValidCompanyStatus(OPEN_STATUS);
+        verify(fullRecordAppointmentRepository).patchAppointmentNameStatusInCompany(
+                eq(COMPANY_NUMBER),
+                eq(COMPANY_NAME), eq(OPEN_STATUS), any(), anyString());
+    }
+
+    @DisplayName("Test throw BadRequestException when updating a companies appointments when missing company name")
+    @Test
+    void shouldThrowBadRequestExceptionWhenUpdatingAppointmentsWhenMissingCompanyName() {
+        // given
+        // when
+        Executable executable = () -> companyAppointmentService.patchCompanyNameStatus(
+                COMPANY_NUMBER, "", OPEN_STATUS);
+
+        // then
+        BadRequestException exception = assertThrows(BadRequestException.class, executable);
+        assertEquals(
+                "Request failed for company [123456], contextId: [ABC123]: company name and/or company status missing.",
+                exception.getMessage());
+        verifyNoInteractions(companyStatusValidator);
+        verifyNoInteractions(fullRecordAppointmentRepository);
+    }
+
+    @DisplayName("Test throw BadRequestException when updating a companies appointments when missing company status")
+    @Test
+    void shouldThrowBadRequestExceptionWhenUpdatingCompanyAppointmentsWhenMissingCompanyStatus() {
+        // given
+        // when
+        Executable executable = () -> companyAppointmentService.patchCompanyNameStatus(
+                COMPANY_NUMBER, COMPANY_NAME, "");
+
+        // then
+        BadRequestException exception = assertThrows(BadRequestException.class, executable);
+        assertEquals(
+                "Request failed for company [123456], contextId: [ABC123]: company name and/or company status missing.",
+                exception.getMessage());
+        verifyNoInteractions(companyStatusValidator);
+        verifyNoInteractions(fullRecordAppointmentRepository);
+    }
+
+    @DisplayName("Test throw BadRequestException when updating a companies appointments when missing company status")
+    @Test
+    void shouldThrowBadRequestExceptionWhenUpdatingCompanyAppointmentsWithInvalidCompanyStatus() {
+        // given
+        when(companyStatusValidator.isValidCompanyStatus(anyString())).thenReturn(false);
+        // when
+        Executable executable = () -> companyAppointmentService.patchCompanyNameStatus(
+                COMPANY_NUMBER, COMPANY_NAME, FAKE_STATUS);
+
+        // then
+        BadRequestException exception = assertThrows(BadRequestException.class, executable);
+        assertEquals(
+                "Request failed for company [123456], contextId: [ABC123]: invalid company status provided.",
+                exception.getMessage());
+        verify(companyStatusValidator).isValidCompanyStatus(FAKE_STATUS);
+        verifyNoInteractions(fullRecordAppointmentRepository);
+    }
+
+    @DisplayName("Test throw ServiceUnavailableException when updating a companies appointments when and Mongo is down")
+    @Test
+    void shouldThrowServiceUnavailableExceptionWhenUpdatingCompanyAppointmentsAndMongoDown() {
+        // given
+        when(companyStatusValidator.isValidCompanyStatus(anyString())).thenReturn(true);
+        when(fullRecordAppointmentRepository.patchAppointmentNameStatusInCompany(anyString(),
+                anyString(), anyString(), any(), anyString()))
+                .thenThrow(new DataAccessResourceFailureException(""));
+        // when
+        Executable executable = () -> companyAppointmentService.patchCompanyNameStatus(
+                COMPANY_NUMBER, COMPANY_NAME, OPEN_STATUS);
+
+        // then
+        ServiceUnavailableException exception = assertThrows(ServiceUnavailableException.class,
+                executable);
+        assertEquals(
+                "Request failed for company [123456], contextId: [ABC123]: error connecting to MongoDB.",
+                exception.getMessage());
+        verify(companyStatusValidator).isValidCompanyStatus(OPEN_STATUS);
+        verify(fullRecordAppointmentRepository).patchAppointmentNameStatusInCompany(
+                eq(COMPANY_NUMBER),
+                eq(COMPANY_NAME), eq(OPEN_STATUS), any(), anyString());
+    }
+
+    @DisplayName("Test throw NotFoundException when updating a companies appointments when company number not found")
+    @Test
+    void shouldThrowNotFoundExceptionWhenUpdatingCompanyAppointmentsWhenCompanyNumberNotFound() {
+        // given
+        when(companyStatusValidator.isValidCompanyStatus(anyString())).thenReturn(true);
+        when(fullRecordAppointmentRepository.patchAppointmentNameStatusInCompany(anyString(),
+                anyString(), anyString(), any(), anyString())).thenReturn(0L);
+        // when
+        Executable executable = () -> companyAppointmentService.patchCompanyNameStatus(
+                COMPANY_NUMBER, COMPANY_NAME, OPEN_STATUS);
+
+        // then
+        NotFoundException exception = assertThrows(NotFoundException.class, executable);
+        assertEquals("No appointments found for company [123456] during PATCH request",
+                exception.getMessage());
+        verify(companyStatusValidator).isValidCompanyStatus(OPEN_STATUS);
+        verify(fullRecordAppointmentRepository).patchAppointmentNameStatusInCompany(
+                eq(COMPANY_NUMBER),
+                eq(COMPANY_NAME), eq(OPEN_STATUS), any(), anyString());
     }
 
     @Test
@@ -432,15 +541,18 @@ class CompanyAppointmentServiceTest {
     void patchNewAppointmentNameStatusSuccessfulUpdate() {
         // given
         when(companyStatusValidator.isValidCompanyStatus(anyString())).thenReturn(true);
-        when(fullRecordAppointmentRepository.patchAppointmentNameStatus(anyString(), anyString(), anyString(), any(), anyString())).thenReturn(1L);
+        when(fullRecordAppointmentRepository.patchAppointmentNameStatus(anyString(), anyString(),
+                anyString(), any(), anyString())).thenReturn(1L);
 
         // when
-        Executable executable = () -> companyAppointmentService.patchNewAppointmentCompanyNameStatus(COMPANY_NUMBER, APPOINTMENT_ID, COMPANY_NAME, OPEN_STATUS);
+        Executable executable = () -> companyAppointmentService.patchNewAppointmentCompanyNameStatus(
+                COMPANY_NUMBER, APPOINTMENT_ID, COMPANY_NAME, OPEN_STATUS);
 
         // then
         assertDoesNotThrow(executable);
         verify(companyStatusValidator).isValidCompanyStatus(OPEN_STATUS);
-        verify(fullRecordAppointmentRepository).patchAppointmentNameStatus(any(), any(), any(), any(), any());
+        verify(fullRecordAppointmentRepository).patchAppointmentNameStatus(any(), any(), any(),
+                any(), any());
     }
 
     @Test
@@ -454,7 +566,8 @@ class CompanyAppointmentServiceTest {
         // then
         BadRequestException exception = assertThrows(BadRequestException.class, executable);
         assertEquals(
-                "Request failed for company [123456] with appointment [345678]: company name and/or company status missing.", exception.getMessage());
+                "Request failed for company [123456] with appointment [345678], contextId: [ABC123]: company name and/or company status missing.",
+                exception.getMessage());
         verifyNoInteractions(companyStatusValidator);
         verifyNoInteractions(fullRecordAppointmentRepository);
     }
@@ -465,11 +578,14 @@ class CompanyAppointmentServiceTest {
         // given
 
         // when
-        Executable executable = () -> companyAppointmentService.patchNewAppointmentCompanyNameStatus(COMPANY_NUMBER, APPOINTMENT_ID, COMPANY_NAME, "");
+        Executable executable = () -> companyAppointmentService.patchNewAppointmentCompanyNameStatus(
+                COMPANY_NUMBER, APPOINTMENT_ID, COMPANY_NAME, "");
 
         // then
         BadRequestException exception = assertThrows(BadRequestException.class, executable);
-        assertEquals("Request failed for company [123456] with appointment [345678]: company name and/or company status missing.", exception.getMessage());
+        assertEquals(
+                "Request failed for company [123456] with appointment [345678], contextId: [ABC123]: company name and/or company status missing.",
+                exception.getMessage());
         verifyNoInteractions(companyStatusValidator);
         verifyNoInteractions(fullRecordAppointmentRepository);
     }
@@ -481,11 +597,14 @@ class CompanyAppointmentServiceTest {
         when(companyStatusValidator.isValidCompanyStatus(FAKE_STATUS)).thenReturn(false);
 
         // when
-        Executable executable = () -> companyAppointmentService.patchNewAppointmentCompanyNameStatus(COMPANY_NUMBER, APPOINTMENT_ID, COMPANY_NAME, FAKE_STATUS);
+        Executable executable = () -> companyAppointmentService.patchNewAppointmentCompanyNameStatus(
+                COMPANY_NUMBER, APPOINTMENT_ID, COMPANY_NAME, FAKE_STATUS);
 
         // then
         BadRequestException exception = assertThrows(BadRequestException.class, executable);
-        assertEquals("Request failed for company [123456] with appointment [345678]: invalid company status provided.", exception.getMessage());
+        assertEquals(
+                "Request failed for company [123456] with appointment [345678], contextId: [ABC123]: invalid company status provided.",
+                exception.getMessage());
         verify(companyStatusValidator).isValidCompanyStatus(FAKE_STATUS);
         verifyNoInteractions(fullRecordAppointmentRepository);
     }
@@ -512,16 +631,22 @@ class CompanyAppointmentServiceTest {
     void patchNewAppointmentNameStatusMongoUnavailableAfterResourceChanged() {
         // given
         when(companyStatusValidator.isValidCompanyStatus(anyString())).thenReturn(true);
-        when(fullRecordAppointmentRepository.patchAppointmentNameStatus(any(), any(), any(), any(), any())).thenThrow(DataAccessResourceFailureException.class);
+        when(fullRecordAppointmentRepository.patchAppointmentNameStatus(any(), any(), any(), any(),
+                any())).thenThrow(DataAccessResourceFailureException.class);
 
         // when
-        Executable executable = () -> companyAppointmentService.patchNewAppointmentCompanyNameStatus(COMPANY_NUMBER, APPOINTMENT_ID, COMPANY_NAME, OPEN_STATUS);
+        Executable executable = () -> companyAppointmentService.patchNewAppointmentCompanyNameStatus(
+                COMPANY_NUMBER, APPOINTMENT_ID, COMPANY_NAME, OPEN_STATUS);
 
         // then
-        ServiceUnavailableException exception = assertThrows(ServiceUnavailableException.class, executable);
-        assertEquals("Request failed for company [123456] with appointment [345678]: error connecting to MongoDB.", exception.getMessage());
+        ServiceUnavailableException exception = assertThrows(ServiceUnavailableException.class,
+                executable);
+        assertEquals(
+                "Request failed for company [123456] with appointment [345678], contextId: [ABC123]: error connecting to MongoDB.",
+                exception.getMessage());
         verify(companyStatusValidator).isValidCompanyStatus(OPEN_STATUS);
-        verify(fullRecordAppointmentRepository).patchAppointmentNameStatus(any(), any(), any(), any(), any());
+        verify(fullRecordAppointmentRepository).patchAppointmentNameStatus(any(), any(), any(),
+                any(), any());
     }
 
     private OfficerData.Builder officerData() {


### PR DESCRIPTION
* Mapped HTTP responses codes to exceptions thrown when patching company name and status
* Added a bulk update method to update company name and status in fullRecordAppointmentRepository
* Implemented CompanyAppointmentService.patchCompanyNameStatus
* Updated CompanyAppointmentService logging to use the context ID from the MDC
* Updated dependencies in the pom.xml and removed unused dependencies

[DSND-1531](https://companieshouse.atlassian.net/browse/DSND-1531)

[DSND-1531]: https://companieshouse.atlassian.net/browse/DSND-1531?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ