### PR TITLE
DSND-1531: Modify route to allow for patch existing appointments

### DIFF
--- a/routes.yaml
+++ b/routes.yaml
@@ -2,6 +2,6 @@ app_name: company-appointments.api.ch.gov.uk
 group: api
 weight: 900
 routes:
-  1: ^/company/.*?/appointments/.*?$
+  1: ^/company/.*?/appointments(/.*?|$)$
   2: ^/company/(.){0,10}/officers-test$
   3: ^/officers/.*/appointments$


### PR DESCRIPTION
* Changes route to allow for both /company/{company_number}/appointments/{appointment_id} and /company/{company_number}/appointments

[DSND-1531](https://companieshouse.atlassian.net/browse/DSND-1531)