### PR TITLE
DSND-1347: Fixed a missing slash when mapping on the ResourceChangedData.resourceUri

### DIFF
--- a/src/main/java/uk/gov/companieshouse/company_appointments/mapper/ResourceChangedRequestMapper.java
+++ b/src/main/java/uk/gov/companieshouse/company_appointments/mapper/ResourceChangedRequestMapper.java
@@ -18,7 +18,7 @@ public class ResourceChangedRequestMapper {
     public ChangedResource mapChangedResource(ResourceChangedRequest request) {
         ChangedResourceEvent event = new ChangedResourceEvent().publishedAt(this.timestampGenerator.get());
         ChangedResource changedResource = new ChangedResource() //NOSONAR
-                .resourceUri(String.format("company/%s/appointments/%s", request.getCompanyNumber(),
+                .resourceUri(String.format("/company/%s/appointments/%s", request.getCompanyNumber(),
                         request.getAppointmentId()))
                 .resourceKind("company-officers")
                 .event(event)

--- a/src/test/java/uk/gov/companieshouse/company_appointments/ResourceChangedRequestMapperTest.java
+++ b/src/test/java/uk/gov/companieshouse/company_appointments/ResourceChangedRequestMapperTest.java
@@ -15,8 +15,8 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.companieshouse.api.chskafka.ChangedResource;
 import uk.gov.companieshouse.api.chskafka.ChangedResourceEvent;
-import uk.gov.companieshouse.api.exemptions.CompanyExemptions;
 import uk.gov.companieshouse.company_appointments.mapper.ResourceChangedRequestMapper;
+import uk.gov.companieshouse.company_appointments.model.data.CompanyAppointmentDocument;
 import uk.gov.companieshouse.company_appointments.model.data.ResourceChangedRequest;
 
 @ExtendWith(MockitoExtension.class)
@@ -51,7 +51,7 @@ class ResourceChangedRequestMapperTest {
                         ResourceChangedTestArgument.ResourceChangedTestArgumentBuilder()
                                 .withRequest(new ResourceChangedRequest(EXPECTED_CONTEXT_ID, "12345678", "87654321", null, false))
                                 .withContextId(EXPECTED_CONTEXT_ID)
-                                .withResourceUri("company/12345678/appointments/87654321")
+                                .withResourceUri("/company/12345678/appointments/87654321")
                                 .withResourceKind("company-officers")
                                 .withEventType("changed")
                                 .withEventPublishedAt(DATE)
@@ -61,12 +61,12 @@ class ResourceChangedRequestMapperTest {
                 Arguments.of(
                     Named.of("Test resource-changed scenario with event type of deleted",
                     ResourceChangedTestArgument.ResourceChangedTestArgumentBuilder()
-                            .withRequest(new ResourceChangedRequest(EXPECTED_CONTEXT_ID, "12345678", "87654321", new CompanyExemptions(), true))
+                            .withRequest(new ResourceChangedRequest(EXPECTED_CONTEXT_ID, "12345678", "87654321", new CompanyAppointmentDocument(), true))
                             .withContextId(EXPECTED_CONTEXT_ID)
-                            .withResourceUri("company/12345678/appointments/87654321")
+                            .withResourceUri("/company/12345678/appointments/87654321")
                             .withResourceKind("company-officers")
                             .withEventType("deleted")
-                            .withDeletedData(new CompanyExemptions())
+                            .withDeletedData(new CompanyAppointmentDocument())
                             .withEventPublishedAt(DATE)
                             .build()
                     )


### PR DESCRIPTION
The mapper for `ResourceChangedData` was not prepending a slash character when building the `resourceUri`