### PR TITLE
DSND-1822: Implement feature flag to disable streaming events.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,9 +29,9 @@
         <skip.unit.tests>false</skip.unit.tests>
 
         <structured-logging.version>1.9.11</structured-logging.version>
-        <sdk-manager-java.version>1.5.16</sdk-manager-java.version>
-        <api-sdk-manager-java-library.version>1.0.6</api-sdk-manager-java-library.version>
-        <private-api-sdk-java.version>2.0.267</private-api-sdk-java.version>
+        <sdk-manager-java.version>1.5.17</sdk-manager-java.version>
+        <api-sdk-manager-java-library.version>1.0.8</api-sdk-manager-java-library.version>
+        <private-api-sdk-java.version>2.0.278</private-api-sdk-java.version>
         <io-cucumber.version>7.11.2</io-cucumber.version>
         <wiremock.version>2.35.0</wiremock.version>
 

--- a/src/main/java/uk/gov/companieshouse/company_appointments/api/ResourceChangedApiService.java
+++ b/src/main/java/uk/gov/companieshouse/company_appointments/api/ResourceChangedApiService.java
@@ -40,6 +40,7 @@ public class ResourceChangedApiService {
      * @param resourceChangedRequest encapsulates details relating to the updated or deleted company exemption
      * @return The service status of the response from chs kafka api
      */
+    @StreamEvents
     public ApiResponse<Void> invokeChsKafkaApi(ResourceChangedRequest resourceChangedRequest) throws ServiceUnavailableException {
         InternalApiClient internalApiClient = apiClientService.getInternalApiClient(); //NOSONAR
         internalApiClient.setBasePath(chsKafkaUrl);

--- a/src/main/java/uk/gov/companieshouse/company_appointments/api/ResourceChangedApiServiceAspect.java
+++ b/src/main/java/uk/gov/companieshouse/company_appointments/api/ResourceChangedApiServiceAspect.java
@@ -1,0 +1,23 @@
+package uk.gov.companieshouse.company_appointments.api;
+
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+import uk.gov.companieshouse.company_appointments.CompanyAppointmentsApplication;
+import uk.gov.companieshouse.logging.Logger;
+import uk.gov.companieshouse.logging.LoggerFactory;
+
+@Aspect
+@Component
+@ConditionalOnProperty(prefix = "feature", name = "seeding_collection_enabled")
+public class ResourceChangedApiServiceAspect {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(CompanyAppointmentsApplication.APPLICATION_NAMESPACE);
+
+    @Around("@annotation(StreamEvents)")
+    public Object checkStreamEventsEnabled() {
+            LOGGER.debug("Stream events disabled; not publishing change to chs-kafka-api");
+            return null;
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/company_appointments/api/StreamEvents.java
+++ b/src/main/java/uk/gov/companieshouse/company_appointments/api/StreamEvents.java
@@ -1,0 +1,11 @@
+package uk.gov.companieshouse.company_appointments.api;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface StreamEvents {
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -5,7 +5,7 @@ logging.level.org.springframework.web.filter.CommonsRequestLoggingFilter=${REQUE
 
 spring.data.mongodb.field-naming-strategy=uk.gov.companieshouse.company_appointments.config.JsonSnakeCaseNamingStrategy
 
-company-metrics-api.endpoint=${COMPANY_METRICS_API_URL}
+company-metrics-api.endpoint=${COMPANY_METRICS_API_URL:localhost}
 spring.jackson.default-property-inclusion=non_null
 
 chs.kafka.api.endpoint=${CHS_KAFKA_API_URL:localhost}

--- a/src/test/java/uk/gov/companieshouse/company_appointments/api/ResourceChangedApiServiceAspectFeatureFlagDisabledITest.java
+++ b/src/test/java/uk/gov/companieshouse/company_appointments/api/ResourceChangedApiServiceAspectFeatureFlagDisabledITest.java
@@ -1,0 +1,66 @@
+package uk.gov.companieshouse.company_appointments.api;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import uk.gov.companieshouse.api.InternalApiClient;
+import uk.gov.companieshouse.api.chskafka.ChangedResource;
+import uk.gov.companieshouse.api.error.ApiErrorResponseException;
+import uk.gov.companieshouse.api.handler.chskafka.PrivateChangedResourceHandler;
+import uk.gov.companieshouse.api.handler.chskafka.request.PrivateChangedResourcePost;
+import uk.gov.companieshouse.api.model.ApiResponse;
+import uk.gov.companieshouse.company_appointments.exception.ServiceUnavailableException;
+import uk.gov.companieshouse.company_appointments.mapper.ResourceChangedRequestMapper;
+import uk.gov.companieshouse.company_appointments.model.data.ResourceChangedRequest;
+
+@SpringBootTest
+class ResourceChangedApiServiceAspectFeatureFlagDisabledITest {
+
+    @Autowired
+    private ResourceChangedApiService resourceChangedApiService;
+
+    @MockBean
+    private ApiClientService apiClientService;
+    @MockBean
+    private ResourceChangedRequestMapper mapper;
+
+    @Mock
+    private InternalApiClient internalApiClient;
+    @Mock
+    private ResourceChangedRequest resourceChangedRequest;
+    @Mock
+    private ChangedResource changedResource;
+    @Mock
+    private PrivateChangedResourceHandler privateChangedResourceHandler;
+    @Mock
+    private PrivateChangedResourcePost changedResourcePost;
+    @Mock
+    private ApiResponse<Void> response;
+
+    @Test
+    void testThatKafkaApiShouldBeCalledWhenFeatureFlagDisabled()
+            throws ApiErrorResponseException, ServiceUnavailableException {
+
+        when(apiClientService.getInternalApiClient()).thenReturn(internalApiClient);
+        when(internalApiClient.privateChangedResourceHandler()).thenReturn(
+                privateChangedResourceHandler);
+        when(privateChangedResourceHandler.postChangedResource(any(), any())).thenReturn(
+                changedResourcePost);
+        when(changedResourcePost.execute()).thenReturn(response);
+        when(mapper.mapChangedResource(resourceChangedRequest)).thenReturn(changedResource);
+
+        resourceChangedApiService.invokeChsKafkaApi(resourceChangedRequest);
+
+        verify(apiClientService).getInternalApiClient();
+        verify(internalApiClient).privateChangedResourceHandler();
+        verify(privateChangedResourceHandler).postChangedResource("/resource-changed",
+                changedResource);
+        verify(changedResourcePost).execute();
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/company_appointments/api/ResourceChangedApiServiceAspectFeatureFlagEnabledITest.java
+++ b/src/test/java/uk/gov/companieshouse/company_appointments/api/ResourceChangedApiServiceAspectFeatureFlagEnabledITest.java
@@ -1,0 +1,45 @@
+package uk.gov.companieshouse.company_appointments.api;
+
+import static org.mockito.Mockito.verifyNoInteractions;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.Mock;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ActiveProfiles;
+import uk.gov.companieshouse.api.InternalApiClient;
+import uk.gov.companieshouse.api.handler.chskafka.PrivateChangedResourceHandler;
+import uk.gov.companieshouse.api.handler.chskafka.request.PrivateChangedResourcePost;
+import uk.gov.companieshouse.company_appointments.exception.ServiceUnavailableException;
+import uk.gov.companieshouse.company_appointments.model.data.ResourceChangedRequest;
+
+@SpringBootTest
+@ActiveProfiles("feature_flag_enabled")
+class ResourceChangedApiServiceAspectFeatureFlagEnabledITest {
+    @Autowired
+    private ResourceChangedApiService resourceChangedApiService;
+
+    @MockBean
+    private ApiClientService apiClientService;
+
+    @Mock
+    private InternalApiClient internalApiClient;
+    @Mock
+    private ResourceChangedRequest resourceChangedRequest;
+    @Mock
+    private PrivateChangedResourceHandler privateChangedResourceHandler;
+    @Mock
+    private PrivateChangedResourcePost changedResourcePost;
+
+    @Test
+    void testThatAspectShouldNotProceedWhenFeatureFlagEnabled() throws ServiceUnavailableException {
+
+        resourceChangedApiService.invokeChsKafkaApi(resourceChangedRequest);
+
+        verifyNoInteractions(apiClientService);
+        verifyNoInteractions(internalApiClient);
+        verifyNoInteractions(privateChangedResourceHandler);
+        verifyNoInteractions(changedResourcePost);
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/company_appointments/api/ResourceChangedApiServiceAspectTest.java
+++ b/src/test/java/uk/gov/companieshouse/company_appointments/api/ResourceChangedApiServiceAspectTest.java
@@ -1,0 +1,24 @@
+package uk.gov.companieshouse.company_appointments.api;
+
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ResourceChangedApiServiceAspectTest {
+
+    @InjectMocks
+    private ResourceChangedApiServiceAspect apiServiceAspect;
+
+    @Test
+    void testAspectDoesNotProceedWhenFlagDisabled() {
+        // when
+        Object actual = apiServiceAspect.checkStreamEventsEnabled();
+
+        // then
+        assertNull(actual);
+    }
+}


### PR DESCRIPTION
* Updated versions of CH specific dependencies in Pom.
* Implemented new ResourceChangedApiService Aspect to stop stream events.
* Stream events stopped by ```SEEDING_COLLECTION_ENABLED=true``` the same flag which toggles company name and status.

[DSND-1822](https://companieshouse.atlassian.net/browse/DSND-1822)

[DSND-1822]: https://companieshouse.atlassian.net/browse/DSND-1822?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ