### PR TITLE
DSND-1970: Return etag as a top level field in company officer list

### DIFF
--- a/src/main/java/uk/gov/companieshouse/company_appointments/service/CompanyAppointmentService.java
+++ b/src/main/java/uk/gov/companieshouse/company_appointments/service/CompanyAppointmentService.java
@@ -137,7 +137,7 @@ public class CompanyAppointmentService {
                 .startIndex(startIndex)
                 .itemsPerPage(itemsPerPage)
                 .links(new LinkTypes().self(String.format("/company/%s/officers", companyNumber)))
-                .etag(officerSummaries.isEmpty() ? "" : officerSummaries.get(0).getEtag());
+                .etag(allAppointmentData.get(0).getData().getEtag());
     }
 
     public void patchCompanyNameStatus(String companyNumber, String companyName,

--- a/src/test/java/uk/gov/companieshouse/company_appointments/service/CompanyAppointmentServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/company_appointments/service/CompanyAppointmentServiceTest.java
@@ -163,6 +163,7 @@ class CompanyAppointmentServiceTest {
         assertEquals(0, result.getInactiveCount());
         assertEquals(0, result.getResignedCount());
         assertEquals(OfficerList.class, result.getClass());
+        assertEquals("etag", result.getEtag());
         verify(companyAppointmentRepository).getCompanyAppointments(eq(COMPANY_NUMBER),
                 eq(ORDER_BY), isNull(), eq(0), eq(35), eq(false), eq(false));
     }
@@ -855,7 +856,8 @@ class CompanyAppointmentServiceTest {
                         .setPoBox("PO Box")
                         .setPremises("Premises")
                         .setRegion("Region"))
-                .contactDetails(new DeltaContactDetails().setContactName("Name"));
+                .contactDetails(new DeltaContactDetails().setContactName("Name"))
+                .etag("etag");
     }
 
     private DeltaSensitiveData buildSensitiveData() {


### PR DESCRIPTION
* Etag is being returned on the individual appointment GET endpoint is not being returned in the GET company officer list, this fixes the issue.

[DSND-1970](https://companieshouse.atlassian.net/browse/DSND-1970)

[DSND-1970]: https://companieshouse.atlassian.net/browse/DSND-1970?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ