### PR TITLE
DSND-1902: Upgrade structured logging

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
     <properties>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
-        <spring-boot-dependencies.version>2.7.11</spring-boot-dependencies.version>
+        <spring-boot-dependencies.version>2.7.13</spring-boot-dependencies.version>
         <testcontainers.version>1.18.0</testcontainers.version>
         <maven-surefire-plugin.version>3.0.0</maven-surefire-plugin.version>
         <maven-failsafe-plugin.version>3.0.0</maven-failsafe-plugin.version>
@@ -28,7 +28,7 @@
         <skip.integration.tests>false</skip.integration.tests>
         <skip.unit.tests>false</skip.unit.tests>
 
-        <structured-logging.version>1.9.11</structured-logging.version>
+        <structured-logging.version>1.9.25</structured-logging.version>
         <sdk-manager-java.version>1.5.17</sdk-manager-java.version>
         <api-sdk-manager-java-library.version>1.0.8</api-sdk-manager-java-library.version>
         <private-api-sdk-java.version>2.0.288</private-api-sdk-java.version>
@@ -73,6 +73,12 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-aop</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.yaml</groupId>
+                    <artifactId>snakeyaml</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
@@ -204,6 +210,10 @@
                 <exclusion>
                     <groupId>commons-fileupload</groupId>
                     <artifactId>commons-fileupload</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.eclipse.jetty</groupId>
+                    <artifactId>jetty-xml</artifactId>
                 </exclusion>
             </exclusions>
         </dependency>

--- a/src/it/java/uk/gov/companieshouse/company_appointments/tests/CompanyAppointmentControllerITest.java
+++ b/src/it/java/uk/gov/companieshouse/company_appointments/tests/CompanyAppointmentControllerITest.java
@@ -52,6 +52,7 @@ class CompanyAppointmentControllerITest {
     private static final String ERIC_IDENTITY = "ERIC-Identity";
     private static final String ERIC_IDENTITY_TYPE = "ERIC-Identity-Type";
     private static final String ERIC_AUTHORISED_KEY_PRIVILEGES = "ERIC-Authorised-Key-Privileges";
+    private static final String CONTEXT_ID = "context_id";
     @Autowired
     private MockMvc mockMvc;
 
@@ -84,6 +85,7 @@ class CompanyAppointmentControllerITest {
     void testReturn200OKIfOfficerIsFound() throws Exception {
         //when
         ResultActions result = mockMvc.perform(get("/company/{company_number}/appointments/{appointment_id}", COMPANY_NUMBER, "active_1")
+                .header(X_REQUEST_ID, CONTEXT_ID)
                 .header(ERIC_IDENTITY, "123")
                 .header(ERIC_IDENTITY_TYPE, "key")
                 .contentType(MediaType.APPLICATION_JSON)
@@ -103,8 +105,11 @@ class CompanyAppointmentControllerITest {
         // when
         ResultActions result = mockMvc
                 .perform(get("/company/{company_number}/appointments/{appointment_id}", COMPANY_NUMBER, "missing")
-                        .header(ERIC_IDENTITY, "123").header(ERIC_IDENTITY_TYPE, "oauth2")
-                        .contentType(MediaType.APPLICATION_JSON).accept(MediaType.APPLICATION_JSON));
+                        .header(X_REQUEST_ID, CONTEXT_ID)
+                        .header(ERIC_IDENTITY, "123")
+                        .header(ERIC_IDENTITY_TYPE, "oauth2")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .accept(MediaType.APPLICATION_JSON));
 
         // then
         result.andExpect(MockMvcResultMatchers.status().isNotFound());
@@ -131,6 +136,7 @@ class CompanyAppointmentControllerITest {
                 .activeCount(2)
                 .resignedCount(1)));
         ResultActions result = mockMvc.perform(get("/company/{company_number}/officers", COMPANY_NUMBER)
+                .header(X_REQUEST_ID, CONTEXT_ID)
                 .header(ERIC_IDENTITY, "123")
                 .header(ERIC_IDENTITY_TYPE, "key")
                 .contentType(MediaType.APPLICATION_JSON)
@@ -151,8 +157,11 @@ class CompanyAppointmentControllerITest {
         when(companyMetricsApiService.invokeGetMetricsApi(anyString())).thenReturn(new ApiResponse<>(200, null, metricsApi));
         ResultActions result = mockMvc
                 .perform(get("/company/{company_number}/officers", "87654321")
-                        .header(ERIC_IDENTITY, "123").header(ERIC_IDENTITY_TYPE, "oauth2")
-                        .contentType(MediaType.APPLICATION_JSON).accept(MediaType.APPLICATION_JSON));
+                        .header(X_REQUEST_ID, CONTEXT_ID)
+                        .header(ERIC_IDENTITY, "123")
+                        .header(ERIC_IDENTITY_TYPE, "oauth2")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .accept(MediaType.APPLICATION_JSON));
 
         // then
         result.andExpect(MockMvcResultMatchers.status().isNotFound());
@@ -167,6 +176,7 @@ class CompanyAppointmentControllerITest {
                 .activeCount(2)
                 .resignedCount(0)));
         ResultActions result = mockMvc.perform(get("/company/{company_number}/officers?filter=active", COMPANY_NUMBER)
+                .header(X_REQUEST_ID, CONTEXT_ID)
                 .header(ERIC_IDENTITY, "123")
                 .header(ERIC_IDENTITY_TYPE, "key")
                 .contentType(MediaType.APPLICATION_JSON)
@@ -189,6 +199,7 @@ class CompanyAppointmentControllerITest {
                 .activeCount(2)
                 .resignedCount(0)));
         ResultActions result = mockMvc.perform(get("/company/{company_number}/officers?order_by=appointed_on", COMPANY_NUMBER)
+                .header(X_REQUEST_ID, CONTEXT_ID)
                 .header(ERIC_IDENTITY, "123")
                 .header(ERIC_IDENTITY_TYPE, "key")
                 .contentType(MediaType.APPLICATION_JSON)
@@ -210,6 +221,7 @@ class CompanyAppointmentControllerITest {
                 .activeCount(2)
                 .resignedCount(1)));
         ResultActions result = mockMvc.perform(get("/company/{company_number}/officers?order_by=surname", COMPANY_NUMBER)
+                .header(X_REQUEST_ID, CONTEXT_ID)
                 .header(ERIC_IDENTITY, "123")
                 .header(ERIC_IDENTITY_TYPE, "key")
                 .contentType(MediaType.APPLICATION_JSON)

--- a/src/it/java/uk/gov/companieshouse/company_appointments/tests/CompanyAppointmentFullRecordControllerMongoUnavailableITest.java
+++ b/src/it/java/uk/gov/companieshouse/company_appointments/tests/CompanyAppointmentFullRecordControllerMongoUnavailableITest.java
@@ -23,6 +23,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.testcontainers.containers.MongoDBContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
+import uk.gov.companieshouse.api.appointment.ExternalData;
 import uk.gov.companieshouse.api.appointment.FullRecordCompanyOfficerApi;
 import uk.gov.companieshouse.company_appointments.CompanyAppointmentsApplication;
 import uk.gov.companieshouse.company_appointments.api.ResourceChangedApiService;
@@ -70,7 +71,8 @@ class CompanyAppointmentFullRecordControllerMongoUnavailableITest {
     void testPutNewAppointmentCompanyNameStatusMongoUnavailable() throws Exception {
         doThrow(new DataAccessException("..."){ }).when(fullRecordRepository).insertOrUpdate(any());
 
-        FullRecordCompanyOfficerApi requestBody = new  FullRecordCompanyOfficerApi();
+        FullRecordCompanyOfficerApi requestBody = new FullRecordCompanyOfficerApi()
+                .externalData(new ExternalData().companyNumber(COMPANY_NUMBER));
 
         mockMvc.perform(put(FULL_RECORD_PUT_ENDPOINT, COMPANY_NUMBER, APPOINTMENT_ID)
                         .contentType(MediaType.APPLICATION_JSON)

--- a/src/main/java/uk/gov/companieshouse/company_appointments/api/CompanyMetricsApiService.java
+++ b/src/main/java/uk/gov/companieshouse/company_appointments/api/CompanyMetricsApiService.java
@@ -9,6 +9,7 @@ import uk.gov.companieshouse.api.metrics.MetricsApi;
 import uk.gov.companieshouse.api.model.ApiResponse;
 import uk.gov.companieshouse.company_appointments.exception.NotFoundException;
 import uk.gov.companieshouse.company_appointments.exception.ServiceUnavailableException;
+import uk.gov.companieshouse.company_appointments.logging.DataMapHolder;
 import uk.gov.companieshouse.logging.Logger;
 
 @Service
@@ -30,6 +31,7 @@ public class CompanyMetricsApiService {
     public ApiResponse<MetricsApi> invokeGetMetricsApi(String companyNumber)
             throws ServiceUnavailableException, NotFoundException {
         InternalApiClient internalApiClient = apiClientService.getInternalApiClient();
+        internalApiClient.getHttpClient().setRequestId(DataMapHolder.getRequestId());
         internalApiClient.setBasePath(metricsUrl);
 
         PrivateCompanyMetricsGet companyMetricsGet =

--- a/src/main/java/uk/gov/companieshouse/company_appointments/api/CompanyMetricsApiService.java
+++ b/src/main/java/uk/gov/companieshouse/company_appointments/api/CompanyMetricsApiService.java
@@ -46,14 +46,14 @@ public class CompanyMetricsApiService {
             return companyMetricsGet.execute();
         } catch (ApiErrorResponseException exception) {
             if (exception.getStatusCode() == 404) {
-                logger.error(String.format("Metrics not found for company number %s", companyNumber), exception);
+                logger.error(String.format("Metrics not found for company number %s", companyNumber), exception, DataMapHolder.getLogMap());
                 throw new NotFoundException(exception.getMessage());
             } else {
-                logger.error("Error occurred while calling /company-metrics endpoint", exception);
+                logger.error("Error occurred while calling /company-metrics endpoint", exception, DataMapHolder.getLogMap());
                 throw new ServiceUnavailableException(exception.getMessage());
             }
         } catch (Exception exception) {
-            logger.error("Error occurred while calling /company-metrics endpoint", exception);
+            logger.error("Error occurred while calling /company-metrics endpoint", exception, DataMapHolder.getLogMap());
             throw new ServiceUnavailableException(exception.getMessage());
         }
     }

--- a/src/main/java/uk/gov/companieshouse/company_appointments/api/ResourceChangedApiService.java
+++ b/src/main/java/uk/gov/companieshouse/company_appointments/api/ResourceChangedApiService.java
@@ -8,6 +8,7 @@ import uk.gov.companieshouse.api.error.ApiErrorResponseException;
 import uk.gov.companieshouse.api.handler.chskafka.request.PrivateChangedResourcePost;
 import uk.gov.companieshouse.api.model.ApiResponse;
 import uk.gov.companieshouse.company_appointments.exception.ServiceUnavailableException;
+import uk.gov.companieshouse.company_appointments.logging.DataMapHolder;
 import uk.gov.companieshouse.company_appointments.mapper.ResourceChangedRequestMapper;
 import uk.gov.companieshouse.company_appointments.model.data.ResourceChangedRequest;
 import uk.gov.companieshouse.logging.Logger;
@@ -43,6 +44,8 @@ public class ResourceChangedApiService {
     @StreamEvents
     public ApiResponse<Void> invokeChsKafkaApi(ResourceChangedRequest resourceChangedRequest) throws ServiceUnavailableException {
         InternalApiClient internalApiClient = apiClientService.getInternalApiClient(); //NOSONAR
+        internalApiClient.getHttpClient().setRequestId(DataMapHolder.getRequestId());
+
         internalApiClient.setBasePath(chsKafkaUrl);
 
         PrivateChangedResourcePost changedResourcePost =
@@ -57,9 +60,9 @@ public class ResourceChangedApiService {
             return changedResourcePost.execute();
         } catch (ApiErrorResponseException ex) {
             if (!HttpStatus.valueOf(ex.getStatusCode()).is2xxSuccessful()) {
-                logger.error("Unsuccessful call to /resource-changed endpoint", ex);
+                logger.error("Unsuccessful call to /resource-changed endpoint", ex, DataMapHolder.getLogMap());
             } else {
-                logger.error("Error occurred while calling /resource-changed endpoint", ex);
+                logger.error("Error occurred while calling /resource-changed endpoint", ex, DataMapHolder.getLogMap());
             }
             throw new ServiceUnavailableException(ex.getMessage());
         }

--- a/src/main/java/uk/gov/companieshouse/company_appointments/api/ResourceChangedApiServiceAspect.java
+++ b/src/main/java/uk/gov/companieshouse/company_appointments/api/ResourceChangedApiServiceAspect.java
@@ -5,6 +5,7 @@ import org.aspectj.lang.annotation.Aspect;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
 import uk.gov.companieshouse.company_appointments.CompanyAppointmentsApplication;
+import uk.gov.companieshouse.company_appointments.logging.DataMapHolder;
 import uk.gov.companieshouse.logging.Logger;
 import uk.gov.companieshouse.logging.LoggerFactory;
 
@@ -17,7 +18,8 @@ public class ResourceChangedApiServiceAspect {
 
     @Around("@annotation(StreamEvents)")
     public Object checkStreamEventsEnabled() {
-            LOGGER.debug("Stream events disabled; not publishing change to chs-kafka-api");
+            LOGGER.debug("Stream events disabled; not publishing change to chs-kafka-api",
+                    DataMapHolder.getLogMap());
             return null;
     }
 }

--- a/src/main/java/uk/gov/companieshouse/company_appointments/controller/CompanyAppointmentController.java
+++ b/src/main/java/uk/gov/companieshouse/company_appointments/controller/CompanyAppointmentController.java
@@ -18,6 +18,7 @@ import uk.gov.companieshouse.company_appointments.CompanyAppointmentsApplication
 import uk.gov.companieshouse.company_appointments.exception.BadRequestException;
 import uk.gov.companieshouse.company_appointments.exception.NotFoundException;
 import uk.gov.companieshouse.company_appointments.exception.ServiceUnavailableException;
+import uk.gov.companieshouse.company_appointments.logging.DataMapHolder;
 import uk.gov.companieshouse.company_appointments.service.CompanyAppointmentService;
 import uk.gov.companieshouse.company_appointments.model.FetchAppointmentsRequest;
 import uk.gov.companieshouse.logging.Logger;
@@ -37,10 +38,13 @@ public class CompanyAppointmentController {
 
     @GetMapping(path = "/appointments/{appointment_id}")
     public ResponseEntity<OfficerSummary> fetchAppointment(@PathVariable("company_number") String companyNumber, @PathVariable("appointment_id") String appointmentID) {
+
+        DataMapHolder.get()
+                .companyNumber(companyNumber);
         try {
             return ResponseEntity.ok(companyAppointmentService.fetchAppointment(companyNumber, appointmentID));
         } catch (NotFoundException e) {
-            LOGGER.info(e.getMessage());
+            LOGGER.info(e.getMessage(), DataMapHolder.getLogMap());
             return ResponseEntity.notFound().build();
         }
     }
@@ -55,6 +59,9 @@ public class CompanyAppointmentController {
             @RequestParam(required = false, name = "register_view") Boolean registerView,
             @RequestParam(required = false, name = "register_type") String registerType) {
 
+        DataMapHolder.get()
+                .companyNumber(companyNumber);
+
         FetchAppointmentsRequest request = FetchAppointmentsRequest.Builder.builder()
                         .withCompanyNumber(companyNumber)
                         .withFilter(filter)
@@ -67,13 +74,13 @@ public class CompanyAppointmentController {
         try {
             return ResponseEntity.ok(companyAppointmentService.fetchAppointmentsForCompany(request));
         } catch (NotFoundException e) {
-            LOGGER.info(e.getMessage());
+            LOGGER.info(e.getMessage(), DataMapHolder.getLogMap());
             return ResponseEntity.notFound().build();
         } catch (BadRequestException e) {
-            LOGGER.info(e.getMessage());
+            LOGGER.info(e.getMessage(), DataMapHolder.getLogMap());
             return ResponseEntity.badRequest().build();
         } catch (ServiceUnavailableException e) {
-            LOGGER.info(e.getMessage());
+            LOGGER.info(e.getMessage(), DataMapHolder.getLogMap());
             return ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE).build();
         }
     }
@@ -82,6 +89,9 @@ public class CompanyAppointmentController {
     public ResponseEntity<Void> patchCompanyNameStatus(
             @PathVariable("company_number") String companyNumber,
             @RequestBody PatchAppointmentNameStatusApi requestBody) {
+
+        DataMapHolder.get()
+                .companyNumber(companyNumber);
         try {
             companyAppointmentService.patchCompanyNameStatus(companyNumber,
                     requestBody.getCompanyName(), requestBody.getCompanyStatus());
@@ -89,13 +99,13 @@ public class CompanyAppointmentController {
                     .header(HttpHeaders.LOCATION, String.format("/company/%s/officers", companyNumber))
                     .build();
         } catch (BadRequestException e) {
-            LOGGER.info(e.getMessage());
+            LOGGER.info(e.getMessage(), DataMapHolder.getLogMap());
             return ResponseEntity.badRequest().build();
         } catch (NotFoundException e) {
-            LOGGER.info(e.getMessage());
+            LOGGER.info(e.getMessage(), DataMapHolder.getLogMap());
             return ResponseEntity.notFound().build();
         } catch (ServiceUnavailableException e) {
-            LOGGER.info(e.getMessage());
+            LOGGER.info(e.getMessage(), DataMapHolder.getLogMap());
             return ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE).build();
         }
     }
@@ -105,6 +115,9 @@ public class CompanyAppointmentController {
             @PathVariable("company_number") String companyNumber,
             @PathVariable("appointment_id") String appointmentId,
             @Valid @RequestBody PatchAppointmentNameStatusApi requestBody) {
+
+        DataMapHolder.get()
+                .companyNumber(companyNumber);
         try {
             companyAppointmentService.patchNewAppointmentCompanyNameStatus(companyNumber, appointmentId,
                     requestBody.getCompanyName(), requestBody.getCompanyStatus());
@@ -112,13 +125,13 @@ public class CompanyAppointmentController {
                     .header(HttpHeaders.LOCATION, String.format("/company/%s/appointments/%s", companyNumber, appointmentId))
                     .build();
         } catch (BadRequestException e) {
-            LOGGER.info(e.getMessage());
+            LOGGER.info(e.getMessage(), DataMapHolder.getLogMap());
             return ResponseEntity.badRequest().build();
         } catch (NotFoundException e) {
-            LOGGER.info(e.getMessage());
+            LOGGER.info(e.getMessage(), DataMapHolder.getLogMap());
             return ResponseEntity.notFound().build();
         } catch (ServiceUnavailableException e) {
-            LOGGER.info(e.getMessage());
+            LOGGER.info(e.getMessage(), DataMapHolder.getLogMap());
             return ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE).build();
         }
     }

--- a/src/main/java/uk/gov/companieshouse/company_appointments/controller/CompanyAppointmentFullRecordController.java
+++ b/src/main/java/uk/gov/companieshouse/company_appointments/controller/CompanyAppointmentFullRecordController.java
@@ -1,5 +1,6 @@
 package uk.gov.companieshouse.company_appointments.controller;
 
+import java.util.Optional;
 import javax.validation.Valid;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
@@ -10,12 +11,12 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import uk.gov.companieshouse.api.appointment.FullRecordCompanyOfficerApi;
 import uk.gov.companieshouse.company_appointments.CompanyAppointmentsApplication;
 import uk.gov.companieshouse.company_appointments.exception.NotFoundException;
 import uk.gov.companieshouse.company_appointments.exception.ServiceUnavailableException;
+import uk.gov.companieshouse.company_appointments.logging.DataMapHolder;
 import uk.gov.companieshouse.company_appointments.model.view.CompanyAppointmentFullRecordView;
 import uk.gov.companieshouse.company_appointments.service.CompanyAppointmentFullRecordService;
 import uk.gov.companieshouse.logging.Logger;
@@ -38,45 +39,60 @@ public class CompanyAppointmentFullRecordController {
     public ResponseEntity<CompanyAppointmentFullRecordView> getAppointment(
             @PathVariable("company_number") String companyNumber,
             @PathVariable("appointment_id") String appointmentID) {
+
+        DataMapHolder.get()
+                .companyNumber(companyNumber);
         try {
             return ResponseEntity.ok(companyAppointmentService.getAppointment(companyNumber, appointmentID));
         } catch (NotFoundException e) {
-            LOGGER.info(e.getMessage());
+            LOGGER.info(e.getMessage(), DataMapHolder.getLogMap());
             return ResponseEntity.notFound().build();
         }
     }
 
     @PutMapping(consumes = "application/json")
     public ResponseEntity<Void> submitOfficerData(
-            @RequestHeader("x-request-id") String contextId,
             @Valid @RequestBody final FullRecordCompanyOfficerApi companyAppointmentData) {
         try {
-            companyAppointmentService.upsertAppointmentDelta(contextId, companyAppointmentData);
+            DataMapHolder.get()
+                    .companyNumber(extractCompanyNumber(companyAppointmentData));
+
+            companyAppointmentService.upsertAppointmentDelta(companyAppointmentData);
             return ResponseEntity.ok().build();
         } catch (ServiceUnavailableException e) {
-            LOGGER.info(e.getMessage());
+            LOGGER.info(e.getMessage(), DataMapHolder.getLogMap());
             return ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE).build();
         } catch (NotFoundException ex) {
-            LOGGER.info(ex.getMessage());
+            LOGGER.info(ex.getMessage(), DataMapHolder.getLogMap());
             return ResponseEntity.status(HttpStatus.NOT_FOUND).build();
+        } catch (IllegalArgumentException ex) {
+            LOGGER.info(ex.getMessage(), DataMapHolder.getLogMap());
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).build();
         }
     }
 
     @DeleteMapping(path = "/delete")
     public ResponseEntity<Void> deleteOfficerData(
-            @RequestHeader("x-request-id") String contextId,
             @PathVariable("company_number") String companyNumber,
             @PathVariable("appointment_id") String appointmentId) {
+        DataMapHolder.get()
+                .companyNumber(companyNumber);
         try {
-            companyAppointmentService.deleteAppointmentDelta(contextId, companyNumber, appointmentId);
+            companyAppointmentService.deleteAppointmentDelta(companyNumber, appointmentId);
             return ResponseEntity.ok().build();
         } catch (NotFoundException e) {
-            LOGGER.info(e.getMessage());
+            LOGGER.info(e.getMessage(), DataMapHolder.getLogMap());
             return ResponseEntity.notFound().build();
         } catch (ServiceUnavailableException e) {
-            LOGGER.info(e.getMessage());
+            LOGGER.info(e.getMessage(), DataMapHolder.getLogMap());
             return ResponseEntity.status(HttpStatus.SERVICE_UNAVAILABLE).build();
         }
     }
 
+    private static String extractCompanyNumber(FullRecordCompanyOfficerApi companyAppointmentData) {
+        return Optional.ofNullable(companyAppointmentData.getExternalData())
+                .map(ext -> Optional.ofNullable(ext.getCompanyNumber())
+                        .orElseThrow(() -> new IllegalArgumentException("Missing company number")))
+                .orElseThrow(() -> new IllegalArgumentException("Missing external data block"));
+    }
 }

--- a/src/main/java/uk/gov/companieshouse/company_appointments/interceptor/AuthenticationInterceptor.java
+++ b/src/main/java/uk/gov/companieshouse/company_appointments/interceptor/AuthenticationInterceptor.java
@@ -1,6 +1,5 @@
 package uk.gov.companieshouse.company_appointments.interceptor;
 
-import java.util.HashMap;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import org.apache.commons.lang.StringUtils;
@@ -8,6 +7,7 @@ import org.apache.commons.lang3.ArrayUtils;
 import org.springframework.http.HttpMethod;
 import org.springframework.stereotype.Component;
 import org.springframework.web.servlet.HandlerInterceptor;
+import uk.gov.companieshouse.company_appointments.logging.DataMapHolder;
 import uk.gov.companieshouse.logging.Logger;
 
 @Component
@@ -30,18 +30,18 @@ public class AuthenticationInterceptor implements HandlerInterceptor {
 
         if (StringUtils.isEmpty(request.getHeader(ERIC_IDENTITY)) ||
                 (StringUtils.isEmpty(identityType) || isInvalidIdentityType(identityType))) {
-            logger.infoRequest(request, "User not authenticated", new HashMap<>());
+            logger.infoRequest(request, "User not authenticated", DataMapHolder.getLogMap());
             response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
             return false;
         }
 
         if (!isKeyAuthorised(request, identityType)) {
-            logger.info("Supplied key does not have sufficient privilege for the action");
+            logger.info("Supplied key does not have sufficient privilege for the action", DataMapHolder.getLogMap());
             response.setStatus(HttpServletResponse.SC_FORBIDDEN);
             return false;
         }
 
-        logger.debugRequest(request, "User authenticated", new HashMap<>());
+        logger.debugRequest(request, "User authenticated", DataMapHolder.getLogMap());
         return true;
     }
 

--- a/src/main/java/uk/gov/companieshouse/company_appointments/interceptor/FullRecordAuthenticationInterceptor.java
+++ b/src/main/java/uk/gov/companieshouse/company_appointments/interceptor/FullRecordAuthenticationInterceptor.java
@@ -1,14 +1,13 @@
 package uk.gov.companieshouse.company_appointments.interceptor;
 
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.Map;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import org.apache.http.HttpStatus;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import org.springframework.web.servlet.HandlerInterceptor;
+import uk.gov.companieshouse.company_appointments.logging.DataMapHolder;
 import uk.gov.companieshouse.logging.Logger;
 
 @Component
@@ -16,7 +15,6 @@ public class FullRecordAuthenticationInterceptor implements HandlerInterceptor {
     private final AuthenticationHelper authHelper;
     private final Logger logger;
 
-    @Autowired
     public FullRecordAuthenticationInterceptor(AuthenticationHelper authHelper, Logger logger) {
         this.authHelper = authHelper;
         this.logger = logger;
@@ -25,7 +23,7 @@ public class FullRecordAuthenticationInterceptor implements HandlerInterceptor {
     @Override
     public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) {
         final String identityType = authHelper.getAuthorisedIdentityType(request);
-        Map<String, Object> logMap = new HashMap<>();
+        Map<String, Object> logMap = DataMapHolder.getLogMap();
 
         if (authHelper.isOauth2IdentityType(identityType)) {
             String companyNumber = request.getRequestURI().split("/")[2];
@@ -59,5 +57,4 @@ public class FullRecordAuthenticationInterceptor implements HandlerInterceptor {
 
         return true;
     }
-
 }

--- a/src/main/java/uk/gov/companieshouse/company_appointments/interceptor/RequestLoggingInterceptor.java
+++ b/src/main/java/uk/gov/companieshouse/company_appointments/interceptor/RequestLoggingInterceptor.java
@@ -34,4 +34,11 @@ public class RequestLoggingInterceptor implements HandlerInterceptor, RequestLog
         logEndRequestProcessing(request, response, logger);
         DataMapHolder.clear();
     }
+
+    @Override
+    public void afterCompletion(HttpServletRequest request, HttpServletResponse response,
+            Object handler, Exception ex) throws Exception {
+        DataMapHolder.clear();
+        HandlerInterceptor.super.afterCompletion(request, response, handler, ex);
+    }
 }

--- a/src/main/java/uk/gov/companieshouse/company_appointments/interceptor/RequestLoggingInterceptor.java
+++ b/src/main/java/uk/gov/companieshouse/company_appointments/interceptor/RequestLoggingInterceptor.java
@@ -3,20 +3,19 @@ package uk.gov.companieshouse.company_appointments.interceptor;
 import static uk.gov.companieshouse.logging.util.LogContextProperties.REQUEST_ID;
 
 import java.util.Optional;
+import java.util.UUID;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import org.slf4j.MDC;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.servlet.HandlerInterceptor;
 import org.springframework.web.servlet.ModelAndView;
+import uk.gov.companieshouse.company_appointments.logging.DataMapHolder;
 import uk.gov.companieshouse.logging.Logger;
 import uk.gov.companieshouse.logging.util.RequestLogger;
 
 public class RequestLoggingInterceptor implements HandlerInterceptor, RequestLogger {
 
-    private Logger logger;
+    private final Logger logger;
 
-    @Autowired
     public RequestLoggingInterceptor(Logger logger) {
         this.logger = logger;
     }
@@ -24,16 +23,15 @@ public class RequestLoggingInterceptor implements HandlerInterceptor, RequestLog
     @Override
     public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) {
         logStartRequestProcessing(request, logger);
-        Optional.ofNullable(request.getHeader("x-request-id"))
-                .ifPresentOrElse(header -> MDC.put(REQUEST_ID.value(), header),
-                        () -> MDC.remove(REQUEST_ID.value()));
-
+        DataMapHolder.initialise(Optional
+                .ofNullable(request.getHeader(REQUEST_ID.value()))
+                .orElse(UUID.randomUUID().toString()));
         return true;
     }
 
     @Override
     public void postHandle(HttpServletRequest request, HttpServletResponse response, Object handler, ModelAndView modelAndView) {
         logEndRequestProcessing(request, response, logger);
-        MDC.remove(REQUEST_ID.value());
+        DataMapHolder.clear();
     }
 }

--- a/src/main/java/uk/gov/companieshouse/company_appointments/logging/DataMapHolder.java
+++ b/src/main/java/uk/gov/companieshouse/company_appointments/logging/DataMapHolder.java
@@ -1,0 +1,44 @@
+package uk.gov.companieshouse.company_appointments.logging;
+
+import java.util.Map;
+import uk.gov.companieshouse.logging.util.DataMap;
+import uk.gov.companieshouse.logging.util.DataMap.Builder;
+
+public class DataMapHolder {
+
+    private static final ThreadLocal<DataMap.Builder> DATAMAP_BUILDER = ThreadLocal.withInitial(
+            () -> new Builder().requestId("uninitialised"));
+
+    private DataMapHolder() {
+    }
+
+    public static void initialise(String requestId) {
+        DATAMAP_BUILDER.get().requestId(requestId);
+    }
+
+    public static void clear() {
+        DATAMAP_BUILDER.remove();
+    }
+
+    public static DataMap.Builder get() {
+        return DATAMAP_BUILDER.get();
+    }
+
+    /**
+     * Used to populate the log context map in structured logging. e.g.
+     * <code>
+     * logger.error("Something happened", DataMapHolder.getLogMap());
+     * </code>
+     *
+     * @return Structured logging DataMap.Builder
+     */
+    public static Map<String, Object> getLogMap() {
+        return DATAMAP_BUILDER.get()
+                .build()
+                .getLogMap();
+    }
+
+    public static String getRequestId() {
+        return (String) getLogMap().get("request_id");
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/company_appointments/mapper/CompanyAppointmentMapper.java
+++ b/src/main/java/uk/gov/companieshouse/company_appointments/mapper/CompanyAppointmentMapper.java
@@ -22,6 +22,7 @@ import uk.gov.companieshouse.api.appointment.OfficerSummary;
 import uk.gov.companieshouse.api.appointment.OfficerSummary.OfficerRoleEnum;
 import uk.gov.companieshouse.api.appointment.PrincipalOfficeAddress;
 import uk.gov.companieshouse.company_appointments.CompanyAppointmentsApplication;
+import uk.gov.companieshouse.company_appointments.logging.DataMapHolder;
 import uk.gov.companieshouse.company_appointments.model.data.CompanyAppointmentDocument;
 import uk.gov.companieshouse.company_appointments.model.data.DeltaContactDetails;
 import uk.gov.companieshouse.company_appointments.model.data.DeltaFormerNames;
@@ -46,7 +47,7 @@ public class CompanyAppointmentMapper {
     }
 
     public OfficerSummary map(CompanyAppointmentDocument companyAppointment, boolean registerView) {
-        LOGGER.debug("Mapping data for appointment: " + companyAppointment.getId());
+        LOGGER.debug("Mapping data for appointment: " + companyAppointment.getId(), DataMapHolder.getLogMap());
 
         DeltaOfficerData data = Optional.ofNullable(companyAppointment.getData())
                 .orElseThrow(() -> new IllegalArgumentException("Missing data element"));
@@ -77,7 +78,7 @@ public class CompanyAppointmentMapper {
                 .contactDetails(mapContactDetails(data.getContactDetails()))
                 .isPre1992Appointment(data.getPre1992Appointment())
                 .personNumber(data.getPersonNumber());
-        LOGGER.debug("Mapped data for appointment: " + companyAppointment.getId());
+        LOGGER.debug("Mapped data for appointment: " + companyAppointment.getId(), DataMapHolder.getLogMap());
         return result;
     }
 

--- a/src/main/java/uk/gov/companieshouse/company_appointments/officerappointments/OfficerAppointmentsController.java
+++ b/src/main/java/uk/gov/companieshouse/company_appointments/officerappointments/OfficerAppointmentsController.java
@@ -7,6 +7,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestParam;
 import uk.gov.companieshouse.api.officer.AppointmentList;
 import uk.gov.companieshouse.company_appointments.exception.BadRequestException;
+import uk.gov.companieshouse.company_appointments.logging.DataMapHolder;
 import uk.gov.companieshouse.logging.Logger;
 
 @Controller
@@ -26,14 +27,16 @@ class OfficerAppointmentsController {
             @RequestParam(value = "start_index", required = false) Integer startIndex,
             @RequestParam(value = "items_per_page", required = false) Integer itemsPerPage) {
         try {
+            DataMapHolder.get()
+                    .officerId(officerId);
             return service.getOfficerAppointments(new OfficerAppointmentsRequest(officerId, filter, startIndex, itemsPerPage))
                     .map(ResponseEntity::ok)
                     .orElseGet(() -> {
-                        logger.error(String.format("No appointments found for officer ID %s", officerId));
+                        logger.error(String.format("No appointments found for officer ID %s", officerId), DataMapHolder.getLogMap());
                         return ResponseEntity.notFound().build();
                     });
         } catch (BadRequestException ex) {
-            logger.error(String.format("Invalid filter parameter supplied: %s, officer ID %s", filter, officerId));
+            logger.error(String.format("Invalid filter parameter supplied: %s, officer ID %s", filter, officerId), DataMapHolder.getLogMap());
             return ResponseEntity.badRequest().build();
         }
     }

--- a/src/main/java/uk/gov/companieshouse/company_appointments/roles/DirectorRoles.java
+++ b/src/main/java/uk/gov/companieshouse/company_appointments/roles/DirectorRoles.java
@@ -8,7 +8,7 @@ public enum DirectorRoles {
     NOMINEE_DIRECTOR("nominee-director"),
     CORPORATE_NOMINEE_DIRECTOR("corporate-nominee-director");
 
-    private String role;
+    private final String role;
 
     DirectorRoles(String role){
         this.role = role;

--- a/src/main/java/uk/gov/companieshouse/company_appointments/roles/SecretarialRoles.java
+++ b/src/main/java/uk/gov/companieshouse/company_appointments/roles/SecretarialRoles.java
@@ -8,7 +8,7 @@ public enum SecretarialRoles{
     NOMINEE_SECRETARY("nominee-secretary"),
     CORPORATE_NOMINEE_SECRETARY("corporate-nominee-secretary");
 
-    private String role;
+    private final String role;
 
     SecretarialRoles(String role){
         this.role = role;

--- a/src/main/java/uk/gov/companieshouse/company_appointments/service/CompanyAppointmentService.java
+++ b/src/main/java/uk/gov/companieshouse/company_appointments/service/CompanyAppointmentService.java
@@ -167,7 +167,7 @@ public class CompanyAppointmentService {
                                 companyNumber));
             }
             LOGGER.debug(String.format("Appointments for company [%s] updated successfully",
-                    companyNumber));
+                    companyNumber), DataMapHolder.getLogMap());
         } catch (DataAccessException ex) {
             throw new ServiceUnavailableException(
                     String.format(PATCH_APPOINTMENTS_ERROR_MESSAGE + "error connecting to MongoDB.",
@@ -199,7 +199,7 @@ public class CompanyAppointmentService {
                                 companyNumber));
             }
             LOGGER.debug(String.format("Appointment [%s] for company [%s] updated successfully", appointmentId,
-                    companyNumber));
+                    companyNumber), DataMapHolder.getLogMap());
         } catch (DataAccessException ex) {
             throw new ServiceUnavailableException(
                     String.format(PATCH_APPOINTMENT_ERROR_MESSAGE + "error connecting to MongoDB.",

--- a/src/main/java/uk/gov/companieshouse/company_appointments/service/CompanyAppointmentService.java
+++ b/src/main/java/uk/gov/companieshouse/company_appointments/service/CompanyAppointmentService.java
@@ -1,7 +1,6 @@
 package uk.gov.companieshouse.company_appointments.service;
 
 import static org.apache.commons.lang3.StringUtils.isBlank;
-import static uk.gov.companieshouse.logging.util.LogContextProperties.REQUEST_ID;
 
 import java.time.Clock;
 import java.time.Instant;
@@ -10,7 +9,6 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
-import org.slf4j.MDC;
 import org.springframework.dao.DataAccessException;
 import org.springframework.stereotype.Service;
 import uk.gov.companieshouse.GenerateEtagUtil;
@@ -25,6 +23,7 @@ import uk.gov.companieshouse.company_appointments.api.CompanyMetricsApiService;
 import uk.gov.companieshouse.company_appointments.exception.BadRequestException;
 import uk.gov.companieshouse.company_appointments.exception.NotFoundException;
 import uk.gov.companieshouse.company_appointments.exception.ServiceUnavailableException;
+import uk.gov.companieshouse.company_appointments.logging.DataMapHolder;
 import uk.gov.companieshouse.company_appointments.mapper.CompanyAppointmentMapper;
 import uk.gov.companieshouse.company_appointments.model.FetchAppointmentsRequest;
 import uk.gov.companieshouse.company_appointments.model.data.CompanyAppointmentDocument;
@@ -37,8 +36,8 @@ import uk.gov.companieshouse.logging.LoggerFactory;
 public class CompanyAppointmentService {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(CompanyAppointmentsApplication.APPLICATION_NAMESPACE);
-    private static final String PATCH_APPOINTMENT_ERROR_MESSAGE = "Request failed for company [%s] with appointment [%s], contextId: [%s]: ";
-    private static final String PATCH_APPOINTMENTS_ERROR_MESSAGE = "Request failed for company [%s], contextId: [%s]: ";
+    private static final String PATCH_APPOINTMENT_ERROR_MESSAGE = "Request failed for company [%s] with appointment [%s]: ";
+    private static final String PATCH_APPOINTMENTS_ERROR_MESSAGE = "Request failed for company [%s]: ";
     private static final int DEFAULT_ITEMS_PER_PAGE = 35;
     private static final int DEFAULT_START_INDEX = 0;
     private static final String ACTIVE = "active";
@@ -65,7 +64,8 @@ public class CompanyAppointmentService {
     }
 
     public OfficerSummary fetchAppointment(String companyNumber, String appointmentID) throws NotFoundException {
-        LOGGER.debug(String.format("Fetching appointment [%s] for company [%s]", appointmentID, companyNumber));
+        LOGGER.debug(String.format("Fetching appointment [%s] for company [%s]", appointmentID, companyNumber),
+                DataMapHolder.getLogMap());
         CompanyAppointmentDocument appointmentDocument = companyAppointmentRepository.readByCompanyNumberAndAppointmentID(
                         companyNumber, appointmentID)
                 .orElseThrow(() -> new NotFoundException(
@@ -88,7 +88,7 @@ public class CompanyAppointmentService {
         boolean filterEnabled = checkFilterEnabled(filter, companyNumber);
 
         LOGGER.debug(
-                String.format("Fetching appointments for company [%s] with order by [%s]", companyNumber, orderBy));
+                String.format("Fetching appointments for company [%s] with order by [%s]", companyNumber, orderBy), DataMapHolder.getLogMap());
 
         MetricsApi metricsApi = companyMetricsApiService.invokeGetMetricsApi(companyNumber).getData();
 
@@ -145,16 +145,16 @@ public class CompanyAppointmentService {
             throws BadRequestException, NotFoundException, ServiceUnavailableException {
         if (isBlank(companyName) || isBlank(companyStatus)) {
             throw new BadRequestException(String.format(PATCH_APPOINTMENTS_ERROR_MESSAGE +
-                    "company name and/or company status missing.", companyNumber, getContextId()));
+                    "company name and/or company status missing.", companyNumber));
         }
         if (!companyStatusValidator.isValidCompanyStatus(companyStatus)) {
             throw new BadRequestException(String.format(PATCH_APPOINTMENTS_ERROR_MESSAGE +
-                    "invalid company status provided.", companyNumber, getContextId()));
+                    "invalid company status provided.", companyNumber));
         }
 
         LOGGER.debug(String.format(
-                "Patching company name: [%s] and company status [%s] for appointments in company [%s], contextID [%s]",
-                companyName, companyStatus, companyNumber, getContextId()));
+                "Patching company name: [%s] and company status [%s] for appointments in company [%s]",
+                companyName, companyStatus, companyNumber), DataMapHolder.getLogMap());
 
         try {
             long updatedCount = companyAppointmentRepository.patchAppointmentNameStatusInCompany(
@@ -171,7 +171,7 @@ public class CompanyAppointmentService {
         } catch (DataAccessException ex) {
             throw new ServiceUnavailableException(
                     String.format(PATCH_APPOINTMENTS_ERROR_MESSAGE + "error connecting to MongoDB.",
-                            companyNumber, getContextId()));
+                            companyNumber));
         }
     }
 
@@ -179,18 +179,16 @@ public class CompanyAppointmentService {
             String companyStatus) throws BadRequestException, NotFoundException, ServiceUnavailableException {
         if (isBlank(companyName) || isBlank(companyStatus)) {
             throw new BadRequestException(String.format(PATCH_APPOINTMENT_ERROR_MESSAGE +
-                            "company name and/or company status missing.", companyNumber, appointmentId,
-                    getContextId()));
+                            "company name and/or company status missing.", companyNumber, appointmentId));
         }
         if (!companyStatusValidator.isValidCompanyStatus(companyStatus)) {
             throw new BadRequestException(String.format(PATCH_APPOINTMENT_ERROR_MESSAGE +
-                            "invalid company status provided.", companyNumber, appointmentId,
-                    getContextId()));
+                            "invalid company status provided.", companyNumber, appointmentId));
         }
 
         LOGGER.debug(String.format(
                 "Patching company name: [%s] and company status [%s] for company [%s] with appointment [%s]",
-                companyName, companyStatus, companyNumber, appointmentId));
+                companyName, companyStatus, companyNumber, appointmentId), DataMapHolder.getLogMap());
         try {
             boolean isUpdated =
                     companyAppointmentRepository.patchAppointmentNameStatus(appointmentId, companyName, companyStatus,
@@ -205,7 +203,7 @@ public class CompanyAppointmentService {
         } catch (DataAccessException ex) {
             throw new ServiceUnavailableException(
                     String.format(PATCH_APPOINTMENT_ERROR_MESSAGE + "error connecting to MongoDB.",
-                            companyNumber, appointmentId, getContextId()));
+                            companyNumber, appointmentId));
         }
     }
 
@@ -221,10 +219,6 @@ public class CompanyAppointmentService {
         } else {
             return false;
         }
-    }
-
-    private String getContextId() {
-        return MDC.get(REQUEST_ID.value());
     }
 
     private static class Counts {

--- a/src/main/java/uk/gov/companieshouse/company_appointments/service/CompanyProfileClient.java
+++ b/src/main/java/uk/gov/companieshouse/company_appointments/service/CompanyProfileClient.java
@@ -11,6 +11,7 @@ import uk.gov.companieshouse.company_appointments.exception.ServiceUnavailableEx
 
 import java.util.Optional;
 import java.util.function.Supplier;
+import uk.gov.companieshouse.company_appointments.logging.DataMapHolder;
 
 @Component
 public class CompanyProfileClient {
@@ -23,6 +24,7 @@ public class CompanyProfileClient {
 
     public Optional<Data> getCompanyProfile(String companyNumber) throws URIValidationException, NotFoundException, ServiceUnavailableException {
         InternalApiClient client = internalApiClientSupplier.get();
+        client.getHttpClient().setRequestId(DataMapHolder.getRequestId());
 
         try {
             return Optional.ofNullable(client.privateCompanyResourceHandler()

--- a/src/main/java/uk/gov/companieshouse/company_appointments/service/DeltaAppointmentTransformerAspect.java
+++ b/src/main/java/uk/gov/companieshouse/company_appointments/service/DeltaAppointmentTransformerAspect.java
@@ -9,6 +9,7 @@ import uk.gov.companieshouse.company_appointments.CompanyAppointmentsApplication
 import uk.gov.companieshouse.company_appointments.exception.FailedToTransformException;
 import uk.gov.companieshouse.company_appointments.exception.NotFoundException;
 import uk.gov.companieshouse.company_appointments.exception.ServiceUnavailableException;
+import uk.gov.companieshouse.company_appointments.logging.DataMapHolder;
 import uk.gov.companieshouse.company_appointments.model.data.CompanyAppointmentDocument;
 import uk.gov.companieshouse.logging.Logger;
 import uk.gov.companieshouse.logging.LoggerFactory;
@@ -44,7 +45,8 @@ public class DeltaAppointmentTransformerAspect {
                                 document.companyName(companyName)
                                         .companyStatus(companyStatus);
 
-                                LOGGER.debug(String.format("Company name [%s] and company status [%s] set on appointment [%s]", companyName, companyStatus, appointmentId));
+                                LOGGER.debug(String.format("Company name [%s] and company status [%s] set on appointment [%s]",
+                                        companyName, companyStatus, appointmentId), DataMapHolder.getLogMap());
                             },
                             () -> {
                                 throw new IllegalArgumentException(COMPANY_PROFILE_NOT_FOUND);

--- a/src/test/java/uk/gov/companieshouse/company_appointments/CompanyProfileClientTest.java
+++ b/src/test/java/uk/gov/companieshouse/company_appointments/CompanyProfileClientTest.java
@@ -2,6 +2,7 @@ package uk.gov.companieshouse.company_appointments;
 
 import com.google.api.client.http.HttpHeaders;
 import com.google.api.client.http.HttpResponseException;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -16,6 +17,7 @@ import uk.gov.companieshouse.api.error.ApiErrorResponseException;
 import uk.gov.companieshouse.api.handler.company.PrivateCompanyResourceHandler;
 import uk.gov.companieshouse.api.handler.company.request.PrivateCompanyFullProfileGet;
 import uk.gov.companieshouse.api.handler.exception.URIValidationException;
+import uk.gov.companieshouse.api.http.HttpClient;
 import uk.gov.companieshouse.api.model.ApiResponse;
 import uk.gov.companieshouse.company_appointments.exception.NotFoundException;
 import uk.gov.companieshouse.company_appointments.exception.ServiceUnavailableException;
@@ -39,12 +41,19 @@ class CompanyProfileClientTest {
     @Mock
     private InternalApiClient internalApiClient;
     @Mock
+    private HttpClient httpClient;
+    @Mock
     private PrivateCompanyResourceHandler privateCompanyResourceHandler;
     @Mock
     private PrivateCompanyFullProfileGet privateCompanyFullProfileGet;
 
     @InjectMocks
     private CompanyProfileClient companyProfileClient;
+
+    @BeforeEach
+    void setup() {
+        when(internalApiClient.getHttpClient()).thenReturn(httpClient);
+    }
 
     @Test
     @DisplayName("Successfully returns data")

--- a/src/test/java/uk/gov/companieshouse/company_appointments/DeltaAppointmentTransformerAspectTest.java
+++ b/src/test/java/uk/gov/companieshouse/company_appointments/DeltaAppointmentTransformerAspectTest.java
@@ -1,5 +1,6 @@
 package uk.gov.companieshouse.company_appointments;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -11,6 +12,7 @@ import uk.gov.companieshouse.api.company.Data;
 import uk.gov.companieshouse.company_appointments.exception.FailedToTransformException;
 import uk.gov.companieshouse.company_appointments.exception.NotFoundException;
 import uk.gov.companieshouse.company_appointments.exception.ServiceUnavailableException;
+import uk.gov.companieshouse.company_appointments.logging.DataMapHolder;
 import uk.gov.companieshouse.company_appointments.model.data.CompanyAppointmentDocument;
 import uk.gov.companieshouse.company_appointments.service.DeltaAppointmentTransformerAspect;
 import uk.gov.companieshouse.company_appointments.service.CompanyProfileClient;
@@ -31,12 +33,19 @@ class DeltaAppointmentTransformerAspectTest {
     private static final String APPOINTMENT_ID = "123456";
     private static final String COMPANY_NAME = "company name";
     private static final String COMPANY_STATUS = "company status";
+    private static final String CONTEXT_ID = "contextId";
+
 
     @InjectMocks
     private DeltaAppointmentTransformerAspect aspect;
 
     @Mock
     private CompanyProfileClient companyProfileClient;
+
+    @BeforeEach
+    void setup() {
+        DataMapHolder.initialise(CONTEXT_ID);
+    }
 
     @Test
     @DisplayName("Successfully populate company name and status fields")

--- a/src/test/java/uk/gov/companieshouse/company_appointments/api/CompanyMetricsApiServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/company_appointments/api/CompanyMetricsApiServiceTest.java
@@ -17,6 +17,7 @@ import uk.gov.companieshouse.api.error.ApiErrorResponseException;
 import uk.gov.companieshouse.api.handler.exception.URIValidationException;
 import uk.gov.companieshouse.api.handler.metrics.PrivateCompanyMetricsResourceHandler;
 import uk.gov.companieshouse.api.handler.metrics.request.PrivateCompanyMetricsGet;
+import uk.gov.companieshouse.api.http.HttpClient;
 import uk.gov.companieshouse.api.metrics.MetricsApi;
 import uk.gov.companieshouse.api.model.ApiResponse;
 import uk.gov.companieshouse.company_appointments.exception.ServiceUnavailableException;
@@ -39,11 +40,15 @@ class CompanyMetricsApiServiceTest {
     PrivateCompanyMetricsGet get;
     @Mock
     Logger logger;
+    @Mock
+    private HttpClient httpClient;
+
 
     @BeforeEach
     void setup() {
         when(apiClientService.getInternalApiClient()).thenReturn(internalApiClient);
         when(internalApiClient.privateCompanyMetricsResourceHandler()).thenReturn(handler);
+        when(internalApiClient.getHttpClient()).thenReturn(httpClient);
         when(handler.getCompanyMetrics(anyString())).thenReturn(get);
 
         service = new CompanyMetricsApiService("url", logger, apiClientService);

--- a/src/test/java/uk/gov/companieshouse/company_appointments/api/ResourceChangedApiServiceAspectFeatureFlagDisabledITest.java
+++ b/src/test/java/uk/gov/companieshouse/company_appointments/api/ResourceChangedApiServiceAspectFeatureFlagDisabledITest.java
@@ -4,6 +4,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -14,6 +15,7 @@ import uk.gov.companieshouse.api.chskafka.ChangedResource;
 import uk.gov.companieshouse.api.error.ApiErrorResponseException;
 import uk.gov.companieshouse.api.handler.chskafka.PrivateChangedResourceHandler;
 import uk.gov.companieshouse.api.handler.chskafka.request.PrivateChangedResourcePost;
+import uk.gov.companieshouse.api.http.HttpClient;
 import uk.gov.companieshouse.api.model.ApiResponse;
 import uk.gov.companieshouse.company_appointments.exception.ServiceUnavailableException;
 import uk.gov.companieshouse.company_appointments.mapper.ResourceChangedRequestMapper;
@@ -42,6 +44,13 @@ class ResourceChangedApiServiceAspectFeatureFlagDisabledITest {
     private PrivateChangedResourcePost changedResourcePost;
     @Mock
     private ApiResponse<Void> response;
+    @Mock
+    private HttpClient httpClient;
+
+    @BeforeEach
+    void setup() {
+        when(internalApiClient.getHttpClient()).thenReturn(httpClient);
+    }
 
     @Test
     void testThatKafkaApiShouldBeCalledWhenFeatureFlagDisabled()

--- a/src/test/java/uk/gov/companieshouse/company_appointments/api/ResourceChangedApiServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/company_appointments/api/ResourceChangedApiServiceTest.java
@@ -9,6 +9,7 @@ import static org.mockito.Mockito.when;
 import com.google.api.client.http.HttpHeaders;
 import com.google.api.client.http.HttpResponseException;
 import java.util.stream.Stream;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Named;
 import org.junit.jupiter.api.Test;
@@ -25,6 +26,7 @@ import uk.gov.companieshouse.api.chskafka.ChangedResource;
 import uk.gov.companieshouse.api.error.ApiErrorResponseException;
 import uk.gov.companieshouse.api.handler.chskafka.PrivateChangedResourceHandler;
 import uk.gov.companieshouse.api.handler.chskafka.request.PrivateChangedResourcePost;
+import uk.gov.companieshouse.api.http.HttpClient;
 import uk.gov.companieshouse.api.model.ApiResponse;
 import uk.gov.companieshouse.company_appointments.exception.ServiceUnavailableException;
 import uk.gov.companieshouse.company_appointments.mapper.ResourceChangedRequestMapper;
@@ -61,8 +63,17 @@ class ResourceChangedApiServiceTest {
     @Mock
     private ChangedResource changedResource;
 
+    @Mock
+    private HttpClient httpClient;
+
+
     @InjectMocks
     private ResourceChangedApiService resourceChangedApiService;
+
+    @BeforeEach
+    void setup() {
+        when(internalApiClient.getHttpClient()).thenReturn(httpClient);
+    }
 
     @Test
     @DisplayName("Test should successfully invoke chs-kafka-api")

--- a/src/test/java/uk/gov/companieshouse/company_appointments/model/transformer/DeltaAppointmentTransformerIntegrationTest.java
+++ b/src/test/java/uk/gov/companieshouse/company_appointments/model/transformer/DeltaAppointmentTransformerIntegrationTest.java
@@ -1,5 +1,6 @@
 package uk.gov.companieshouse.company_appointments.model.transformer;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -13,6 +14,7 @@ import uk.gov.companieshouse.api.appointment.FullRecordCompanyOfficerApi;
 import uk.gov.companieshouse.api.appointment.InternalData;
 import uk.gov.companieshouse.api.appointment.ItemLinkTypes;
 import uk.gov.companieshouse.api.appointment.SensitiveData;
+import uk.gov.companieshouse.company_appointments.logging.DataMapHolder;
 import uk.gov.companieshouse.company_appointments.model.data.CompanyAppointmentDocument;
 import uk.gov.companieshouse.company_appointments.model.data.DeltaOfficerData;
 import uk.gov.companieshouse.company_appointments.model.data.DeltaSensitiveData;
@@ -36,6 +38,7 @@ class DeltaAppointmentTransformerIntegrationTest {
     private static final String COMPANY_NAME = "companyName";
     private static final String COMPANY_STATUS = "companyStatus";
     private static final String COMPANY_NUMBER = "12345678";
+    private static final String CONTEXT_ID = "contextId";
 
     @Autowired
     private DeltaAppointmentTransformer transformer;
@@ -55,6 +58,11 @@ class DeltaAppointmentTransformerIntegrationTest {
     private DeltaSensitiveDataTransformer sensitiveDataTransformer;
     @MockBean
     private CompanyProfileClient client;
+
+    @BeforeEach
+    void setup() {
+        DataMapHolder.initialise(CONTEXT_ID);
+    }
 
     @Test
     void successfullyCallAspect() throws Exception {

--- a/src/test/java/uk/gov/companieshouse/company_appointments/officerappointments/OfficerAppointmentsControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/company_appointments/officerappointments/OfficerAppointmentsControllerTest.java
@@ -6,6 +6,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.util.Map;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -69,7 +70,7 @@ class OfficerAppointmentsControllerTest {
         assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
         assertNull(response.getBody());
         verify(service).getOfficerAppointments(new OfficerAppointmentsRequest(OFFICER_ID, null, null, null));
-        verify(logger).error(loggerCaptor.capture());
+        verify(logger).error(loggerCaptor.capture(), any(Map.class));
         assertEquals(String.format("No appointments found for officer ID %s", OFFICER_ID), loggerCaptor.getValue());
     }
 
@@ -86,7 +87,7 @@ class OfficerAppointmentsControllerTest {
         assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
         assertNull(response.getBody());
         verify(service).getOfficerAppointments(new OfficerAppointmentsRequest(OFFICER_ID, "invalid", null, null));
-        verify(logger).error(loggerCaptor.capture());
+        verify(logger).error(loggerCaptor.capture(), any(Map.class));
         assertEquals(String.format("Invalid filter parameter supplied: %s, officer ID %s", "invalid", OFFICER_ID), loggerCaptor.getValue());
     }
 }

--- a/src/test/java/uk/gov/companieshouse/company_appointments/service/CompanyAppointmentFullRecordServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/company_appointments/service/CompanyAppointmentFullRecordServiceTest.java
@@ -70,7 +70,6 @@ class CompanyAppointmentFullRecordServiceTest {
 
     private final static String COMPANY_NUMBER = "123456";
     private final static String APPOINTMENT_ID = "345678";
-    private final static String CONTEXT_ID = "contextId";
     private final static OffsetDateTime DELTA_AT_LATER = OffsetDateTime.parse("2022-01-14T00:00:00.000000Z");
     private final static OffsetDateTime DELTA_AT_STALE = OffsetDateTime.parse("2022-01-12T00:00:00.000000Z");
     private final static Clock CLOCK = Clock.fixed(Instant.parse("2021-08-01T00:00:00.000000Z"),
@@ -158,7 +157,7 @@ class CompanyAppointmentFullRecordServiceTest {
                 .thenReturn(transformedAppointmentApi);
 
         // When
-        companyAppointmentService.upsertAppointmentDelta(CONTEXT_ID, fullRecordCompanyOfficerApi);
+        companyAppointmentService.upsertAppointmentDelta(fullRecordCompanyOfficerApi);
 
         // then
         verify(companyAppointmentRepository).insertOrUpdate(captor.capture());
@@ -175,7 +174,7 @@ class CompanyAppointmentFullRecordServiceTest {
         });
 
         // When
-        Executable executable = () -> companyAppointmentService.upsertAppointmentDelta(CONTEXT_ID,
+        Executable executable = () -> companyAppointmentService.upsertAppointmentDelta(
                 fullRecordCompanyOfficerApi);
 
         // then
@@ -190,7 +189,7 @@ class CompanyAppointmentFullRecordServiceTest {
         when(resourceChangedApiService.invokeChsKafkaApi(any())).thenThrow(IllegalArgumentException.class);
 
         // When
-        Executable executable = () -> companyAppointmentService.upsertAppointmentDelta(CONTEXT_ID,
+        Executable executable = () -> companyAppointmentService.upsertAppointmentDelta(
                 fullRecordCompanyOfficerApi);
 
         // then
@@ -204,7 +203,7 @@ class CompanyAppointmentFullRecordServiceTest {
                 .when(deltaAppointmentTransformer).transform(any(FullRecordCompanyOfficerApi.class));
 
         // When
-        Executable executable = () -> companyAppointmentService.upsertAppointmentDelta(CONTEXT_ID,
+        Executable executable = () -> companyAppointmentService.upsertAppointmentDelta(
                 fullRecordCompanyOfficerApi);
 
         // then
@@ -240,7 +239,7 @@ class CompanyAppointmentFullRecordServiceTest {
                 : Optional.empty());
 
         // When
-        companyAppointmentService.upsertAppointmentDelta(CONTEXT_ID, fullRecordCompanyOfficerApi);
+        companyAppointmentService.upsertAppointmentDelta(fullRecordCompanyOfficerApi);
 
         // then
         VerificationMode expectedTimes = (deltaExists && shouldBeStale) ? never() : times(1);
@@ -254,7 +253,7 @@ class CompanyAppointmentFullRecordServiceTest {
                 APPOINTMENT_ID))
                 .thenReturn(Optional.of(new CompanyAppointmentDocument()));
 
-        companyAppointmentService.deleteAppointmentDelta(CONTEXT_ID, COMPANY_NUMBER, APPOINTMENT_ID);
+        companyAppointmentService.deleteAppointmentDelta(COMPANY_NUMBER, APPOINTMENT_ID);
 
         verify(companyAppointmentRepository).deleteByCompanyNumberAndID(COMPANY_NUMBER,
                 APPOINTMENT_ID);
@@ -266,7 +265,7 @@ class CompanyAppointmentFullRecordServiceTest {
                 .thenThrow(new FailedToTransformException("message"));
 
         Assert.assertThrows(ServiceUnavailableException.class, () ->
-                companyAppointmentService.upsertAppointmentDelta(CONTEXT_ID, new FullRecordCompanyOfficerApi()));
+                companyAppointmentService.upsertAppointmentDelta(new FullRecordCompanyOfficerApi()));
     }
 
     @Test
@@ -275,7 +274,7 @@ class CompanyAppointmentFullRecordServiceTest {
                 APPOINTMENT_ID))
                 .thenReturn(Optional.empty());
 
-        Executable executable = () -> companyAppointmentService.deleteAppointmentDelta(CONTEXT_ID, COMPANY_NUMBER,
+        Executable executable = () -> companyAppointmentService.deleteAppointmentDelta(COMPANY_NUMBER,
                 APPOINTMENT_ID);
 
         assertThrows(NotFoundException.class, executable);
@@ -289,7 +288,7 @@ class CompanyAppointmentFullRecordServiceTest {
         });
 
         // When
-        Executable executable = () -> companyAppointmentService.deleteAppointmentDelta(CONTEXT_ID, COMPANY_NUMBER,
+        Executable executable = () -> companyAppointmentService.deleteAppointmentDelta(COMPANY_NUMBER,
                 APPOINTMENT_ID);
 
         // then
@@ -305,7 +304,7 @@ class CompanyAppointmentFullRecordServiceTest {
         when(resourceChangedApiService.invokeChsKafkaApi(any())).thenThrow(IllegalArgumentException.class);
 
         // When
-        Executable executable = () -> companyAppointmentService.deleteAppointmentDelta(CONTEXT_ID, COMPANY_NUMBER,
+        Executable executable = () -> companyAppointmentService.deleteAppointmentDelta(COMPANY_NUMBER,
                 APPOINTMENT_ID);
 
         // then

--- a/src/test/java/uk/gov/companieshouse/company_appointments/service/CompanyAppointmentServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/company_appointments/service/CompanyAppointmentServiceTest.java
@@ -15,7 +15,6 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
-import static uk.gov.companieshouse.logging.util.LogContextProperties.REQUEST_ID;
 
 import java.time.Clock;
 import java.time.LocalDateTime;
@@ -30,7 +29,6 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.junit.jupiter.api.function.Executable;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.slf4j.MDC;
 import org.springframework.dao.DataAccessResourceFailureException;
 import uk.gov.companieshouse.api.appointment.LinkTypes;
 import uk.gov.companieshouse.api.appointment.OfficerList;
@@ -90,7 +88,6 @@ class CompanyAppointmentServiceTest {
     private static final String COMPANY_NAME = "ACME LTD";
     private static final String OPEN_STATUS = "open";
     private static final String FAKE_STATUS = "fake";
-    private static final String CONTEXT_ID = "ABC123";
 
     @BeforeEach
     void setUp() {
@@ -101,7 +98,6 @@ class CompanyAppointmentServiceTest {
                 companyMetricsApiService,
                 companyStatusValidator,
                 clock);
-        MDC.put(REQUEST_ID.value(), CONTEXT_ID);
     }
 
     @Test
@@ -608,7 +604,7 @@ class CompanyAppointmentServiceTest {
         // then
         BadRequestException exception = assertThrows(BadRequestException.class, executable);
         assertEquals(
-                "Request failed for company [123456], contextId: [ABC123]: company name and/or company status missing.",
+                "Request failed for company [123456]: company name and/or company status missing.",
                 exception.getMessage());
         verifyNoInteractions(companyStatusValidator);
         verifyNoInteractions(companyAppointmentRepository);
@@ -625,7 +621,7 @@ class CompanyAppointmentServiceTest {
         // then
         BadRequestException exception = assertThrows(BadRequestException.class, executable);
         assertEquals(
-                "Request failed for company [123456], contextId: [ABC123]: company name and/or company status missing.",
+                "Request failed for company [123456]: company name and/or company status missing.",
                 exception.getMessage());
         verifyNoInteractions(companyStatusValidator);
         verifyNoInteractions(companyAppointmentRepository);
@@ -643,7 +639,7 @@ class CompanyAppointmentServiceTest {
         // then
         BadRequestException exception = assertThrows(BadRequestException.class, executable);
         assertEquals(
-                "Request failed for company [123456], contextId: [ABC123]: invalid company status provided.",
+                "Request failed for company [123456]: invalid company status provided.",
                 exception.getMessage());
         verify(companyStatusValidator).isValidCompanyStatus(FAKE_STATUS);
         verifyNoInteractions(companyAppointmentRepository);
@@ -665,7 +661,7 @@ class CompanyAppointmentServiceTest {
         ServiceUnavailableException exception = assertThrows(ServiceUnavailableException.class,
                 executable);
         assertEquals(
-                "Request failed for company [123456], contextId: [ABC123]: error connecting to MongoDB.",
+                "Request failed for company [123456]: error connecting to MongoDB.",
                 exception.getMessage());
         verify(companyStatusValidator).isValidCompanyStatus(OPEN_STATUS);
         verify(companyAppointmentRepository).patchAppointmentNameStatusInCompany(
@@ -725,7 +721,7 @@ class CompanyAppointmentServiceTest {
         // then
         BadRequestException exception = assertThrows(BadRequestException.class, executable);
         assertEquals(
-                "Request failed for company [123456] with appointment [345678], contextId: [ABC123]: company name and/or company status missing.",
+                "Request failed for company [123456] with appointment [345678]: company name and/or company status missing.",
                 exception.getMessage());
         verifyNoInteractions(companyStatusValidator);
         verifyNoInteractions(companyAppointmentRepository);
@@ -743,7 +739,7 @@ class CompanyAppointmentServiceTest {
         // then
         BadRequestException exception = assertThrows(BadRequestException.class, executable);
         assertEquals(
-                "Request failed for company [123456] with appointment [345678], contextId: [ABC123]: company name and/or company status missing.",
+                "Request failed for company [123456] with appointment [345678]: company name and/or company status missing.",
                 exception.getMessage());
         verifyNoInteractions(companyStatusValidator);
         verifyNoInteractions(companyAppointmentRepository);
@@ -762,7 +758,7 @@ class CompanyAppointmentServiceTest {
         // then
         BadRequestException exception = assertThrows(BadRequestException.class, executable);
         assertEquals(
-                "Request failed for company [123456] with appointment [345678], contextId: [ABC123]: invalid company status provided.",
+                "Request failed for company [123456] with appointment [345678]: invalid company status provided.",
                 exception.getMessage());
         verify(companyStatusValidator).isValidCompanyStatus(FAKE_STATUS);
         verifyNoInteractions(companyAppointmentRepository);
@@ -804,7 +800,7 @@ class CompanyAppointmentServiceTest {
         ServiceUnavailableException exception = assertThrows(ServiceUnavailableException.class,
                 executable);
         assertEquals(
-                "Request failed for company [123456] with appointment [345678], contextId: [ABC123]: error connecting to MongoDB.",
+                "Request failed for company [123456] with appointment [345678]: error connecting to MongoDB.",
                 exception.getMessage());
         verify(companyStatusValidator).isValidCompanyStatus(OPEN_STATUS);
         verify(companyAppointmentRepository).patchAppointmentNameStatus(any(), any(), any(),


### PR DESCRIPTION
* Added a `DataMapHolder` class to store a `DataMapHolder.Builder` instance that captures log data during message processing.
* Added a `String DataMapHolder.getRequestId()` to access the same request ID as used for logging
* Updated the `RequestLoggingInterceptor` to initialise the `DataMapHolder` with the request ID then ensures it is clean when processing is complete.
* Updated all logger calls to include the structured logging `DataMap` content.

The `RequestLoggingInterceptor` replaces the `StructuredLoggingFilter` described in the [Structured Logging](https://companieshouse.atlassian.net/wiki/spaces/TEAM4/pages/4253188169/Adding+Structured+Logging+to+Data+Sync+services) Confluence page. This page will be updated in due course.

[DSND-1902](https://companieshouse.atlassian.net/browse/DSND-1902)

[DSND-1902]: https://companieshouse.atlassian.net/browse/DSND-1902?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ