### PR TITLE
DSND-1968: Implement correct items per page for internal get officers list

### DIFF
--- a/src/it/java/uk/gov/companieshouse/company_appointments/officerappointments/OfficerAppointmentsControllerITest.java
+++ b/src/it/java/uk/gov/companieshouse/company_appointments/officerappointments/OfficerAppointmentsControllerITest.java
@@ -4,12 +4,18 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.hasSize;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static uk.gov.companieshouse.company_appointments.interceptor.AuthenticationHelperImpl.ERIC_AUTHORISED_KEY_PRIVILEGES_HEADER;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+
 import org.apache.commons.io.IOUtils;
 import org.bson.Document;
 import org.junit.jupiter.api.BeforeAll;
@@ -20,6 +26,8 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.data.mongodb.core.SimpleMongoClientDatabaseFactory;
+import org.springframework.data.mongodb.core.query.Criteria;
+import org.springframework.data.mongodb.core.query.Query;
 import org.springframework.http.MediaType;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.web.servlet.MockMvc;
@@ -28,6 +36,7 @@ import org.testcontainers.containers.MongoDBContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
 import uk.gov.companieshouse.company_appointments.CompanyAppointmentsApplication;
+import uk.gov.companieshouse.company_appointments.model.data.CompanyAppointmentDocument;
 
 @Testcontainers
 @AutoConfigureMockMvc
@@ -37,17 +46,19 @@ class OfficerAppointmentsControllerITest {
 
     @Container
     private static final MongoDBContainer mongoDBContainer = new MongoDBContainer("mongo:4.4");
+    private static final String DELTA_APPOINTMENTS_COLLECTION = "delta_appointments";
+    private static MongoTemplate mongoTemplate;
     @Autowired
     private MockMvc mockMvc;
 
     @BeforeAll
     static void start() throws IOException {
         System.setProperty("spring.data.mongodb.uri", mongoDBContainer.getReplicaSetUrl());
-        MongoTemplate mongoTemplate = new MongoTemplate(new SimpleMongoClientDatabaseFactory(mongoDBContainer.getReplicaSetUrl()));
-        mongoTemplate.createCollection("delta_appointments");
-        mongoTemplate.insert(Document.parse(IOUtils.resourceToString("/appointment-data.json", StandardCharsets.UTF_8)), "delta_appointments");
-        mongoTemplate.insert(Document.parse(IOUtils.resourceToString("/appointment-data2.json", StandardCharsets.UTF_8)), "delta_appointments");
-        mongoTemplate.insert(Document.parse(IOUtils.resourceToString("/appointment-data3.json", StandardCharsets.UTF_8)), "delta_appointments");
+        mongoTemplate = new MongoTemplate(new SimpleMongoClientDatabaseFactory(mongoDBContainer.getReplicaSetUrl()));
+        mongoTemplate.createCollection(DELTA_APPOINTMENTS_COLLECTION);
+        mongoTemplate.insert(Document.parse(IOUtils.resourceToString("/appointment-data.json", StandardCharsets.UTF_8)), DELTA_APPOINTMENTS_COLLECTION);
+        mongoTemplate.insert(Document.parse(IOUtils.resourceToString("/appointment-data2.json", StandardCharsets.UTF_8)), DELTA_APPOINTMENTS_COLLECTION);
+        mongoTemplate.insert(Document.parse(IOUtils.resourceToString("/appointment-data3.json", StandardCharsets.UTF_8)), DELTA_APPOINTMENTS_COLLECTION);
         System.setProperty("company-metrics-api.endpoint", "localhost");
     }
 
@@ -115,5 +126,147 @@ class OfficerAppointmentsControllerITest {
 
         // then
         result.andExpect(status().isUnauthorized());
+    }
+
+    @DisplayName("Should return HTTP 200 OK and a list of 500 appointments for a particular officer id when using internal app privileges")
+    @Test
+    void getOfficerAppointmentsInternal() throws Exception {
+        // given
+        final String officerId = UUID.randomUUID().toString();
+        final int itemsPerPage = 500;
+
+        List<Document> documentsToInsert = new ArrayList<>();
+        for (int i = 0; i < itemsPerPage; i++) {
+            String rawJson = IOUtils.resourceToString("/internal-appointment-data.json", StandardCharsets.UTF_8);
+            Document document = Document.parse(rawJson
+                    .replaceAll("<id>", UUID.randomUUID().toString())
+                    .replaceAll("<officerId>", officerId));
+            documentsToInsert.add(document);
+        }
+        mongoTemplate.insert(documentsToInsert, DELTA_APPOINTMENTS_COLLECTION);
+
+        //when
+        ResultActions result = mockMvc.perform(get("/officers/{officer_id}/appointments?items_per_page={itemsPerPage}", officerId, itemsPerPage)
+                .header("ERIC-Identity", "123")
+                .header("ERIC-Identity-Type", "key")
+                .header(ERIC_AUTHORISED_KEY_PRIVILEGES_HEADER, "internal-app")
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.APPLICATION_JSON));
+
+        //then
+        result.andExpect(status().isOk())
+                .andExpect(jsonPath("$.date_of_birth", not(contains("day"))))
+                .andExpect(jsonPath("$.date_of_birth.year", is(1980)))
+                .andExpect(jsonPath("$.date_of_birth.month", is(1)))
+                .andExpect(jsonPath("$.is_corporate_officer", is(false)))
+                .andExpect(jsonPath("$.items_per_page", is(itemsPerPage)))
+                .andExpect(jsonPath("$.kind", is("personal-appointment")))
+                .andExpect(jsonPath("$.links.self", is(String.format("/officers/%s/appointments", officerId))))
+                .andExpect(jsonPath("$.items", hasSize(itemsPerPage)))
+                .andExpect(jsonPath("$.name", is("Noname1 Noname2 NOSURNAME")))
+                .andExpect(jsonPath("$.start_index", is(0)))
+                .andExpect(jsonPath("$.total_results", is(itemsPerPage)));
+
+        // clean up
+        Query query = new Query()
+                .addCriteria(Criteria.where("officer_id").is(officerId));
+        mongoTemplate.findAllAndRemove(query, DELTA_APPOINTMENTS_COLLECTION);
+
+        assertTrue(mongoTemplate.find(query, CompanyAppointmentDocument.class).isEmpty());
+    }
+
+    @DisplayName("Should return HTTP 200 OK and a list of 500 appointments for a particular officer id when using internal app privileges and items per page is above 500")
+    @Test
+    void getOfficerAppointmentsInternalWhenItemsPerPageExceeds500() throws Exception {
+        // given
+        final String officerId = UUID.randomUUID().toString();
+        final int expectedItemsPerPage = 500;
+        final int requestedItemsPerPage = 550;
+
+        List<Document> documentsToInsert = new ArrayList<>();
+        for (int i = 0; i < requestedItemsPerPage; i++) {
+            String rawJson = IOUtils.resourceToString("/internal-appointment-data.json", StandardCharsets.UTF_8);
+            Document document = Document.parse(rawJson
+                    .replaceAll("<id>", UUID.randomUUID().toString())
+                    .replaceAll("<officerId>", officerId));
+            documentsToInsert.add(document);
+        }
+        mongoTemplate.insert(documentsToInsert, DELTA_APPOINTMENTS_COLLECTION);
+
+        //when
+        ResultActions result = mockMvc.perform(get("/officers/{officer_id}/appointments?items_per_page={itemsPerPage}", officerId, requestedItemsPerPage)
+                .header("ERIC-Identity", "123")
+                .header("ERIC-Identity-Type", "key")
+                .header(ERIC_AUTHORISED_KEY_PRIVILEGES_HEADER, "internal-app")
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.APPLICATION_JSON));
+
+        //then
+        result.andExpect(status().isOk())
+                .andExpect(jsonPath("$.date_of_birth", not(contains("day"))))
+                .andExpect(jsonPath("$.date_of_birth.year", is(1980)))
+                .andExpect(jsonPath("$.date_of_birth.month", is(1)))
+                .andExpect(jsonPath("$.is_corporate_officer", is(false)))
+                .andExpect(jsonPath("$.items_per_page", is(expectedItemsPerPage)))
+                .andExpect(jsonPath("$.kind", is("personal-appointment")))
+                .andExpect(jsonPath("$.links.self", is(String.format("/officers/%s/appointments", officerId))))
+                .andExpect(jsonPath("$.items", hasSize(expectedItemsPerPage)))
+                .andExpect(jsonPath("$.name", is("Noname1 Noname2 NOSURNAME")))
+                .andExpect(jsonPath("$.start_index", is(0)))
+                .andExpect(jsonPath("$.total_results", is(requestedItemsPerPage)));
+
+        // clean up
+        Query query = new Query()
+                .addCriteria(Criteria.where("officer_id").is(officerId));
+        mongoTemplate.findAllAndRemove(query, DELTA_APPOINTMENTS_COLLECTION);
+
+        assertTrue(mongoTemplate.find(query, CompanyAppointmentDocument.class).isEmpty());
+    }
+
+    @DisplayName("Should return HTTP 200 OK and a list of 50 appointments for a particular officer id when not using internal app privileges and items per page is above 500")
+    @Test
+    void getOfficerAppointmentsExternalWhenItemsPerPageExceeds500() throws Exception {
+        // given
+        final String officerId = UUID.randomUUID().toString();
+        final int expectedItemsPerPage = 50;
+        final int requestedItemsPerPage = 550;
+
+        List<Document> documentsToInsert = new ArrayList<>();
+        for (int i = 0; i < requestedItemsPerPage; i++) {
+            String rawJson = IOUtils.resourceToString("/internal-appointment-data.json", StandardCharsets.UTF_8);
+            Document document = Document.parse(rawJson
+                    .replaceAll("<id>", UUID.randomUUID().toString())
+                    .replaceAll("<officerId>", officerId));
+            documentsToInsert.add(document);
+        }
+        mongoTemplate.insert(documentsToInsert, DELTA_APPOINTMENTS_COLLECTION);
+
+        //when
+        ResultActions result = mockMvc.perform(get("/officers/{officer_id}/appointments?items_per_page={itemsPerPage}", officerId, requestedItemsPerPage)
+                .header("ERIC-Identity", "123")
+                .header("ERIC-Identity-Type", "key")
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.APPLICATION_JSON));
+
+        //then
+        result.andExpect(status().isOk())
+                .andExpect(jsonPath("$.date_of_birth", not(contains("day"))))
+                .andExpect(jsonPath("$.date_of_birth.year", is(1980)))
+                .andExpect(jsonPath("$.date_of_birth.month", is(1)))
+                .andExpect(jsonPath("$.is_corporate_officer", is(false)))
+                .andExpect(jsonPath("$.items_per_page", is(expectedItemsPerPage)))
+                .andExpect(jsonPath("$.kind", is("personal-appointment")))
+                .andExpect(jsonPath("$.links.self", is(String.format("/officers/%s/appointments", officerId))))
+                .andExpect(jsonPath("$.items", hasSize(expectedItemsPerPage)))
+                .andExpect(jsonPath("$.name", is("Noname1 Noname2 NOSURNAME")))
+                .andExpect(jsonPath("$.start_index", is(0)))
+                .andExpect(jsonPath("$.total_results", is(requestedItemsPerPage)));
+
+        // clean up
+        Query query = new Query()
+                .addCriteria(Criteria.where("officer_id").is(officerId));
+        mongoTemplate.findAllAndRemove(query, DELTA_APPOINTMENTS_COLLECTION);
+
+        assertTrue(mongoTemplate.find(query, CompanyAppointmentDocument.class).isEmpty());
     }
 }

--- a/src/main/java/uk/gov/companieshouse/company_appointments/interceptor/AuthenticationHelperImpl.java
+++ b/src/main/java/uk/gov/companieshouse/company_appointments/interceptor/AuthenticationHelperImpl.java
@@ -20,9 +20,9 @@ public class AuthenticationHelperImpl implements AuthenticationHelper {
     public static final int USER_EMAIL_INDEX = 0;
     public static final int USER_FORENAME_INDEX = 1;
     public static final int USER_SURNAME_INDEX = 2;
-    private static final String INTERNAL_APP_PRIVILEGE = "internal-app";
+    public static final String INTERNAL_APP_PRIVILEGE = "internal-app";
     private static final String SENSITIVE_DATA_PRIVILEGE = "sensitive-data";
-    private static final String ERIC_AUTHORISED_KEY_PRIVILEGES_HEADER
+    public static final String ERIC_AUTHORISED_KEY_PRIVILEGES_HEADER
             = "ERIC-Authorised-Key-Privileges";
     private static final String ERIC_AUTHORISED_TOKEN_PERMISSIONS_HEADER
             = "ERIC-Authorised-Token-Permissions";

--- a/src/main/java/uk/gov/companieshouse/company_appointments/officerappointments/ItemsPerPageService.java
+++ b/src/main/java/uk/gov/companieshouse/company_appointments/officerappointments/ItemsPerPageService.java
@@ -33,7 +33,7 @@ public class ItemsPerPageService {
 
     private boolean hasInternalAppPrivileges(String authPrivileges) {
         return Optional.ofNullable(authPrivileges)
-                .map(v -> v.split(","))
+                .map(rawAuthPrivileges -> rawAuthPrivileges.split(","))
                 .map(privileges -> ArrayUtils.contains(privileges, INTERNAL_APP_PRIVILEGE))
                 .orElse(false);
     }

--- a/src/main/java/uk/gov/companieshouse/company_appointments/officerappointments/ItemsPerPageService.java
+++ b/src/main/java/uk/gov/companieshouse/company_appointments/officerappointments/ItemsPerPageService.java
@@ -1,0 +1,40 @@
+package uk.gov.companieshouse.company_appointments.officerappointments;
+
+import org.apache.commons.lang.ArrayUtils;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+
+import static uk.gov.companieshouse.company_appointments.interceptor.AuthenticationHelperImpl.INTERNAL_APP_PRIVILEGE;
+
+@Component
+public class ItemsPerPageService {
+
+    private static final int ITEMS_PER_PAGE = 35;
+    private static final int MAX_ITEMS_PER_PAGE_EXTERNAL = 50;
+
+    private final int maxItemsPerPageInternal;
+
+    public ItemsPerPageService(@Value("${items-per-page-max-internal}") final int maxItemsPerPageInternal) {
+        this.maxItemsPerPageInternal = maxItemsPerPageInternal;
+    }
+
+    public int getItemsPerPage(Integer itemsPerPage, String authPrivileges) {
+        if (itemsPerPage == null || itemsPerPage == 0) {
+            itemsPerPage = ITEMS_PER_PAGE;
+        } else {
+            int maxItemsPerPage = hasInternalAppPrivileges(authPrivileges) ?
+                    maxItemsPerPageInternal : MAX_ITEMS_PER_PAGE_EXTERNAL;
+            itemsPerPage = Math.min(Math.abs(itemsPerPage), maxItemsPerPage);
+        }
+        return itemsPerPage;
+    }
+
+    private boolean hasInternalAppPrivileges(String authPrivileges) {
+        return Optional.ofNullable(authPrivileges)
+                .map(v -> v.split(","))
+                .map(privileges -> ArrayUtils.contains(privileges, INTERNAL_APP_PRIVILEGE))
+                .orElse(false);
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/company_appointments/officerappointments/ItemsPerPageService.java
+++ b/src/main/java/uk/gov/companieshouse/company_appointments/officerappointments/ItemsPerPageService.java
@@ -11,7 +11,7 @@ import static uk.gov.companieshouse.company_appointments.interceptor.Authenticat
 @Component
 public class ItemsPerPageService {
 
-    private static final int ITEMS_PER_PAGE = 35;
+    private static final int DEFAULT_ITEMS_PER_PAGE = 35;
     private static final int MAX_ITEMS_PER_PAGE_EXTERNAL = 50;
 
     private final int maxItemsPerPageInternal;
@@ -22,7 +22,7 @@ public class ItemsPerPageService {
 
     public int getItemsPerPage(Integer itemsPerPage, String authPrivileges) {
         if (itemsPerPage == null || itemsPerPage == 0) {
-            itemsPerPage = ITEMS_PER_PAGE;
+            itemsPerPage = DEFAULT_ITEMS_PER_PAGE;
         } else {
             int maxItemsPerPage = hasInternalAppPrivileges(authPrivileges) ?
                     maxItemsPerPageInternal : MAX_ITEMS_PER_PAGE_EXTERNAL;

--- a/src/main/java/uk/gov/companieshouse/company_appointments/officerappointments/OfficerAppointmentsController.java
+++ b/src/main/java/uk/gov/companieshouse/company_appointments/officerappointments/OfficerAppointmentsController.java
@@ -1,5 +1,7 @@
 package uk.gov.companieshouse.company_appointments.officerappointments;
 
+import static uk.gov.companieshouse.company_appointments.interceptor.AuthenticationHelperImpl.ERIC_AUTHORISED_KEY_PRIVILEGES_HEADER;
+
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -12,8 +14,6 @@ import uk.gov.companieshouse.company_appointments.exception.BadRequestException;
 import uk.gov.companieshouse.company_appointments.logging.DataMapHolder;
 import uk.gov.companieshouse.logging.Logger;
 import uk.gov.companieshouse.logging.LoggerFactory;
-
-import static uk.gov.companieshouse.company_appointments.interceptor.AuthenticationHelperImpl.ERIC_AUTHORISED_KEY_PRIVILEGES_HEADER;
 
 @Controller
 class OfficerAppointmentsController {

--- a/src/main/java/uk/gov/companieshouse/company_appointments/officerappointments/OfficerAppointmentsController.java
+++ b/src/main/java/uk/gov/companieshouse/company_appointments/officerappointments/OfficerAppointmentsController.java
@@ -4,39 +4,49 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestParam;
 import uk.gov.companieshouse.api.officer.AppointmentList;
+import uk.gov.companieshouse.company_appointments.CompanyAppointmentsApplication;
 import uk.gov.companieshouse.company_appointments.exception.BadRequestException;
 import uk.gov.companieshouse.company_appointments.logging.DataMapHolder;
 import uk.gov.companieshouse.logging.Logger;
+import uk.gov.companieshouse.logging.LoggerFactory;
+
+import static uk.gov.companieshouse.company_appointments.interceptor.AuthenticationHelperImpl.ERIC_AUTHORISED_KEY_PRIVILEGES_HEADER;
 
 @Controller
 class OfficerAppointmentsController {
 
-    private final OfficerAppointmentsService service;
-    private final Logger logger;
+    private static final Logger LOGGER = LoggerFactory.getLogger(CompanyAppointmentsApplication.APPLICATION_NAMESPACE);
 
-    OfficerAppointmentsController(OfficerAppointmentsService service, Logger logger) {
+    private final OfficerAppointmentsService service;
+    private final ItemsPerPageService itemsPerPageService;
+
+    OfficerAppointmentsController(OfficerAppointmentsService service, ItemsPerPageService itemsPerPageService) {
         this.service = service;
-        this.logger = logger;
+        this.itemsPerPageService = itemsPerPageService;
     }
 
     @GetMapping(path = "/officers/{officer_id}/appointments")
-    public ResponseEntity<AppointmentList> getOfficerAppointments(@PathVariable("officer_id") String officerId,
+    public ResponseEntity<AppointmentList> getOfficerAppointments(
+            @PathVariable("officer_id") String officerId,
             @RequestParam(value = "filter", required = false) String filter,
             @RequestParam(value = "start_index", required = false) Integer startIndex,
-            @RequestParam(value = "items_per_page", required = false) Integer itemsPerPage) {
+            @RequestParam(value = "items_per_page", required = false) Integer itemsPerPage,
+            @RequestHeader(value = ERIC_AUTHORISED_KEY_PRIVILEGES_HEADER, required = false) String authPrivileges) {
         try {
             DataMapHolder.get()
                     .officerId(officerId);
-            return service.getOfficerAppointments(new OfficerAppointmentsRequest(officerId, filter, startIndex, itemsPerPage))
+            int adjustedItemsPerPage = itemsPerPageService.getItemsPerPage(itemsPerPage, authPrivileges);
+            return service.getOfficerAppointments(new OfficerAppointmentsRequest(officerId, filter, startIndex, adjustedItemsPerPage))
                     .map(ResponseEntity::ok)
                     .orElseGet(() -> {
-                        logger.error(String.format("No appointments found for officer ID %s", officerId), DataMapHolder.getLogMap());
+                        LOGGER.error(String.format("No appointments found for officer ID %s", officerId), DataMapHolder.getLogMap());
                         return ResponseEntity.notFound().build();
                     });
         } catch (BadRequestException ex) {
-            logger.error(String.format("Invalid filter parameter supplied: %s, officer ID %s", filter, officerId), DataMapHolder.getLogMap());
+            LOGGER.error(String.format("Invalid filter parameter supplied: %s, officer ID %s", filter, officerId), DataMapHolder.getLogMap());
             return ResponseEntity.badRequest().build();
         }
     }

--- a/src/main/java/uk/gov/companieshouse/company_appointments/officerappointments/OfficerAppointmentsService.java
+++ b/src/main/java/uk/gov/companieshouse/company_appointments/officerappointments/OfficerAppointmentsService.java
@@ -8,8 +8,6 @@ import uk.gov.companieshouse.company_appointments.officerappointments.OfficerApp
 @Service
 class OfficerAppointmentsService {
 
-    private static final int ITEMS_PER_PAGE = 35;
-    private static final int MAX_ITEMS_PER_PAGE = 50;
     private static final int START_INDEX = 0;
 
     private final OfficerAppointmentsRepository repository;
@@ -23,13 +21,13 @@ class OfficerAppointmentsService {
         this.filterService = filterService;
     }
 
-    Optional<AppointmentList> getOfficerAppointments(OfficerAppointmentsRequest request) {
-        String officerId = request.getOfficerId();
+    Optional<AppointmentList> getOfficerAppointments(OfficerAppointmentsRequest params) {
+        String officerId = params.getOfficerId();
         return repository.findFirstByOfficerId(officerId)
                 .flatMap(firstAppointment -> {
-                    int startIndex = getStartIndex(request);
-                    int itemsPerPage = getItemsPerPage(request);
-                    Filter filter = filterService.prepareFilter(request.getFilter(), request.getOfficerId());
+                    int startIndex = getStartIndex(params);
+                    int itemsPerPage = params.getItemsPerPage();
+                    Filter filter = filterService.prepareFilter(params.getFilter(), params.getOfficerId());
 
                     OfficerAppointmentsAggregate aggregate = repository.findOfficerAppointments(officerId,
                             filter.isFilterEnabled(), filter.getFilterStatuses(), startIndex, itemsPerPage);
@@ -40,18 +38,6 @@ class OfficerAppointmentsService {
                             .firstAppointment(firstAppointment)
                             .aggregate(aggregate));
                 });
-    }
-
-    private static int getItemsPerPage(OfficerAppointmentsRequest request) {
-        int itemsPerPage;
-        if (request.getItemsPerPage() == null || request.getItemsPerPage() == 0) {
-            itemsPerPage = ITEMS_PER_PAGE;
-        } else if (Math.abs(request.getItemsPerPage()) > 50) {
-            itemsPerPage = MAX_ITEMS_PER_PAGE;
-        } else {
-            itemsPerPage = Math.abs(request.getItemsPerPage());
-        }
-        return itemsPerPage;
     }
 
     private static int getStartIndex(OfficerAppointmentsRequest request) {

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -15,3 +15,5 @@ api.api-url=${API_URL:localhost}
 api.api-key=${CHS_API_KEY:chsApiKey}
 
 feature.seeding_collection_enabled=${SEEDING_COLLECTION_ENABLED:false}
+
+items-per-page-max-internal=${OFFICER_APPOINTMENTS_THRESHOLD:500}

--- a/src/test/java/uk/gov/companieshouse/company_appointments/officerappointments/ItemsPerPageServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/company_appointments/officerappointments/ItemsPerPageServiceTest.java
@@ -1,0 +1,135 @@
+package uk.gov.companieshouse.company_appointments.officerappointments;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Named;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import java.util.stream.Stream;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class ItemsPerPageServiceTest {
+
+    private ItemsPerPageService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new ItemsPerPageService(500);
+    }
+
+    @ParameterizedTest
+    @MethodSource("itemsPerPageScenarios")
+    void testGetItemsPerPage(ItemsPerPageTestArgument argument) {
+        // given
+
+        // when
+        int actual = service.getItemsPerPage(argument.getItemsPerPage(), argument.getAuthPrivileges());
+
+        // then
+        assertEquals(argument.getExpectedItemsPerPage(), actual);
+    }
+
+    private static Stream<Arguments> itemsPerPageScenarios() {
+        return Stream.of(
+                Arguments.of(
+                        Named.of("Null items per page returns default 35 items per page",
+                                ItemsPerPageTestArgument.Builder.builder()
+                                        .itemsPerPage(null)
+                                        .authPrivileges(null)
+                                        .expectedItemsPerPage(35)
+                                        .build())),
+                Arguments.of(
+                        Named.of("20 items per page returns 20 items per page",
+                                ItemsPerPageTestArgument.Builder.builder()
+                                        .itemsPerPage(20)
+                                        .authPrivileges(null)
+                                        .expectedItemsPerPage(20)
+                                        .build())),
+                Arguments.of(
+                        Named.of("51 items per page returns 50 items per page when no internal-app privileges",
+                                ItemsPerPageTestArgument.Builder.builder()
+                                        .itemsPerPage(51)
+                                        .authPrivileges(null)
+                                        .expectedItemsPerPage(50)
+                                        .build())),
+                Arguments.of(
+                        Named.of("500 items per page returns 500 items per page when internal-app privileges",
+                                ItemsPerPageTestArgument.Builder.builder()
+                                        .itemsPerPage(500)
+                                        .authPrivileges("any,internal-app,any")
+                                        .expectedItemsPerPage(500)
+                                        .build())),
+                Arguments.of(
+                        Named.of("490 items per page returns 490 items per page when internal-app privileges",
+                                ItemsPerPageTestArgument.Builder.builder()
+                                        .itemsPerPage(490)
+                                        .authPrivileges("any,internal-app,any")
+                                        .expectedItemsPerPage(490)
+                                        .build())),
+                Arguments.of(
+                        Named.of("501 items per page returns 500 items per page when internal-app privileges",
+                                ItemsPerPageTestArgument.Builder.builder()
+                                        .itemsPerPage(501)
+                                        .authPrivileges("any,internal-app,any")
+                                        .expectedItemsPerPage(500)
+                                        .build())));
+    }
+
+    private static class ItemsPerPageTestArgument {
+        private final Integer itemsPerPage;
+        private final String authPrivileges;
+        private final int expectedItemsPerPage;
+
+        private ItemsPerPageTestArgument(Builder builder) {
+            itemsPerPage = builder.itemsPerPage;
+            authPrivileges = builder.authPrivileges;
+            expectedItemsPerPage = builder.expectedItemsPerPage;
+        }
+
+        public Integer getItemsPerPage() {
+            return itemsPerPage;
+        }
+
+        public String getAuthPrivileges() {
+            return authPrivileges;
+        }
+
+        public int getExpectedItemsPerPage() {
+            return expectedItemsPerPage;
+        }
+
+        public static final class Builder {
+            private Integer itemsPerPage;
+            private String authPrivileges;
+            private int expectedItemsPerPage;
+
+            private Builder() {
+            }
+
+            public static Builder builder() {
+                return new Builder();
+            }
+
+            public Builder itemsPerPage(Integer itemsPerPage) {
+                this.itemsPerPage = itemsPerPage;
+                return this;
+            }
+
+            public Builder authPrivileges(String authPrivileges) {
+                this.authPrivileges = authPrivileges;
+                return this;
+            }
+
+            public Builder expectedItemsPerPage(int expectedItemsPerPage) {
+                this.expectedItemsPerPage = expectedItemsPerPage;
+                return this;
+            }
+
+            public ItemsPerPageTestArgument build() {
+                return new ItemsPerPageTestArgument(this);
+            }
+        }
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/company_appointments/officerappointments/ItemsPerPageServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/company_appointments/officerappointments/ItemsPerPageServiceTest.java
@@ -41,6 +41,13 @@ class ItemsPerPageServiceTest {
                                         .expectedItemsPerPage(35)
                                         .build())),
                 Arguments.of(
+                        Named.of("Null items per page returns default 35 items per page",
+                                ItemsPerPageTestArgument.Builder.builder()
+                                        .itemsPerPage(0)
+                                        .authPrivileges(null)
+                                        .expectedItemsPerPage(35)
+                                        .build())),
+                Arguments.of(
                         Named.of("20 items per page returns 20 items per page",
                                 ItemsPerPageTestArgument.Builder.builder()
                                         .itemsPerPage(20)

--- a/src/test/java/uk/gov/companieshouse/company_appointments/officerappointments/ItemsPerPageServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/company_appointments/officerappointments/ItemsPerPageServiceTest.java
@@ -41,7 +41,7 @@ class ItemsPerPageServiceTest {
                                         .expectedItemsPerPage(35)
                                         .build())),
                 Arguments.of(
-                        Named.of("Null items per page returns default 35 items per page",
+                        Named.of("Zero items per page returns default 35 items per page",
                                 ItemsPerPageTestArgument.Builder.builder()
                                         .itemsPerPage(0)
                                         .authPrivileges(null)

--- a/src/test/java/uk/gov/companieshouse/company_appointments/officerappointments/OfficerAppointmentsControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/company_appointments/officerappointments/OfficerAppointmentsControllerTest.java
@@ -3,16 +3,14 @@ package uk.gov.companieshouse.company_appointments.officerappointments;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import java.util.Map;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.ArgumentCaptor;
-import org.mockito.Captor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -20,7 +18,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import uk.gov.companieshouse.api.officer.AppointmentList;
 import uk.gov.companieshouse.company_appointments.exception.BadRequestException;
-import uk.gov.companieshouse.logging.Logger;
 
 @ExtendWith(MockitoExtension.class)
 class OfficerAppointmentsControllerTest {
@@ -34,22 +31,20 @@ class OfficerAppointmentsControllerTest {
     private OfficerAppointmentsService service;
 
     @Mock
-    private AppointmentList officerAppointments;
+    private ItemsPerPageService itemsPerPageService;
 
     @Mock
-    private Logger logger;
-
-    @Captor
-    private ArgumentCaptor<String> loggerCaptor;
+    private AppointmentList officerAppointments;
 
     @Test
     @DisplayName("Call to get officer appointments returns http 200 ok and officer appointments api")
     void testGetOfficerAppointments() throws BadRequestException {
         // given
+        when(itemsPerPageService.getItemsPerPage(any(), anyString())).thenReturn(5);
         when(service.getOfficerAppointments(any())).thenReturn(Optional.of(officerAppointments));
 
         // when
-        ResponseEntity<AppointmentList> response = controller.getOfficerAppointments(OFFICER_ID, null, 0, 5);
+        ResponseEntity<AppointmentList> response = controller.getOfficerAppointments(OFFICER_ID, null, 0, 5, "");
 
         // then
         assertEquals(HttpStatus.OK, response.getStatusCode());
@@ -61,33 +56,31 @@ class OfficerAppointmentsControllerTest {
     @DisplayName("Call to get officer appointments returns http 404 not found when officer id does not exist")
     void testGetOfficerAppointmentsNotFound() throws BadRequestException {
         // given
+        when(itemsPerPageService.getItemsPerPage(any(), anyString())).thenReturn(35);
         when(service.getOfficerAppointments(any())).thenReturn(Optional.empty());
 
         // when
-        ResponseEntity<AppointmentList> response = controller.getOfficerAppointments(OFFICER_ID, null, null, null);
+        ResponseEntity<AppointmentList> response = controller.getOfficerAppointments(OFFICER_ID, null, null, null, "");
 
         // then
         assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
         assertNull(response.getBody());
-        verify(service).getOfficerAppointments(new OfficerAppointmentsRequest(OFFICER_ID, null, null, null));
-        verify(logger).error(loggerCaptor.capture(), any(Map.class));
-        assertEquals(String.format("No appointments found for officer ID %s", OFFICER_ID), loggerCaptor.getValue());
+        verify(service).getOfficerAppointments(new OfficerAppointmentsRequest(OFFICER_ID, null, null, 35));
     }
 
     @Test
     @DisplayName("Call to get officer appointments returns http 400 bad request when filter parameter is invalid")
     void testGetOfficerAppointmentsBadRequest() throws BadRequestException {
         // given
+        when(itemsPerPageService.getItemsPerPage(any(), anyString())).thenReturn(35);
         when(service.getOfficerAppointments(any())).thenThrow(BadRequestException.class);
 
         // when
-        ResponseEntity<AppointmentList> response = controller.getOfficerAppointments(OFFICER_ID, "invalid", null, null);
+        ResponseEntity<AppointmentList> response = controller.getOfficerAppointments(OFFICER_ID, "invalid", null, null, "");
 
         // then
         assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
         assertNull(response.getBody());
-        verify(service).getOfficerAppointments(new OfficerAppointmentsRequest(OFFICER_ID, "invalid", null, null));
-        verify(logger).error(loggerCaptor.capture(), any(Map.class));
-        assertEquals(String.format("Invalid filter parameter supplied: %s, officer ID %s", "invalid", OFFICER_ID), loggerCaptor.getValue());
+        verify(service).getOfficerAppointments(new OfficerAppointmentsRequest(OFFICER_ID, "invalid", null, 35));
     }
 }

--- a/src/test/java/uk/gov/companieshouse/company_appointments/officerappointments/OfficerAppointmentsServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/company_appointments/officerappointments/OfficerAppointmentsServiceTest.java
@@ -34,7 +34,7 @@ class OfficerAppointmentsServiceTest {
     private static final String OFFICER_ID = "officerId";
     private static final int START_INDEX = 0;
     private static final int ITEMS_PER_PAGE = 35;
-    private static final int MAX_ITEMS_PER_PAGE = 50;
+    private static final int MAX_ITEMS_PER_PAGE_INTERNAL = 500;
     private static final String REMOVED = "removed";
     private static final String CONVERTED_CLOSED = "converted-closed";
     private static final String DISSOLVED = "dissolved";
@@ -60,7 +60,7 @@ class OfficerAppointmentsServiceTest {
                         Named.of("Get officer appointments returns an officer appointments api",
                                 new ServiceTestArgument.Builder()
                                         .withRequest(
-                                                new OfficerAppointmentsRequest(OFFICER_ID, null, null, null))
+                                                new OfficerAppointmentsRequest(OFFICER_ID, null, null, 35))
                                         .withOfficerId(OFFICER_ID)
                                         .withFilterEnabled(false)
                                         .withStartIndex(START_INDEX)
@@ -69,7 +69,7 @@ class OfficerAppointmentsServiceTest {
                 Arguments.of(
                         Named.of("Get officer appointments returns an officer appointments api when filter is empty",
                                 new ServiceTestArgument.Builder()
-                                        .withRequest(new OfficerAppointmentsRequest(OFFICER_ID, "", null, null))
+                                        .withRequest(new OfficerAppointmentsRequest(OFFICER_ID, "", null, 35))
                                         .withOfficerId(OFFICER_ID)
                                         .withFilterEnabled(false)
                                         .withStartIndex(START_INDEX)
@@ -79,7 +79,7 @@ class OfficerAppointmentsServiceTest {
                         Named.of("Get officer appointments returns an officer appointments api when filter is active",
                                 new ServiceTestArgument.Builder()
                                         .withRequest(
-                                                new OfficerAppointmentsRequest(OFFICER_ID, "active", null, null))
+                                                new OfficerAppointmentsRequest(OFFICER_ID, "active", null, 35))
                                         .withOfficerId(OFFICER_ID)
                                         .withFilterEnabled(true)
                                         .withFilterStatuses(List.of(DISSOLVED, CONVERTED_CLOSED, REMOVED))
@@ -98,40 +98,22 @@ class OfficerAppointmentsServiceTest {
                                         .withItemsPerPage(3)
                                         .build())),
                 Arguments.of(
-                        Named.of("Get officer appointments returns default paging when itemsPerPage is 0",
+                        Named.of("Get officer appointments successfully handles paging values over 35",
                                 new ServiceTestArgument.Builder()
-                                        .withRequest(new OfficerAppointmentsRequest(OFFICER_ID, null, null, 0))
-                                        .withOfficerId(OFFICER_ID)
-                                        .withFilterEnabled(false)
-                                        .withStartIndex(0)
-                                        .withItemsPerPage(35)
-                                        .build())),
-                Arguments.of(
-                        Named.of("Get officer appointments successfully handles negative paging values",
-                                new ServiceTestArgument.Builder()
-                                        .withRequest(new OfficerAppointmentsRequest(OFFICER_ID, null, -1, -5))
+                                        .withRequest(new OfficerAppointmentsRequest(OFFICER_ID, null, 1, 36))
                                         .withOfficerId(OFFICER_ID)
                                         .withFilterEnabled(false)
                                         .withStartIndex(1)
-                                        .withItemsPerPage(5)
+                                        .withItemsPerPage(36)
                                         .build())),
                 Arguments.of(
-                        Named.of("Get officer appointments successfully handles paging values over 50",
+                        Named.of("Get officer appointments successfully handles paging values of 500",
                                 new ServiceTestArgument.Builder()
-                                        .withRequest(new OfficerAppointmentsRequest(OFFICER_ID, null, 1, 55))
+                                        .withRequest(new OfficerAppointmentsRequest(OFFICER_ID, null, 1, 500))
                                         .withOfficerId(OFFICER_ID)
                                         .withFilterEnabled(false)
                                         .withStartIndex(1)
-                                        .withItemsPerPage(MAX_ITEMS_PER_PAGE)
-                                        .build())),
-                Arguments.of(
-                        Named.of("Get officer appointments successfully handles negative paging values over 50",
-                                new ServiceTestArgument.Builder()
-                                        .withRequest(new OfficerAppointmentsRequest(OFFICER_ID, null, -1, -55))
-                                        .withOfficerId(OFFICER_ID)
-                                        .withFilterEnabled(false)
-                                        .withStartIndex(1)
-                                        .withItemsPerPage(MAX_ITEMS_PER_PAGE)
+                                        .withItemsPerPage(MAX_ITEMS_PER_PAGE_INTERNAL)
                                         .build())));
     }
 

--- a/src/test/resources/application-feature_flag_enabled.properties
+++ b/src/test/resources/application-feature_flag_enabled.properties
@@ -12,3 +12,5 @@ api.api-url=${API_URL:localhost}
 api.api-key=${CHS_API_KEY:chsApiKey}
 
 feature.seeding_collection_enabled=true
+
+items-per-page-max-internal=500

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -12,3 +12,5 @@ api.api-url=${API_URL:localhost}
 api.api-key=${CHS_API_KEY:chsApiKey}
 
 feature.seeding_collection_enabled=false
+
+items-per-page-max-internal=500

--- a/src/test/resources/internal-appointment-data.json
+++ b/src/test/resources/internal-appointment-data.json
@@ -21,7 +21,9 @@
     "nationality" : "British",
     "forename" : "Noname1",
     "surname" : "NOSURNAME",
-    "updated_at" : ISODate("2020-08-26T13:00:00.000Z"),
+    "updated" : {
+      "at" : ISODate("2020-08-26T13:00:00.000Z")
+    },
     "other_forenames" : "Noname2",
     "appointed_on" : ISODate("2020-08-26T12:00:00.000Z"),
     "etag" : "8f58a770d34f982a1b2a5a29fcde12528e82f903",

--- a/src/test/resources/internal-appointment-data.json
+++ b/src/test/resources/internal-appointment-data.json
@@ -1,0 +1,59 @@
+{
+  "_id" : "<id>",
+  "appointment_id" : "<id>",
+  "company_name" : "TEST COMPANY LIMITED",
+  "company_number" : "12345678",
+  "company_status" : "active",
+  "created" : {
+    "at" : ISODate("2020-08-26T12:00:00.000Z")
+  },
+  "data" : {
+    "officer_role" : "director",
+    "title" : "Mrs",
+    "country_of_residence" : "United Kingdom",
+    "links" : {
+      "officer" : {
+        "self" : "/officers/<officerId>",
+        "appointments" : "/officers/<officerId>/appointments"
+      },
+      "self" : "/company/12345678/appointments/7IjxamNGLlqtIingmTZJJ42Hw9Q"
+    },
+    "nationality" : "British",
+    "forename" : "Noname1",
+    "surname" : "NOSURNAME",
+    "updated_at" : ISODate("2020-08-26T13:00:00.000Z"),
+    "other_forenames" : "Noname2",
+    "appointed_on" : ISODate("2020-08-26T12:00:00.000Z"),
+    "etag" : "8f58a770d34f982a1b2a5a29fcde12528e82f903",
+    "occupation" : "Company Director",
+    "service_address" : {
+      "region" : "Cardiff",
+      "address_line_1" : "1 Crown Way",
+      "postal_code" : "CF14 3UZ",
+      "address_line_2" : "Pavement",
+      "locality" : "Cardiff"
+    }
+  },
+  "sensitive_data" : {
+    "usual_residential_address" : {
+      "address_line_1" : "ura_line1",
+      "address_line_2" : "ura_line2",
+      "care_of" : "ura_care_of",
+      "country" : "United Kingdom",
+      "locality" : "Cardiff",
+      "po_box" : "ura_po",
+      "postal_code" : "CF2 1B6",
+      "premises" : "URA",
+      "region" : "ura_region"
+    },
+    "date_of_birth" : ISODate("1980-01-01T00:00:00.000Z")
+  },
+  "delta_at" : ISODate("2020-06-23T12:13:03.006Z"),
+  "internal_id" : "2500085646",
+  "officer_id" : "<officerId>",
+  "officer_role_sort_order" : 200,
+  "updated" : {
+    "at" : ISODate("2020-08-26T13:00:00.000Z")
+  },
+  "previous_officer_id" : "<officerId>"
+}

--- a/src/test/resources/internal-appointment-data.json
+++ b/src/test/resources/internal-appointment-data.json
@@ -21,9 +21,6 @@
     "nationality" : "British",
     "forename" : "Noname1",
     "surname" : "NOSURNAME",
-    "updated" : {
-      "at" : ISODate("2020-08-26T13:00:00.000Z")
-    },
     "other_forenames" : "Noname2",
     "appointed_on" : ISODate("2020-08-26T12:00:00.000Z"),
     "etag" : "8f58a770d34f982a1b2a5a29fcde12528e82f903",


### PR DESCRIPTION
This PR changes the logic for calculating the max items per page. When an external GET request hits the API, the max items per page is set to 50, even if the query param is set to above that number. When an internal GET request hits the API, the max items per page is set to 500.

Whether or not the incoming request is external or internal is determined by the request header having a certain string that proves it can only be an internal request.

Tested locally.

[DSND-1968](https://companieshouse.atlassian.net/browse/DSND-1968)

[DSND-1968]: https://companieshouse.atlassian.net/browse/DSND-1968?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ