### PR TITLE
DSND-2047: Refactor findOfficerAppointments query to handle officers with large numbers of appointments

### DIFF
--- a/src/it/java/uk/gov/companieshouse/company_appointments/officerappointments/OfficerAppointmentsControllerITest.java
+++ b/src/it/java/uk/gov/companieshouse/company_appointments/officerappointments/OfficerAppointmentsControllerITest.java
@@ -10,6 +10,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static uk.gov.companieshouse.company_appointments.interceptor.AuthenticationHelperImpl.ERIC_AUTHORISED_KEY_PRIVILEGES_HEADER;
 
+import com.mongodb.client.result.DeleteResult;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
@@ -170,7 +171,7 @@ class OfficerAppointmentsControllerITest {
         // clean up
         Query query = new Query()
                 .addCriteria(Criteria.where("officer_id").is(officerId));
-        mongoTemplate.findAllAndRemove(query, DELTA_APPOINTMENTS_COLLECTION);
+        mongoTemplate.remove(query, DELTA_APPOINTMENTS_COLLECTION);
 
         assertTrue(mongoTemplate.find(query, CompanyAppointmentDocument.class).isEmpty());
     }
@@ -218,7 +219,7 @@ class OfficerAppointmentsControllerITest {
         // clean up
         Query query = new Query()
                 .addCriteria(Criteria.where("officer_id").is(officerId));
-        mongoTemplate.findAllAndRemove(query, DELTA_APPOINTMENTS_COLLECTION);
+        mongoTemplate.remove(query, DELTA_APPOINTMENTS_COLLECTION);
 
         assertTrue(mongoTemplate.find(query, CompanyAppointmentDocument.class).isEmpty());
     }
@@ -266,21 +267,22 @@ class OfficerAppointmentsControllerITest {
         // clean up
         Query query = new Query()
                 .addCriteria(Criteria.where("officer_id").is(officerId));
-        mongoTemplate.findAllAndRemove(query, DELTA_APPOINTMENTS_COLLECTION);
+        mongoTemplate.remove(query, DELTA_APPOINTMENTS_COLLECTION);
 
         assertTrue(mongoTemplate.find(query, CompanyAppointmentDocument.class).isEmpty());
     }
 
-    @DisplayName("Should return HTTP 200 OK and a list of 500K appointments for an officer with 150K appointments")
+    @DisplayName("Should return HTTP 200 OK and a list of 500K appointments for an officer with 400K appointments")
     @Test
     void getOfficerAppointmentsInternalWhenOfficerHas150KAppointments() throws Exception {
         // given
         final String officerId = UUID.randomUUID().toString();
         final int expectedItemsPerPage = 500;
         final int requestedItemsPerPage = 500;
+        final int appointmentCount = 400_000;
 
         List<Document> documentsToInsert = new ArrayList<>();
-        for (int i = 0; i < requestedItemsPerPage; i++) {
+        for (int i = 0; i < appointmentCount; i++) {
             String rawJson = IOUtils.resourceToString("/internal-appointment-data.json", StandardCharsets.UTF_8);
             Document document = Document.parse(rawJson
                     .replaceAll("<id>", UUID.randomUUID().toString())
@@ -310,12 +312,12 @@ class OfficerAppointmentsControllerITest {
                 .andExpect(jsonPath("$.items", hasSize(expectedItemsPerPage)))
                 .andExpect(jsonPath("$.name", is("Noname1 Noname2 NOSURNAME")))
                 .andExpect(jsonPath("$.start_index", is(0)))
-                .andExpect(jsonPath("$.total_results", is(requestedItemsPerPage)));
+                .andExpect(jsonPath("$.total_results", is(appointmentCount)));
 
         // clean up
         Query query = new Query()
                 .addCriteria(Criteria.where("officer_id").is(officerId));
-        mongoTemplate.findAllAndRemove(query, DELTA_APPOINTMENTS_COLLECTION);
+        mongoTemplate.remove(query, DELTA_APPOINTMENTS_COLLECTION);
 
         assertTrue(mongoTemplate.find(query, CompanyAppointmentDocument.class).isEmpty());
     }

--- a/src/it/java/uk/gov/companieshouse/company_appointments/officerappointments/OfficerAppointmentsControllerITest.java
+++ b/src/it/java/uk/gov/companieshouse/company_appointments/officerappointments/OfficerAppointmentsControllerITest.java
@@ -271,6 +271,55 @@ class OfficerAppointmentsControllerITest {
         assertTrue(mongoTemplate.find(query, CompanyAppointmentDocument.class).isEmpty());
     }
 
+    @DisplayName("Should return HTTP 200 OK and a list of 500K appointments for an officer with 150K appointments")
+    @Test
+    void getOfficerAppointmentsInternalWhenOfficerHas150KAppointments() throws Exception {
+        // given
+        final String officerId = UUID.randomUUID().toString();
+        final int expectedItemsPerPage = 500;
+        final int requestedItemsPerPage = 500;
+
+        List<Document> documentsToInsert = new ArrayList<>();
+        for (int i = 0; i < requestedItemsPerPage; i++) {
+            String rawJson = IOUtils.resourceToString("/internal-appointment-data.json", StandardCharsets.UTF_8);
+            Document document = Document.parse(rawJson
+                    .replaceAll("<id>", UUID.randomUUID().toString())
+                    .replaceAll("<officerId>", officerId));
+            documentsToInsert.add(document);
+        }
+        mongoTemplate.insert(documentsToInsert, DELTA_APPOINTMENTS_COLLECTION);
+
+        //when
+        ResultActions result = mockMvc.perform(get("/officers/{officer_id}/appointments?items_per_page={itemsPerPage}", officerId, requestedItemsPerPage)
+                .header("ERIC-Identity", "123")
+                .header("ERIC-Identity-Type", "key")
+                .header("X-Request-Id", "requestId")
+                .header(ERIC_AUTHORISED_KEY_PRIVILEGES_HEADER, "internal-app")
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.APPLICATION_JSON));
+
+        //then
+        result.andExpect(status().isOk())
+                .andExpect(jsonPath("$.date_of_birth", not(contains("day"))))
+                .andExpect(jsonPath("$.date_of_birth.year", is(1980)))
+                .andExpect(jsonPath("$.date_of_birth.month", is(1)))
+                .andExpect(jsonPath("$.is_corporate_officer", is(false)))
+                .andExpect(jsonPath("$.items_per_page", is(expectedItemsPerPage)))
+                .andExpect(jsonPath("$.kind", is("personal-appointment")))
+                .andExpect(jsonPath("$.links.self", is(String.format("/officers/%s/appointments", officerId))))
+                .andExpect(jsonPath("$.items", hasSize(expectedItemsPerPage)))
+                .andExpect(jsonPath("$.name", is("Noname1 Noname2 NOSURNAME")))
+                .andExpect(jsonPath("$.start_index", is(0)))
+                .andExpect(jsonPath("$.total_results", is(requestedItemsPerPage)));
+
+        // clean up
+        Query query = new Query()
+                .addCriteria(Criteria.where("officer_id").is(officerId));
+        mongoTemplate.findAllAndRemove(query, DELTA_APPOINTMENTS_COLLECTION);
+
+        assertTrue(mongoTemplate.find(query, CompanyAppointmentDocument.class).isEmpty());
+    }
+
     @DisplayName("Should return HTTP 200 OK and a list of 50 appointments for a particular officer id when not using internal app privileges and items per page is above 500")
     @Test
     void getOfficerAppointmentsExternalWhenItemsPerPageExceeds500() throws Exception {

--- a/src/it/java/uk/gov/companieshouse/company_appointments/officerappointments/OfficerAppointmentsRepositoryITest.java
+++ b/src/it/java/uk/gov/companieshouse/company_appointments/officerappointments/OfficerAppointmentsRepositoryITest.java
@@ -82,11 +82,6 @@ class OfficerAppointmentsRepositoryITest {
         assertEquals(5, officerAppointmentsAggregate.getTotalResults());
         assertEquals(1, officerAppointmentsAggregate.getInactiveCount());
         assertEquals(2, officerAppointmentsAggregate.getResignedCount());
-        assertEquals(OFFICER_ID, officerAppointmentsAggregate.getOfficerAppointments().get(0).getOfficerId());
-        assertEquals(OFFICER_ID, officerAppointmentsAggregate.getOfficerAppointments().get(1).getOfficerId());
-        assertEquals(OFFICER_ID, officerAppointmentsAggregate.getOfficerAppointments().get(2).getOfficerId());
-        assertEquals(OFFICER_ID, officerAppointmentsAggregate.getOfficerAppointments().get(3).getOfficerId());
-        assertEquals(OFFICER_ID, officerAppointmentsAggregate.getOfficerAppointments().get(4).getOfficerId());
 
         assertEquals("active_1",
                 officerAppointmentsAggregate.getOfficerAppointments().get(0).getId());
@@ -134,9 +129,6 @@ class OfficerAppointmentsRepositoryITest {
         assertEquals(0, officerAppointmentsAggregate.getInactiveCount());
         assertEquals(0, officerAppointmentsAggregate.getResignedCount());
 
-        assertEquals(OFFICER_ID, officerAppointmentsAggregate.getOfficerAppointments().get(0).getOfficerId());
-        assertEquals(OFFICER_ID, officerAppointmentsAggregate.getOfficerAppointments().get(1).getOfficerId());
-
         assertEquals("active_1",
                 officerAppointmentsAggregate.getOfficerAppointments().get(0).getId());
         assertEquals("active_2",
@@ -171,9 +163,6 @@ class OfficerAppointmentsRepositoryITest {
         assertEquals(5, officerAppointmentsAggregate.getTotalResults());
         assertEquals(1, officerAppointmentsAggregate.getInactiveCount());
         assertEquals(2, officerAppointmentsAggregate.getResignedCount());
-        assertEquals(OFFICER_ID, officerAppointmentsAggregate.getOfficerAppointments().get(0).getOfficerId());
-        assertEquals(OFFICER_ID, officerAppointmentsAggregate.getOfficerAppointments().get(1).getOfficerId());
-        assertEquals(OFFICER_ID, officerAppointmentsAggregate.getOfficerAppointments().get(2).getOfficerId());
 
         assertEquals("active_2",
                 officerAppointmentsAggregate.getOfficerAppointments().get(0).getId());
@@ -196,7 +185,6 @@ class OfficerAppointmentsRepositoryITest {
         assertEquals(2, officerAppointmentsAggregate.getTotalResults());
         assertEquals(0, officerAppointmentsAggregate.getInactiveCount());
         assertEquals(0, officerAppointmentsAggregate.getResignedCount());
-        assertEquals(OFFICER_ID, officerAppointmentsAggregate.getOfficerAppointments().get(0).getOfficerId());
 
         assertEquals("active_2",
                 officerAppointmentsAggregate.getOfficerAppointments().get(0).getId());

--- a/src/it/java/uk/gov/companieshouse/company_appointments/tests/CompanyAppointmentRepositoryITest.java
+++ b/src/it/java/uk/gov/companieshouse/company_appointments/tests/CompanyAppointmentRepositoryITest.java
@@ -123,4 +123,15 @@ class CompanyAppointmentRepositoryITest {
         // then
         assertFalse(actual);
     }
+
+    @DisplayName("Repository returns document with given company number and appointment ID")
+    @Test
+    void readByCompanyNumberAndAppointmentID() {
+        // given
+        // when
+        Optional<CompanyAppointmentDocument> actual = repository.readByCompanyNumberAndAppointmentID(COMPANY_NUMBER, APPOINTMENT_ID);
+
+        // then
+        assertTrue(actual.isPresent());
+    }
 }

--- a/src/it/resources/application-test.properties
+++ b/src/it/resources/application-test.properties
@@ -5,3 +5,5 @@ spring.data.mongodb.field-naming-strategy=uk.gov.companieshouse.company_appointm
 
 chs.kafka.api.endpoint=http://localhost:8888
 chs.kafka.api.key=chsApiKey
+
+logging.level.org.springframework.data.mongodb.core.MongoTemplate=DEBUG

--- a/src/main/java/uk/gov/companieshouse/company_appointments/officerappointments/CompanyAppointmentDocumentId.java
+++ b/src/main/java/uk/gov/companieshouse/company_appointments/officerappointments/CompanyAppointmentDocumentId.java
@@ -1,0 +1,18 @@
+package uk.gov.companieshouse.company_appointments.officerappointments;
+
+import org.springframework.data.annotation.Id;
+
+public class CompanyAppointmentDocumentId {
+
+    @Id
+    private String id;
+
+    public String getId() {
+        return id;
+    }
+
+    public CompanyAppointmentDocumentId id(String id) {
+        this.id = id;
+        return this;
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/company_appointments/officerappointments/OfficerAppointmentsAggregate.java
+++ b/src/main/java/uk/gov/companieshouse/company_appointments/officerappointments/OfficerAppointmentsAggregate.java
@@ -4,7 +4,6 @@ import java.util.ArrayList;
 import java.util.List;
 import org.springframework.data.mongodb.core.mapping.Document;
 import org.springframework.data.mongodb.core.mapping.Field;
-import uk.gov.companieshouse.company_appointments.model.data.CompanyAppointmentDocument;
 
 @Document
 class OfficerAppointmentsAggregate {
@@ -12,12 +11,11 @@ class OfficerAppointmentsAggregate {
     @Field("total_results")
     private Integer totalResults;
     @Field("officer_appointments")
-    private List<CompanyAppointmentDocument> officerAppointments;
+    private List<CompanyAppointmentDocumentId> officerAppointments;
     @Field("inactive_count")
     private Integer inactiveCount;
     @Field("resigned_count")
     private Integer resignedCount;
-
 
     OfficerAppointmentsAggregate() {
         this.officerAppointments = new ArrayList<>();
@@ -32,12 +30,12 @@ class OfficerAppointmentsAggregate {
         return this;
     }
 
-    public List<CompanyAppointmentDocument> getOfficerAppointments() {
+    public List<CompanyAppointmentDocumentId> getOfficerAppointments() {
         return officerAppointments;
     }
 
     public OfficerAppointmentsAggregate officerAppointments(
-            List<CompanyAppointmentDocument> officerAppointments) {
+            List<CompanyAppointmentDocumentId> officerAppointments) {
         this.officerAppointments = officerAppointments;
         return this;
     }

--- a/src/main/java/uk/gov/companieshouse/company_appointments/officerappointments/OfficerAppointmentsMapper.java
+++ b/src/main/java/uk/gov/companieshouse/company_appointments/officerappointments/OfficerAppointmentsMapper.java
@@ -3,6 +3,7 @@ package uk.gov.companieshouse.company_appointments.officerappointments;
 import static java.util.Optional.ofNullable;
 import static uk.gov.companieshouse.api.officer.AppointmentList.KindEnum;
 
+import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import org.springframework.stereotype.Component;
@@ -48,7 +49,7 @@ class OfficerAppointmentsMapper {
                                     .links(new OfficerLinkTypes().self(
                                             String.format("/officers/%s/appointments",
                                                     firstAppointment.getOfficerId())))
-                                    .items(itemsMapper.map(aggregate.getOfficerAppointments()))
+                                    .items(itemsMapper.map(mapperRequest.getOfficerAppointments()))
                                     .name(nameMapper.map(data))
                                     .startIndex(mapperRequest.getStartIndex())
                                     .totalResults(aggregate.getTotalResults())
@@ -71,6 +72,7 @@ class OfficerAppointmentsMapper {
         private Integer startIndex;
         private Integer itemsPerPage;
         private CompanyAppointmentDocument firstAppointment;
+        private List<CompanyAppointmentDocument> officerAppointments;
         private OfficerAppointmentsAggregate aggregate;
 
         Integer getStartIndex() {
@@ -109,6 +111,16 @@ class OfficerAppointmentsMapper {
             return this;
         }
 
+        List<CompanyAppointmentDocument> getOfficerAppointments() {
+            return officerAppointments;
+        }
+
+        MapperRequest officerAppointments(
+                List<CompanyAppointmentDocument> officerAppointments) {
+            this.officerAppointments = officerAppointments;
+            return this;
+        }
+
         @Override
         public boolean equals(Object o) {
             if (this == o) {
@@ -118,14 +130,16 @@ class OfficerAppointmentsMapper {
                 return false;
             }
             MapperRequest that = (MapperRequest) o;
-            return Objects.equals(startIndex, that.startIndex) && Objects.equals(itemsPerPage,
-                    that.itemsPerPage) && Objects.equals(firstAppointment, that.firstAppointment)
-                    && Objects.equals(aggregate, that.aggregate);
+            return Objects.equals(startIndex, that.startIndex) && Objects.equals(
+                    itemsPerPage, that.itemsPerPage) && Objects.equals(firstAppointment,
+                    that.firstAppointment) && Objects.equals(officerAppointments,
+                    that.officerAppointments) && Objects.equals(aggregate, that.aggregate);
         }
 
         @Override
         public int hashCode() {
-            return Objects.hash(startIndex, itemsPerPage, firstAppointment, aggregate);
+            return Objects.hash(startIndex, itemsPerPage, firstAppointment, officerAppointments,
+                    aggregate);
         }
     }
 }

--- a/src/main/java/uk/gov/companieshouse/company_appointments/officerappointments/OfficerAppointmentsRepository.java
+++ b/src/main/java/uk/gov/companieshouse/company_appointments/officerappointments/OfficerAppointmentsRepository.java
@@ -3,6 +3,7 @@ package uk.gov.companieshouse.company_appointments.officerappointments;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.mongodb.repository.Aggregation;
+import org.springframework.data.mongodb.repository.Meta;
 import org.springframework.data.mongodb.repository.MongoRepository;
 import org.springframework.stereotype.Repository;
 import uk.gov.companieshouse.company_appointments.model.data.CompanyAppointmentDocument;
@@ -95,6 +96,7 @@ interface OfficerAppointmentsRepository extends MongoRepository<CompanyAppointme
         +       "}"
         +   "}"
     })
+    @Meta(allowDiskUse = true)
     OfficerAppointmentsAggregate findOfficerAppointments(String officerId, boolean filterEnabled,
             List<String> filterStatuses, int startIndex, int pageSize);
 

--- a/src/main/java/uk/gov/companieshouse/company_appointments/officerappointments/OfficerAppointmentsService.java
+++ b/src/main/java/uk/gov/companieshouse/company_appointments/officerappointments/OfficerAppointmentsService.java
@@ -1,7 +1,7 @@
 package uk.gov.companieshouse.company_appointments.officerappointments;
 
+import java.util.List;
 import java.util.Optional;
-import java.util.Set;
 import java.util.stream.Collectors;
 import org.springframework.stereotype.Service;
 import uk.gov.companieshouse.api.officer.AppointmentList;
@@ -33,9 +33,9 @@ class OfficerAppointmentsService {
 
                     OfficerAppointmentsAggregate aggregate = repository.findOfficerAppointments(officerId,
                             filter.isFilterEnabled(), filter.getFilterStatuses(), startIndex, itemsPerPage);
-                    Set<String> docIds = aggregate.getOfficerAppointments().stream()
+                    List<String> docIds = aggregate.getOfficerAppointments().stream()
                             .map(CompanyAppointmentDocumentId::getId)
-                            .collect(Collectors.toSet());
+                            .collect(Collectors.toList());
                     return mapper.mapOfficerAppointments(new MapperRequest()
                             .startIndex(startIndex)
                             .itemsPerPage(itemsPerPage)

--- a/src/main/java/uk/gov/companieshouse/company_appointments/officerappointments/OfficerAppointmentsService.java
+++ b/src/main/java/uk/gov/companieshouse/company_appointments/officerappointments/OfficerAppointmentsService.java
@@ -1,6 +1,8 @@
 package uk.gov.companieshouse.company_appointments.officerappointments;
 
 import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 import org.springframework.stereotype.Service;
 import uk.gov.companieshouse.api.officer.AppointmentList;
 import uk.gov.companieshouse.company_appointments.officerappointments.OfficerAppointmentsMapper.MapperRequest;
@@ -31,12 +33,16 @@ class OfficerAppointmentsService {
 
                     OfficerAppointmentsAggregate aggregate = repository.findOfficerAppointments(officerId,
                             filter.isFilterEnabled(), filter.getFilterStatuses(), startIndex, itemsPerPage);
-
+                    Set<String> docIds = aggregate.getOfficerAppointments().stream()
+                            .map(CompanyAppointmentDocumentId::getId)
+                            .collect(Collectors.toSet());
                     return mapper.mapOfficerAppointments(new MapperRequest()
                             .startIndex(startIndex)
                             .itemsPerPage(itemsPerPage)
                             .firstAppointment(firstAppointment)
-                            .aggregate(aggregate));
+                            .aggregate(aggregate)
+                            .officerAppointments(repository.findByIdIn(docIds))
+                    );
                 });
     }
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,6 +1,6 @@
 spring.data.mongodb.uri=${MONGODB_URL}
 logging.level.org.springframework.web=${WEB_LOGGING_LEVEL:INFO}
-logging.level.uk.gov.companieshouse.company_appointments=${LOGLEVEL}
+logging.level.uk.gov.companieshouse.company_appointments=${LOGLEVEL:INFO}
 logging.level.org.springframework.web.filter.CommonsRequestLoggingFilter=${REQUEST_LOGGING_LEVEL:INFO}
 
 spring.data.mongodb.field-naming-strategy=uk.gov.companieshouse.company_appointments.config.JsonSnakeCaseNamingStrategy

--- a/src/test/java/uk/gov/companieshouse/company_appointments/logging/DataMapHolderTest.java
+++ b/src/test/java/uk/gov/companieshouse/company_appointments/logging/DataMapHolderTest.java
@@ -1,0 +1,49 @@
+package uk.gov.companieshouse.company_appointments.logging;
+
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import uk.gov.companieshouse.logging.util.DataMap;
+
+class DataMapHolderTest {
+
+    @BeforeEach
+    void setUp() {
+        DataMapHolder.clear();
+    }
+
+    @Test
+    void getLogMapWithExplicitRequestId() {
+        DataMapHolder.initialise("requestId");
+
+        var logMap = DataMapHolder.getLogMap();
+        assertEquals("requestId", DataMapHolder.getRequestId());
+    }
+
+    @Test
+    void getLogMapWithDefaultRequestId() {
+        var logMap = DataMapHolder.getLogMap();
+        assertEquals("uninitialised", DataMapHolder.getRequestId());
+    }
+
+    @Test
+    void get() {
+        DataMapHolder.initialise("requestId");
+
+        DataMap.Builder builder = DataMapHolder.get();
+        DataMap dataMap = builder.build();
+        assertEquals("requestId", dataMap.getLogMap().get("request_id"));
+    }
+
+    @Test
+    void clear() {
+        DataMapHolder.clear();
+        assertEquals("uninitialised", DataMapHolder.getRequestId());
+
+        var logMap = DataMapHolder.getLogMap();
+        assertTrue(logMap.containsKey("request_id"));
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/company_appointments/officerappointments/OfficerAppointmentsMapperTest.java
+++ b/src/test/java/uk/gov/companieshouse/company_appointments/officerappointments/OfficerAppointmentsMapperTest.java
@@ -3,6 +3,7 @@ package uk.gov.companieshouse.company_appointments.officerappointments;
 import static java.util.Collections.emptyList;
 import static java.util.Collections.singletonList;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -176,6 +177,44 @@ class OfficerAppointmentsMapperTest {
         verifyNoInteractions(roleMapper);
         verifyNoInteractions(itemsMapper);
         verifyNoInteractions(nameMapper);
+    }
+
+    @Test
+    void testEqualsAndHashCode() {
+        OfficerAppointmentsAggregate aggregate = new OfficerAppointmentsAggregate()
+                .totalResults(0)
+                .inactiveCount(0)
+                .resignedCount(0)
+                .officerAppointments(Collections.emptyList());
+        CompanyAppointmentDocument companyAppointmentDocument = getCompanyAppointmentDocument(getOfficerData(DIRECTOR), getSensitiveOfficerData());
+
+        // when
+        MapperRequest request1 = new MapperRequest()
+                .startIndex(START_INDEX)
+                .itemsPerPage(ITEMS_PER_PAGE)
+                .firstAppointment(companyAppointmentDocument)
+                .officerAppointments(Collections.emptyList())
+                .aggregate(aggregate);
+
+        MapperRequest request2 = new MapperRequest()
+                .startIndex(START_INDEX)
+                .itemsPerPage(ITEMS_PER_PAGE)
+                .firstAppointment(companyAppointmentDocument)
+                .officerAppointments(Collections.emptyList())
+                .aggregate(aggregate);
+
+        MapperRequest request3 = new MapperRequest()
+                .startIndex(10)
+                .itemsPerPage(10)
+                .firstAppointment(companyAppointmentDocument)
+                .officerAppointments(Collections.emptyList())
+                .aggregate(aggregate);
+
+        assertEquals(request1, request1);
+        assertEquals(request1, request2);
+        assertNotEquals(request1, request3);
+        assertNotEquals(request1, null);
+        assertEquals(request1.hashCode(), request2.hashCode());
     }
 
     private OfficerAppointmentsAggregate getOfficerAppointmentsAggregate() {

--- a/src/test/java/uk/gov/companieshouse/company_appointments/officerappointments/OfficerAppointmentsRepositoryTest.java
+++ b/src/test/java/uk/gov/companieshouse/company_appointments/officerappointments/OfficerAppointmentsRepositoryTest.java
@@ -31,7 +31,7 @@ import uk.gov.companieshouse.company_appointments.model.data.CompanyAppointmentD
 @SpringBootTest(classes = CompanyAppointmentsApplication.class, webEnvironment = SpringBootTest.WebEnvironment.MOCK)
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
 @TestPropertySource(properties = { "logging.level.org.springframework.data.mongodb.core.MongoTemplate=DEBUG" })
-class OfficerAppointmentsRepositoryITest {
+class OfficerAppointmentsRepositoryTest {
 
     private static final String OFFICER_ID = "5VEOBB4a9dlB_iugw_vieHjWpCk";
     private static final String SECOND_OFFICER_ID = "1234";

--- a/src/test/java/uk/gov/companieshouse/company_appointments/officerappointments/OfficerAppointmentsServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/company_appointments/officerappointments/OfficerAppointmentsServiceTest.java
@@ -122,13 +122,17 @@ class OfficerAppointmentsServiceTest {
     void getOfficerAppointments(ServiceTestArgument argument) throws BadRequestException {
         // given
         Filter filter = new Filter(argument.isFilterEnabled(), argument.getFilterStatuses());
+        List<CompanyAppointmentDocument> companyAppointmentDocuments = List.of(companyAppointmentDocument);
 
         when(repository.findFirstByOfficerId(anyString())).thenReturn(Optional.of(
                 companyAppointmentDocument));
         when(filterService.prepareFilter(any(), any())).thenReturn(filter);
         when(repository.findOfficerAppointments(anyString(), anyBoolean(), any(), anyInt(), anyInt())).thenReturn(
                 officerAppointmentsAggregate);
+        when(repository.findByIdIn(any())).thenReturn(companyAppointmentDocuments);
         when(mapper.mapOfficerAppointments(any())).thenReturn(Optional.of(officerAppointments));
+        when(officerAppointmentsAggregate.getOfficerAppointments()).thenReturn(List.of(
+                new CompanyAppointmentDocumentId().id(argument.getOfficerId())));
 
         // when
         Optional<AppointmentList> actual = service.getOfficerAppointments(argument.getRequest());
@@ -143,6 +147,7 @@ class OfficerAppointmentsServiceTest {
                 .startIndex(argument.getStartIndex())
                 .itemsPerPage(argument.getItemsPerPage())
                 .firstAppointment(companyAppointmentDocument)
+                .officerAppointments(companyAppointmentDocuments)
                 .aggregate(officerAppointmentsAggregate));
     }
 

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -14,3 +14,5 @@ api.api-key=${CHS_API_KEY:chsApiKey}
 feature.seeding_collection_enabled=false
 
 items-per-page-max-internal=500
+
+logging.level.org.springframework.data.mongodb.core.MongoTemplate=DEBUG


### PR DESCRIPTION
The initial bug was due to an officer having >150K appointments in Staging.
* Added an integration test to the fix exceeds this number with a load of head
* Projects out just the required fields to satisfy the findOfficerAppointments query early in the aggregation pipeline.
* Added a new repository method to return a collection of CompanyAppointmentDocuments given a set of document ids.
room
[DSND-2047](https://companieshouse.atlassian.net/browse/DSND-2047)

[DSND-2047]: https://companieshouse.atlassian.net/browse/DSND-2047?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ