### PR TITLE
DSND-2041: Add transactional annotation to company appointment full record service

### DIFF
--- a/src/main/java/uk/gov/companieshouse/company_appointments/config/MongoDbConfig.java
+++ b/src/main/java/uk/gov/companieshouse/company_appointments/config/MongoDbConfig.java
@@ -2,13 +2,23 @@ package uk.gov.companieshouse.company_appointments.config;
 
 import org.springframework.beans.factory.InitializingBean;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Lazy;
+import org.springframework.data.mongodb.MongoDatabaseFactory;
+import org.springframework.data.mongodb.MongoTransactionManager;
 import org.springframework.data.mongodb.core.convert.DefaultMongoTypeMapper;
 import org.springframework.data.mongodb.core.convert.MappingMongoConverter;
+import org.springframework.transaction.annotation.EnableTransactionManagement;
 
 @Configuration
+@EnableTransactionManagement
 public class MongoDbConfig implements InitializingBean {
+
+    @Bean
+    MongoTransactionManager transactionManager(MongoDatabaseFactory dbFactory) {
+        return new MongoTransactionManager(dbFactory);
+    }
 
     @Autowired
     @Lazy

--- a/src/main/java/uk/gov/companieshouse/company_appointments/exception/FailedToTransformException.java
+++ b/src/main/java/uk/gov/companieshouse/company_appointments/exception/FailedToTransformException.java
@@ -1,6 +1,6 @@
 package uk.gov.companieshouse.company_appointments.exception;
 
-public class FailedToTransformException extends Exception {
+public class FailedToTransformException extends RuntimeException {
 
     public FailedToTransformException(String message) {
         super(message);

--- a/src/main/java/uk/gov/companieshouse/company_appointments/exception/NotFoundException.java
+++ b/src/main/java/uk/gov/companieshouse/company_appointments/exception/NotFoundException.java
@@ -1,6 +1,6 @@
 package uk.gov.companieshouse.company_appointments.exception;
 
-public class NotFoundException extends Exception {
+public class NotFoundException extends RuntimeException {
 
     public NotFoundException(String message) {
         super(message);

--- a/src/main/java/uk/gov/companieshouse/company_appointments/exception/ServiceUnavailableException.java
+++ b/src/main/java/uk/gov/companieshouse/company_appointments/exception/ServiceUnavailableException.java
@@ -1,6 +1,6 @@
 package uk.gov.companieshouse.company_appointments.exception;
 
-public class ServiceUnavailableException extends Exception {
+public class ServiceUnavailableException extends RuntimeException {
 
     public ServiceUnavailableException(String message) {
         super(message);

--- a/src/main/java/uk/gov/companieshouse/company_appointments/service/CompanyAppointmentFullRecordService.java
+++ b/src/main/java/uk/gov/companieshouse/company_appointments/service/CompanyAppointmentFullRecordService.java
@@ -36,7 +36,6 @@ public class CompanyAppointmentFullRecordService {
     private final ResourceChangedApiService resourceChangedApiService;
     private final Clock clock;
     
-    @Autowired
     public CompanyAppointmentFullRecordService(
             DeltaAppointmentTransformer deltaAppointmentTransformer,
             CompanyAppointmentRepository companyAppointmentRepository, ResourceChangedApiService resourceChangedApiService, Clock clock) {
@@ -78,8 +77,10 @@ public class CompanyAppointmentFullRecordService {
                     saveAppointment(companyAppointmentDocument, instant);
                 }
             } catch (DataAccessException e) {
+                LOGGER.debug(String.format("%s: %s", e.getClass().getName(), e.getMessage()), DataMapHolder.getLogMap());
                 throw new ServiceUnavailableException("Error connecting to MongoDB");
             } catch (IllegalArgumentException e) {
+                LOGGER.debug(String.format("%s: %s", e.getClass().getName(), e.getMessage()), DataMapHolder.getLogMap());
                 throw new ServiceUnavailableException("Error connecting to chs-kafka-api");
             }
     }
@@ -98,8 +99,10 @@ public class CompanyAppointmentFullRecordService {
                     companyNumber, appointmentId, appointmentData, true));
             LOGGER.debug(String.format("ChsKafka api DELETED invoked updated successfully for company number: %s", companyNumber), DataMapHolder.getLogMap());
         } catch (DataAccessException e) {
+            LOGGER.debug(String.format("%s: %s", e.getClass().getName(), e.getMessage()), DataMapHolder.getLogMap());
             throw new ServiceUnavailableException("Error connecting to MongoDB");
         } catch (IllegalArgumentException e) {
+            LOGGER.debug(String.format("%s: %s", e.getClass().getName(), e.getMessage()), DataMapHolder.getLogMap());
             throw new ServiceUnavailableException("Error connecting to chs-kafka-api");
         }
     }

--- a/src/main/java/uk/gov/companieshouse/company_appointments/service/CompanyAppointmentFullRecordService.java
+++ b/src/main/java/uk/gov/companieshouse/company_appointments/service/CompanyAppointmentFullRecordService.java
@@ -8,6 +8,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.dao.DataAccessException;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import uk.gov.companieshouse.api.appointment.FullRecordCompanyOfficerApi;
 import uk.gov.companieshouse.company_appointments.CompanyAppointmentsApplication;
 import uk.gov.companieshouse.company_appointments.api.ResourceChangedApiService;
@@ -55,6 +56,7 @@ public class CompanyAppointmentFullRecordService {
                         String.format("Appointment [%s] for company [%s] not found", appointmentID, companyNumber)));
     }
 
+    @Transactional
     public void upsertAppointmentDelta(final FullRecordCompanyOfficerApi requestBody) throws ServiceUnavailableException {
             CompanyAppointmentDocument companyAppointmentDocument;
             try {
@@ -82,6 +84,7 @@ public class CompanyAppointmentFullRecordService {
             }
     }
 
+    @Transactional
     public void deleteAppointmentDelta(String companyNumber, String appointmentId) throws NotFoundException, ServiceUnavailableException {
         LOGGER.debug(String.format("Deleting appointment [%s] for company [%s]", appointmentId, companyNumber), DataMapHolder.getLogMap());
         try {
@@ -89,12 +92,11 @@ public class CompanyAppointmentFullRecordService {
             if (appointmentData.isEmpty()) {
                 throw new NotFoundException(String.format("Appointment [%s] for company [%s] not found", appointmentId, companyNumber));
             }
+            companyAppointmentRepository.deleteByCompanyNumberAndID(companyNumber, appointmentId);
 
             resourceChangedApiService.invokeChsKafkaApi(new ResourceChangedRequest(DataMapHolder.getRequestId(),
                     companyNumber, appointmentId, appointmentData, true));
             LOGGER.debug(String.format("ChsKafka api DELETED invoked updated successfully for company number: %s", companyNumber), DataMapHolder.getLogMap());
-
-            companyAppointmentRepository.deleteByCompanyNumberAndID(companyNumber, appointmentId);
         } catch (DataAccessException e) {
             throw new ServiceUnavailableException("Error connecting to MongoDB");
         } catch (IllegalArgumentException e) {
@@ -103,12 +105,12 @@ public class CompanyAppointmentFullRecordService {
     }
 
     private void saveAppointment(CompanyAppointmentDocument document, DeltaTimestamp instant) throws ServiceUnavailableException {
+        document.created(instant);
+        companyAppointmentRepository.insertOrUpdate(document);
         resourceChangedApiService.invokeChsKafkaApi(
                 new ResourceChangedRequest(DataMapHolder.getRequestId(), document.getCompanyNumber(), document.getAppointmentId(), null, false));
         LOGGER.debug(String.format("ChsKafka api CHANGED invoked updated successfully for company number: %s",
                 document.getCompanyNumber()), DataMapHolder.getLogMap());
-        document.created(instant);
-        companyAppointmentRepository.insertOrUpdate(document);
     }
 
     private void updateAppointment(CompanyAppointmentDocument document, CompanyAppointmentDocument existingAppointment) throws ServiceUnavailableException {


### PR DESCRIPTION
This PR fixes a race condition where resource-change-publisher calls GET on appointments api before the appointment has been persisted to the db. 

Now the full record saves and deletes are transactional, we know that the appointment has been persisted/deleted when the service method completes (i.e., before RCP calls GET).

In order for a transaction to work in the case of a failed transaction (ie. chs-kafka-api is down, and we don't want to save to the db), the exceptions thrown must extend `RuntimeException` rather than `Exception`. We also need to have the database save/delete call before the call to chs-kafka-api.

Tested locally.

[DSND-2041](https://companieshouse.atlassian.net/browse/DSND-2041)

[DSND-2041]: https://companieshouse.atlassian.net/browse/DSND-2041?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ