### PR TITLE
DSND-1520: Fix bug in resource deleted request

### DIFF
--- a/src/main/java/uk/gov/companieshouse/company_appointments/service/CompanyAppointmentFullRecordService.java
+++ b/src/main/java/uk/gov/companieshouse/company_appointments/service/CompanyAppointmentFullRecordService.java
@@ -1,11 +1,15 @@
 package uk.gov.companieshouse.company_appointments.service;
 
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import java.io.UncheckedIOException;
 import java.time.Clock;
 import java.time.Instant;
 import java.util.Map;
 import java.util.Optional;
 import org.apache.commons.lang3.StringUtils;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.dao.DataAccessException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -16,6 +20,7 @@ import uk.gov.companieshouse.company_appointments.exception.FailedToTransformExc
 import uk.gov.companieshouse.company_appointments.exception.NotFoundException;
 import uk.gov.companieshouse.company_appointments.exception.ServiceUnavailableException;
 import uk.gov.companieshouse.company_appointments.logging.DataMapHolder;
+import uk.gov.companieshouse.company_appointments.mapper.CompanyAppointmentMapper;
 import uk.gov.companieshouse.company_appointments.model.data.CompanyAppointmentDocument;
 import uk.gov.companieshouse.company_appointments.model.data.DeltaOfficerData;
 import uk.gov.companieshouse.company_appointments.model.data.DeltaTimestamp;
@@ -28,27 +33,39 @@ import uk.gov.companieshouse.logging.LoggerFactory;
 
 @Service
 public class CompanyAppointmentFullRecordService {
-    
+
     private static final Logger LOGGER = LoggerFactory.getLogger(CompanyAppointmentsApplication.APPLICATION_NAMESPACE);
+    private static final ObjectMapper NULL_CLEANING_OBJECT_MAPPER = new ObjectMapper()
+            .registerModule(new JavaTimeModule())
+            .setSerializationInclusion(Include.NON_NULL);
 
     private final DeltaAppointmentTransformer deltaAppointmentTransformer;
     private final CompanyAppointmentRepository companyAppointmentRepository;
     private final ResourceChangedApiService resourceChangedApiService;
+    private final CompanyAppointmentMapper companyAppointmentMapper;
     private final Clock clock;
-    
+
     public CompanyAppointmentFullRecordService(
             DeltaAppointmentTransformer deltaAppointmentTransformer,
-            CompanyAppointmentRepository companyAppointmentRepository, ResourceChangedApiService resourceChangedApiService, Clock clock) {
+            CompanyAppointmentRepository companyAppointmentRepository,
+            ResourceChangedApiService resourceChangedApiService,
+            CompanyAppointmentMapper companyAppointmentMapper, Clock clock) {
         this.deltaAppointmentTransformer = deltaAppointmentTransformer;
         this.companyAppointmentRepository = companyAppointmentRepository;
         this.resourceChangedApiService = resourceChangedApiService;
+        this.companyAppointmentMapper = companyAppointmentMapper;
         this.clock = clock;
     }
 
-    public CompanyAppointmentFullRecordView getAppointment(String companyNumber, String appointmentID) throws NotFoundException {
-        LOGGER.debug(String.format("Fetching appointment [%s] for company [%s]", appointmentID, companyNumber), DataMapHolder.getLogMap());
-        Optional<CompanyAppointmentDocument> appointmentData = companyAppointmentRepository.readByCompanyNumberAndID(companyNumber, appointmentID);
-        appointmentData.ifPresent(appt -> LOGGER.debug(String.format("Found appointment [%s] for company [%s]", appointmentID, companyNumber), DataMapHolder.getLogMap()));
+    public CompanyAppointmentFullRecordView getAppointment(String companyNumber, String appointmentID)
+            throws NotFoundException {
+        LOGGER.debug(String.format("Fetching appointment [%s] for company [%s]", appointmentID, companyNumber),
+                DataMapHolder.getLogMap());
+        Optional<CompanyAppointmentDocument> appointmentData = companyAppointmentRepository.readByCompanyNumberAndID(
+                companyNumber, appointmentID);
+        appointmentData.ifPresent(appt -> LOGGER.debug(
+                String.format("Found appointment [%s] for company [%s]", appointmentID, companyNumber),
+                DataMapHolder.getLogMap()));
 
         return appointmentData.map(app -> CompanyAppointmentFullRecordView.Builder.view(app).build())
                 .orElseThrow(() -> new NotFoundException(
@@ -56,48 +73,27 @@ public class CompanyAppointmentFullRecordService {
     }
 
     @Transactional
-    public void upsertAppointmentDelta(final FullRecordCompanyOfficerApi requestBody) throws ServiceUnavailableException {
-            CompanyAppointmentDocument companyAppointmentDocument;
-            try {
-                companyAppointmentDocument = deltaAppointmentTransformer.transform(requestBody);
-            } catch (FailedToTransformException ex) {
-                throw new ServiceUnavailableException(String.format("Failed to transform payload: %s", ex.getMessage()));
-            }
-            var instant = new DeltaTimestamp(Instant.now(clock));
-            DeltaOfficerData officer = companyAppointmentDocument.getData();
-
-            if (officer != null) {
-                companyAppointmentDocument.updated(instant);
-            }
-            try {
-                Optional<CompanyAppointmentDocument> existingAppointment = getExistingDelta(companyAppointmentDocument);
-                if (existingAppointment.isPresent()) {
-                    updateAppointment(companyAppointmentDocument, existingAppointment.get());
-                } else {
-                    saveAppointment(companyAppointmentDocument, instant);
-                }
-            } catch (DataAccessException e) {
-                LOGGER.debug(String.format("%s: %s", e.getClass().getName(), e.getMessage()), DataMapHolder.getLogMap());
-                throw new ServiceUnavailableException("Error connecting to MongoDB");
-            } catch (IllegalArgumentException e) {
-                LOGGER.debug(String.format("%s: %s", e.getClass().getName(), e.getMessage()), DataMapHolder.getLogMap());
-                throw new ServiceUnavailableException("Error connecting to chs-kafka-api");
-            }
-    }
-
-    @Transactional
-    public void deleteAppointmentDelta(String companyNumber, String appointmentId) throws NotFoundException, ServiceUnavailableException {
-        LOGGER.debug(String.format("Deleting appointment [%s] for company [%s]", appointmentId, companyNumber), DataMapHolder.getLogMap());
+    public void upsertAppointmentDelta(final FullRecordCompanyOfficerApi requestBody)
+            throws ServiceUnavailableException {
+        CompanyAppointmentDocument companyAppointmentDocument;
         try {
-            Optional<CompanyAppointmentDocument> appointmentData = companyAppointmentRepository.readByCompanyNumberAndID(companyNumber, appointmentId);
-            if (appointmentData.isEmpty()) {
-                throw new NotFoundException(String.format("Appointment [%s] for company [%s] not found", appointmentId, companyNumber));
-            }
-            companyAppointmentRepository.deleteByCompanyNumberAndID(companyNumber, appointmentId);
+            companyAppointmentDocument = deltaAppointmentTransformer.transform(requestBody);
+        } catch (FailedToTransformException ex) {
+            throw new ServiceUnavailableException(String.format("Failed to transform payload: %s", ex.getMessage()));
+        }
+        var instant = new DeltaTimestamp(Instant.now(clock));
+        DeltaOfficerData officer = companyAppointmentDocument.getData();
 
-            resourceChangedApiService.invokeChsKafkaApi(new ResourceChangedRequest(DataMapHolder.getRequestId(),
-                    companyNumber, appointmentId, appointmentData, true));
-            LOGGER.debug(String.format("ChsKafka api DELETED invoked updated successfully for company number: %s", companyNumber), DataMapHolder.getLogMap());
+        if (officer != null) {
+            companyAppointmentDocument.updated(instant);
+        }
+        try {
+            Optional<CompanyAppointmentDocument> existingAppointment = getExistingDelta(companyAppointmentDocument);
+            if (existingAppointment.isPresent()) {
+                updateAppointment(companyAppointmentDocument, existingAppointment.get());
+            } else {
+                saveAppointment(companyAppointmentDocument, instant);
+            }
         } catch (DataAccessException e) {
             LOGGER.debug(String.format("%s: %s", e.getClass().getName(), e.getMessage()), DataMapHolder.getLogMap());
             throw new ServiceUnavailableException("Error connecting to MongoDB");
@@ -107,16 +103,53 @@ public class CompanyAppointmentFullRecordService {
         }
     }
 
-    private void saveAppointment(CompanyAppointmentDocument document, DeltaTimestamp instant) throws ServiceUnavailableException {
+    @Transactional
+    public void deleteAppointmentDelta(String companyNumber, String appointmentId)
+            throws NotFoundException, ServiceUnavailableException {
+        LOGGER.debug(String.format("Deleting appointment [%s] for company [%s]", appointmentId, companyNumber),
+                DataMapHolder.getLogMap());
+        try {
+            Optional<CompanyAppointmentDocument> document = companyAppointmentRepository.readByCompanyNumberAndID(
+                    companyNumber, appointmentId);
+            if (document.isEmpty()) {
+                throw new NotFoundException(
+                        String.format("Appointment [%s] for company [%s] not found", appointmentId, companyNumber));
+            }
+            companyAppointmentRepository.deleteByCompanyNumberAndID(companyNumber, appointmentId);
+
+            // Serialise and deserialise OfficerSummary an extra time to remove null fields
+            String officerJson = NULL_CLEANING_OBJECT_MAPPER.writeValueAsString(companyAppointmentMapper.map(document.get()));
+            Object officerObject = NULL_CLEANING_OBJECT_MAPPER.readValue(officerJson, Object.class);
+
+            resourceChangedApiService.invokeChsKafkaApi(new ResourceChangedRequest(DataMapHolder.getRequestId(),
+                    companyNumber, appointmentId, officerObject, true));
+            LOGGER.debug(String.format("ChsKafka api DELETED invoked updated successfully for company number: %s",
+                    companyNumber), DataMapHolder.getLogMap());
+        } catch (DataAccessException e) {
+            LOGGER.debug(String.format("%s: %s", e.getClass().getName(), e.getMessage()), DataMapHolder.getLogMap());
+            throw new ServiceUnavailableException("Error connecting to MongoDB");
+        } catch (IllegalArgumentException e) {
+            LOGGER.debug(String.format("%s: %s", e.getClass().getName(), e.getMessage()), DataMapHolder.getLogMap());
+            throw new ServiceUnavailableException("Error connecting to chs-kafka-api");
+        } catch (JsonProcessingException e) {
+            LOGGER.debug("Failed to serialise/deserialise officer summary", DataMapHolder.getLogMap());
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    private void saveAppointment(CompanyAppointmentDocument document, DeltaTimestamp instant)
+            throws ServiceUnavailableException {
         document.created(instant);
         companyAppointmentRepository.insertOrUpdate(document);
         resourceChangedApiService.invokeChsKafkaApi(
-                new ResourceChangedRequest(DataMapHolder.getRequestId(), document.getCompanyNumber(), document.getAppointmentId(), null, false));
+                new ResourceChangedRequest(DataMapHolder.getRequestId(), document.getCompanyNumber(),
+                        document.getAppointmentId(), null, false));
         LOGGER.debug(String.format("ChsKafka api CHANGED invoked updated successfully for company number: %s",
                 document.getCompanyNumber()), DataMapHolder.getLogMap());
     }
 
-    private void updateAppointment(CompanyAppointmentDocument document, CompanyAppointmentDocument existingAppointment) throws ServiceUnavailableException {
+    private void updateAppointment(CompanyAppointmentDocument document, CompanyAppointmentDocument existingAppointment)
+            throws ServiceUnavailableException {
 
         if (isDeltaStale(document.getDeltaAt(), existingAppointment.getDeltaAt())) {
             logStaleIncomingDelta(document, existingAppointment.getDeltaAt());
@@ -129,7 +162,8 @@ public class CompanyAppointmentFullRecordService {
         return !incomingDelta.isAfter(existingDelta);
     }
 
-    private Optional<CompanyAppointmentDocument> getExistingDelta(final CompanyAppointmentDocument incomingAppointment) {
+    private Optional<CompanyAppointmentDocument> getExistingDelta(
+            final CompanyAppointmentDocument incomingAppointment) {
 
         final String id = incomingAppointment.getId();
         final String companyNumber = incomingAppointment.getCompanyNumber();

--- a/src/test/java/uk/gov/companieshouse/company_appointments/CompanyAppointmentControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/company_appointments/CompanyAppointmentControllerTest.java
@@ -77,7 +77,7 @@ public class CompanyAppointmentControllerTest {
     }
 
     @Test
-    void testControllerReturns200StatusAndAppointmentsForCompany() throws Exception {
+    void testControllerReturns200StatusAndAppointmentsForCompany() {
         // given
         FetchAppointmentsRequest request =
                 FetchAppointmentsRequest.Builder.builder()
@@ -98,7 +98,7 @@ public class CompanyAppointmentControllerTest {
     }
 
     @Test
-    void testControllerReturns404StatusIfAppointmentForCompanyNotFound() throws Exception {
+    void testControllerReturns404StatusIfAppointmentForCompanyNotFound() {
         // given
         when(companyAppointmentService.fetchAppointmentsForCompany(any())).thenThrow(NotFoundException.class);
 
@@ -111,7 +111,7 @@ public class CompanyAppointmentControllerTest {
     }
 
     @Test
-    void testControllerReturns400StatusIfOrderByParameterIsIncorrect() throws Exception {
+    void testControllerReturns400StatusIfOrderByParameterIsIncorrect() {
         // given
         FetchAppointmentsRequest request =
                 FetchAppointmentsRequest.Builder.builder()
@@ -131,7 +131,7 @@ public class CompanyAppointmentControllerTest {
     }
 
     @Test
-    void testFetchAppointmentForCompanyWithIndexAndItemsReturns200Status() throws Exception {
+    void testFetchAppointmentForCompanyWithIndexAndItemsReturns200Status() {
         // given
         FetchAppointmentsRequest request =
                 FetchAppointmentsRequest.Builder.builder()
@@ -152,7 +152,7 @@ public class CompanyAppointmentControllerTest {
     }
 
     @Test
-    void testControllerReturns500StatusIfThereIsServiceUnavailable() throws Exception {
+    void testControllerReturns500StatusIfThereIsServiceUnavailable() {
         // given
         FetchAppointmentsRequest request =
                 FetchAppointmentsRequest.Builder.builder()
@@ -174,7 +174,7 @@ public class CompanyAppointmentControllerTest {
     }
 
     @Test
-    void shouldReturnOKForValidRequestWhenPatchingNameAndStatus() throws Exception {
+    void shouldReturnOKForValidRequestWhenPatchingNameAndStatus() {
         // Given
 
         // When
@@ -188,7 +188,7 @@ public class CompanyAppointmentControllerTest {
     }
 
     @Test
-    void shouldThrowNotFoundForMissingCompanyNumberWhenPatchingNameAndStatus() throws Exception {
+    void shouldThrowNotFoundForMissingCompanyNumberWhenPatchingNameAndStatus() {
         // Given
         doThrow(NotFoundException.class)
                 .when(companyAppointmentService).patchCompanyNameStatus(any(), any(), any());
@@ -204,7 +204,7 @@ public class CompanyAppointmentControllerTest {
     }
 
     @Test
-    void shouldThrowBadRequestForMissingCompanyNameWhenPatchingNameAndStatus() throws Exception {
+    void shouldThrowBadRequestForMissingCompanyNameWhenPatchingNameAndStatus() {
         // Given
         doThrow(BadRequestException.class)
                 .when(companyAppointmentService).patchCompanyNameStatus(any(), any(), any());
@@ -220,8 +220,7 @@ public class CompanyAppointmentControllerTest {
     }
 
     @Test
-    void shouldThrowServiceUnavailableForWhenPatchingNameAndStatusAndMongoUnavailable()
-            throws Exception {
+    void shouldThrowServiceUnavailableForWhenPatchingNameAndStatusAndMongoUnavailable() {
         // Given
         doThrow(ServiceUnavailableException.class)
                 .when(companyAppointmentService).patchCompanyNameStatus(any(), any(), any());

--- a/src/test/java/uk/gov/companieshouse/company_appointments/CompanyAppointmentFullRecordControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/company_appointments/CompanyAppointmentFullRecordControllerTest.java
@@ -93,7 +93,7 @@ class CompanyAppointmentFullRecordControllerTest {
     }
 
     @Test
-    void testControllerReturns503StatusWhenPutEndpointIsCalled() throws Exception {
+    void testControllerReturns503StatusWhenPutEndpointIsCalled() {
         // given
         doThrow(ServiceUnavailableException.class)
                 .when(companyAppointmentService).upsertAppointmentDelta(any());
@@ -115,7 +115,7 @@ class CompanyAppointmentFullRecordControllerTest {
     }
 
     @Test
-    void testControllerReturns404WhenOfficerNotDeleted() throws Exception{
+    void testControllerReturns404WhenOfficerNotDeleted() {
         doThrow(NotFoundException.class).when(companyAppointmentService).deleteAppointmentDelta(any(), any());
 
         ResponseEntity<Void> response = companyAppointmentFullRecordController.deleteOfficerData(COMPANY_NUMBER, APPOINTMENT_ID);

--- a/src/test/java/uk/gov/companieshouse/company_appointments/ResourceChangedRequestMapperTest.java
+++ b/src/test/java/uk/gov/companieshouse/company_appointments/ResourceChangedRequestMapperTest.java
@@ -16,7 +16,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import uk.gov.companieshouse.api.chskafka.ChangedResource;
 import uk.gov.companieshouse.api.chskafka.ChangedResourceEvent;
 import uk.gov.companieshouse.company_appointments.mapper.ResourceChangedRequestMapper;
-import uk.gov.companieshouse.company_appointments.model.data.CompanyAppointmentDocument;
 import uk.gov.companieshouse.company_appointments.model.data.ResourceChangedRequest;
 
 @ExtendWith(MockitoExtension.class)
@@ -24,6 +23,7 @@ class ResourceChangedRequestMapperTest {
 
     private static final String EXPECTED_CONTEXT_ID = "35234234";
     private static final String DATE = "date";
+    private static final Object deletedData = new Object();
 
     @Mock
     private Supplier<String> timestampGenerator;
@@ -61,12 +61,13 @@ class ResourceChangedRequestMapperTest {
                 Arguments.of(
                     Named.of("Test resource-changed scenario with event type of deleted",
                     ResourceChangedTestArgument.ResourceChangedTestArgumentBuilder()
-                            .withRequest(new ResourceChangedRequest(EXPECTED_CONTEXT_ID, "12345678", "87654321", new CompanyAppointmentDocument(), true))
+                            .withRequest(new ResourceChangedRequest(EXPECTED_CONTEXT_ID, "12345678", "87654321",
+                                    deletedData, true))
                             .withContextId(EXPECTED_CONTEXT_ID)
                             .withResourceUri("/company/12345678/appointments/87654321")
                             .withResourceKind("company-officers")
                             .withEventType("deleted")
-                            .withDeletedData(new CompanyAppointmentDocument())
+                            .withDeletedData(deletedData)
                             .withEventPublishedAt(DATE)
                             .build()
                     )

--- a/src/test/java/uk/gov/companieshouse/company_appointments/SortMapperTest.java
+++ b/src/test/java/uk/gov/companieshouse/company_appointments/SortMapperTest.java
@@ -19,7 +19,7 @@ class SortMapperTest {
     }
 
     @Test
-    void testOfficerRoleSortOrder() throws Exception {
+    void testOfficerRoleSortOrder() {
 
         Sort expected = Sort.by(Sort.Direction.ASC, "officer_role_sort_order")
                 .and(Sort.by(Sort.Direction.ASC, "data.company_name", "data.surname"))
@@ -33,7 +33,7 @@ class SortMapperTest {
     }
 
     @Test
-    void testOfficerRoleSortByAppointedOn() throws Exception {
+    void testOfficerRoleSortByAppointedOn() {
 
         Sort expected = Sort.by(Sort.Direction.DESC, "data.appointed_on", "data.appointed_before");
 
@@ -43,7 +43,7 @@ class SortMapperTest {
     }
 
     @Test
-    void testOfficerRoleSortBySurname() throws Exception {
+    void testOfficerRoleSortBySurname() {
 
         Sort expected = Sort.by(Sort.Direction.ASC, "data.company_name", "data.surname");
 
@@ -53,7 +53,7 @@ class SortMapperTest {
     }
 
     @Test
-    void testOfficerRoleSortByResignedOn() throws Exception {
+    void testOfficerRoleSortByResignedOn() {
 
         Sort expected = Sort.by(Sort.Direction.DESC, "data.resigned_on");
 
@@ -63,7 +63,7 @@ class SortMapperTest {
     }
 
     @Test
-    void testOfficerRoleSortByThrowsBadRequestExceptionWhenInvalidParameter() throws Exception {
+    void testOfficerRoleSortByThrowsBadRequestExceptionWhenInvalidParameter() {
 
         BadRequestException thrown = assertThrows(BadRequestException.class, () -> sortMapper.getSort("invalid"));
 

--- a/src/test/java/uk/gov/companieshouse/company_appointments/model/transformer/DeltaIdentificationTransformerTest.java
+++ b/src/test/java/uk/gov/companieshouse/company_appointments/model/transformer/DeltaIdentificationTransformerTest.java
@@ -12,7 +12,7 @@ class DeltaIdentificationTransformerTest {
     private final DeltaIdentificationTransformer transformer = new DeltaIdentificationTransformer();
 
     @Test
-    void shouldTransformValidIdentification() throws Exception {
+    void shouldTransformValidIdentification() {
         Identification identification = new Identification()
                 .identificationType(IdentificationTypeEnum.UK_LIMITED_COMPANY)
                 .legalAuthority("legalAuthority")
@@ -30,7 +30,7 @@ class DeltaIdentificationTransformerTest {
     }
 
     @Test
-    void shouldTransformWithNullIdentificationType() throws Exception {
+    void shouldTransformWithNullIdentificationType() {
         Identification identification = new Identification()
                 .legalAuthority("legalAuthority")
                 .legalForm("legalForm")

--- a/src/test/java/uk/gov/companieshouse/company_appointments/model/transformer/DeltaItemLinkTypesTransformerTest.java
+++ b/src/test/java/uk/gov/companieshouse/company_appointments/model/transformer/DeltaItemLinkTypesTransformerTest.java
@@ -12,7 +12,7 @@ class DeltaItemLinkTypesTransformerTest {
     private final DeltaItemLinkTypesTransformer transformer = new DeltaItemLinkTypesTransformer();
 
     @Test
-    void shouldTransformItemLinkTypes() throws Exception {
+    void shouldTransformItemLinkTypes() {
 
         ItemLinkTypes itemLinkTypes = new ItemLinkTypes()
                 .self("self")
@@ -29,7 +29,7 @@ class DeltaItemLinkTypesTransformerTest {
     }
 
     @Test
-    void shouldTransformItemLinkTypesWithNullOfficerLinkTypes() throws Exception {
+    void shouldTransformItemLinkTypesWithNullOfficerLinkTypes() {
         ItemLinkTypes itemLinkTypes = new ItemLinkTypes()
                 .self("self");
 

--- a/src/test/java/uk/gov/companieshouse/company_appointments/service/CompanyAppointmentFullRecordServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/company_appointments/service/CompanyAppointmentFullRecordServiceTest.java
@@ -40,6 +40,7 @@ import uk.gov.companieshouse.company_appointments.api.ResourceChangedApiService;
 import uk.gov.companieshouse.company_appointments.exception.FailedToTransformException;
 import uk.gov.companieshouse.company_appointments.exception.NotFoundException;
 import uk.gov.companieshouse.company_appointments.exception.ServiceUnavailableException;
+import uk.gov.companieshouse.company_appointments.mapper.CompanyAppointmentMapper;
 import uk.gov.companieshouse.company_appointments.model.data.CompanyAppointmentDocument;
 import uk.gov.companieshouse.company_appointments.model.data.DeltaItemLinkTypes;
 import uk.gov.companieshouse.company_appointments.model.data.DeltaOfficerData;
@@ -61,6 +62,8 @@ class CompanyAppointmentFullRecordServiceTest {
     private CompanyAppointmentRepository companyAppointmentRepository;
     @Mock
     private ResourceChangedApiService resourceChangedApiService;
+    @Mock
+    private CompanyAppointmentMapper companyAppointmentMapper;
     @Captor
     private ArgumentCaptor<CompanyAppointmentDocument> captor;
 
@@ -92,7 +95,7 @@ class CompanyAppointmentFullRecordServiceTest {
     void setUp() {
         companyAppointmentService =
                 new CompanyAppointmentFullRecordService(deltaAppointmentTransformer,
-                        companyAppointmentRepository, resourceChangedApiService, CLOCK);
+                        companyAppointmentRepository, resourceChangedApiService, companyAppointmentMapper, CLOCK);
     }
 
     @Test
@@ -135,7 +138,7 @@ class CompanyAppointmentFullRecordServiceTest {
     }
 
     @Test
-    void testPutAppointmentData() throws Exception {
+    void testPutAppointmentData() {
         // given
         DeltaOfficerData data = DeltaOfficerData.Builder.builder()
                 .officerRole("director")
@@ -164,7 +167,7 @@ class CompanyAppointmentFullRecordServiceTest {
     }
 
     @Test
-    void testPutAppointmentDataThrowsServiceUnavailableException() throws Exception {
+    void testPutAppointmentDataThrowsServiceUnavailableException() {
         // given
         when(deltaAppointmentTransformer.transform(any(FullRecordCompanyOfficerApi.class))).thenReturn(
                 new CompanyAppointmentDocument());
@@ -181,7 +184,7 @@ class CompanyAppointmentFullRecordServiceTest {
     }
 
     @Test
-    void testPutAppointmentDataThrowsServiceUnavailableExceptionWhenIllegalArgumentExceptionCaught() throws Exception {
+    void testPutAppointmentDataThrowsServiceUnavailableExceptionWhenIllegalArgumentExceptionCaught() {
         // given
         when(deltaAppointmentTransformer.transform(any(FullRecordCompanyOfficerApi.class))).thenReturn(
                 new CompanyAppointmentDocument());
@@ -201,7 +204,7 @@ class CompanyAppointmentFullRecordServiceTest {
             final Instant existingDeltaAt,
             final OffsetDateTime incomingDeltaAt,
             boolean deltaExists,
-            boolean shouldBeStale) throws Exception {
+            boolean shouldBeStale) {
 
         // given
         fullRecordCompanyOfficerApi.getInternalData().setDeltaAt(incomingDeltaAt);
@@ -233,7 +236,7 @@ class CompanyAppointmentFullRecordServiceTest {
     }
 
     @Test
-    void deleteOfficer() throws Exception {
+    void deleteOfficer() {
         when(companyAppointmentRepository.readByCompanyNumberAndID(COMPANY_NUMBER,
                 APPOINTMENT_ID))
                 .thenReturn(Optional.of(new CompanyAppointmentDocument()));
@@ -245,7 +248,7 @@ class CompanyAppointmentFullRecordServiceTest {
     }
 
     @Test
-    void testServiceThrows500WhenTransformFails() throws Exception {
+    void testServiceThrows500WhenTransformFails() {
         when(deltaAppointmentTransformer.transform(any(FullRecordCompanyOfficerApi.class)))
                 .thenThrow(new FailedToTransformException("message"));
 

--- a/src/test/java/uk/gov/companieshouse/company_appointments/service/CompanyAppointmentServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/company_appointments/service/CompanyAppointmentServiceTest.java
@@ -129,7 +129,7 @@ class CompanyAppointmentServiceTest {
     }
 
     @Test
-    void testFetchAppointmentsForCompanyNumberReturnsMappedAppointmentData() throws Exception {
+    void testFetchAppointmentsForCompanyNumberReturnsMappedAppointmentData() {
         CompanyAppointmentDocument appointmentDocument = buildCompanyAppointmentDocument(buildOfficerData().build(),
                 ACTIVE);
         List<CompanyAppointmentDocument> allAppointmentData = List.of(appointmentDocument);
@@ -164,8 +164,7 @@ class CompanyAppointmentServiceTest {
     }
 
     @Test
-    void testFetchAppointmentsForCompanyWithActiveCompanyStatusHasZeroInactiveAppointments()
-            throws Exception {
+    void testFetchAppointmentsForCompanyWithActiveCompanyStatusHasZeroInactiveAppointments() {
         DeltaOfficerData officer = buildOfficerData()
                 .resignedOn(null)
                 .build();
@@ -196,8 +195,7 @@ class CompanyAppointmentServiceTest {
     }
 
     @Test
-    void testFetchAppointmentsForCompanyWithAnInactiveCompanyStatusHasZeroActiveAppointments()
-            throws Exception {
+    void testFetchAppointmentsForCompanyWithAnInactiveCompanyStatusHasZeroActiveAppointments() {
         DeltaOfficerData officer = buildOfficerData()
                 .resignedOn(null)
                 .build();
@@ -228,8 +226,7 @@ class CompanyAppointmentServiceTest {
     }
 
     @Test
-    void testFetchAppointmentsForCompanyWithAnInactiveCompanyStatusHasZeroActiveAppointmentsWhenFilterIsApplied()
-            throws Exception {
+    void testFetchAppointmentsForCompanyWithAnInactiveCompanyStatusHasZeroActiveAppointmentsWhenFilterIsApplied() {
         FetchAppointmentsRequest request =
                 FetchAppointmentsRequest.Builder.builder()
                         .withCompanyNumber(COMPANY_NUMBER)
@@ -254,8 +251,7 @@ class CompanyAppointmentServiceTest {
     }
 
     @Test
-    void testFetchAppointmentsForCompanyReturnEmptyResponseWhenCompanyIsInactiveAndFilterIsApplied()
-            throws Exception {
+    void testFetchAppointmentsForCompanyReturnEmptyResponseWhenCompanyIsInactiveAndFilterIsApplied() {
         FetchAppointmentsRequest request =
                 FetchAppointmentsRequest.Builder.builder()
                         .withCompanyNumber(COMPANY_NUMBER)
@@ -301,8 +297,7 @@ class CompanyAppointmentServiceTest {
     }
 
     @Test
-    void shouldReturnTotalCountEqualToActiveCountWhenCompanyStatusIsActiveAndActiveFilterIsApplied()
-            throws Exception {
+    void shouldReturnTotalCountEqualToActiveCountWhenCompanyStatusIsActiveAndActiveFilterIsApplied() {
         DeltaOfficerData officer = buildOfficerData()
                 .resignedOn(null)
                 .build();
@@ -335,7 +330,7 @@ class CompanyAppointmentServiceTest {
     }
 
     @Test
-    void testRegisterViewIsFalseShouldNotCheckMetricsForRegisterView() throws Exception {
+    void testRegisterViewIsFalseShouldNotCheckMetricsForRegisterView() {
         CompanyAppointmentDocument appointmentDocument = buildCompanyAppointmentDocument(buildOfficerData().build(),
                 ACTIVE);
 
@@ -362,7 +357,7 @@ class CompanyAppointmentServiceTest {
     }
 
     @Test
-    void testNoRegisterViewIsNullShouldNotCheckMetricsForRegisterView() throws Exception {
+    void testNoRegisterViewIsNullShouldNotCheckMetricsForRegisterView() {
         CompanyAppointmentDocument appointmentDocument = buildCompanyAppointmentDocument(buildOfficerData().build(),
                 ACTIVE);
 
@@ -458,7 +453,7 @@ class CompanyAppointmentServiceTest {
     }
 
     @Test
-    void throwNotFoundExceptionIfCountsAppointmentsIsNull() throws Exception {
+    void throwNotFoundExceptionIfCountsAppointmentsIsNull() {
         FetchAppointmentsRequest request =
                 FetchAppointmentsRequest.Builder.builder()
                         .withCompanyNumber(COMPANY_NUMBER)
@@ -476,8 +471,7 @@ class CompanyAppointmentServiceTest {
     }
 
     @Test
-    void testFetchAppointmentsForCompanyReturnsAppointmentsIfRegisterTypeMatchesDirectorsAndRoleTypeIsDirector()
-            throws Exception {
+    void testFetchAppointmentsForCompanyReturnsAppointmentsIfRegisterTypeMatchesDirectorsAndRoleTypeIsDirector() {
         CompanyAppointmentDocument appointmentDocument = buildCompanyAppointmentDocument(
                 buildOfficerData().officerRole("director").build(), ACTIVE);
 
@@ -509,8 +503,7 @@ class CompanyAppointmentServiceTest {
     }
 
     @Test
-    void testFetchAppointmentsForCompanyReturnsAppointmentsIfRegisterTypeMatchesSecretariesAndRoleTypeIsSecretary()
-            throws Exception {
+    void testFetchAppointmentsForCompanyReturnsAppointmentsIfRegisterTypeMatchesSecretariesAndRoleTypeIsSecretary() {
         CompanyAppointmentDocument appointmentDocument = buildCompanyAppointmentDocument(
                 buildOfficerData().officerRole("secretary").build(), ACTIVE);
 
@@ -542,8 +535,7 @@ class CompanyAppointmentServiceTest {
     }
 
     @Test
-    void testFetchAppointmentsForCompanyReturnsAppointmentsIfRegisterTypeMatchesLLPMembersAndRoleTypeIsLLPMember()
-            throws Exception {
+    void testFetchAppointmentsForCompanyReturnsAppointmentsIfRegisterTypeMatchesLLPMembersAndRoleTypeIsLLPMember() {
         CompanyAppointmentDocument appointmentDocument = buildCompanyAppointmentDocument(
                 buildOfficerData().officerRole("llp-member").build(), ACTIVE);
 
@@ -576,7 +568,7 @@ class CompanyAppointmentServiceTest {
 
     @Test
     @DisplayName("Test update a companies appointments")
-    void shouldUpdateCompanyAppointments() throws Exception {
+    void shouldUpdateCompanyAppointments() {
         // given
         when(companyStatusValidator.isValidCompanyStatus(anyString())).thenReturn(true);
         when(companyAppointmentRepository.patchAppointmentNameStatusInCompany(anyString(),


### PR DESCRIPTION
* Deleted data is now sent correctly as an OfficerSummary.
* OfficerSummary is serialised and deserialsied an extra time to remove nulls from the Object before the request is sent. This is because the object mapper used in api-sdk-java does not specify NON_NULL serialisation inclusion.

[DSND-2050](https://companieshouse.atlassian.net/browse/DSND-2050)

[DSND-2050]: https://companieshouse.atlassian.net/browse/DSND-2050?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ