### PR TITLE
DSND-2014: Remove external GET endpoints

### DIFF
--- a/routes.yaml
+++ b/routes.yaml
@@ -2,6 +2,5 @@ app_name: company-appointments.api.ch.gov.uk
 group: api
 weight: 900
 routes:
-  1: ^/company/.*?/appointments(/.*?|$)$
-  2: ^/company/(.){0,10}/officers$
-  3: ^/officers/.*/appointments$
+  1: ^/company/.*?/appointments(/.*?|$)/full_record(/.*?|$)$
+  2: ^/company/.*?/appointments$

--- a/routes.yaml
+++ b/routes.yaml
@@ -2,4 +2,4 @@ app_name: company-appointments.api.ch.gov.uk
 group: api
 weight: 900
 routes:
-  1: ^/company/.*?/appointments(/.*?|$)/full_record(/delete|$)$
+  1: ^/company/.*?/appointments/.*?/full_record(/delete$|$)

--- a/routes.yaml
+++ b/routes.yaml
@@ -2,5 +2,4 @@ app_name: company-appointments.api.ch.gov.uk
 group: api
 weight: 900
 routes:
-  1: ^/company/.*?/appointments(/.*?|$)/full_record(/.*?|$)$
-  2: ^/company/.*?/appointments$
+  1: ^/company/.*?/appointments(/.*?|$)/full_record(/delete|$)$

--- a/src/it/java/uk/gov/companieshouse/company_appointments/officerappointments/OfficerAppointmentsControllerITest.java
+++ b/src/it/java/uk/gov/companieshouse/company_appointments/officerappointments/OfficerAppointmentsControllerITest.java
@@ -39,6 +39,7 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 import uk.gov.companieshouse.company_appointments.CompanyAppointmentsApplication;
 import uk.gov.companieshouse.company_appointments.model.data.CompanyAppointmentDocument;
 
+@Disabled("Temporary removal of external GET endpoints for purposes of seeding the delta_appointments collection in Live")
 @Testcontainers
 @AutoConfigureMockMvc
 @SpringBootTest(classes = CompanyAppointmentsApplication.class, webEnvironment = SpringBootTest.WebEnvironment.MOCK)

--- a/src/it/java/uk/gov/companieshouse/company_appointments/tests/AuthenticationInterceptorsITest.java
+++ b/src/it/java/uk/gov/companieshouse/company_appointments/tests/AuthenticationInterceptorsITest.java
@@ -8,6 +8,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import java.time.Instant;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
@@ -75,6 +76,7 @@ class AuthenticationInterceptorsITest {
                         .build();
     }
 
+    @Disabled("Temporary removal of external GET endpoints for purposes of seeding the delta_appointments collection in Live")
     @Test
     void fetchAppointmentWhenOauth2AuthThenAllowed() throws Exception {
         addOauth2Headers(false);
@@ -85,6 +87,7 @@ class AuthenticationInterceptorsITest {
                 .andExpect(jsonPath("$.name").value(NAME));
     }
 
+    @Disabled("Temporary removal of external GET endpoints for purposes of seeding the delta_appointments collection in Live")
     @Test
     void fetchAppointmentWhenPrivilegedKeyAuthThenAllowed() throws Exception {
         addApiKeyHeaders(true);
@@ -95,6 +98,7 @@ class AuthenticationInterceptorsITest {
                 .andExpect(jsonPath("$.name").value(NAME));
     }
 
+    @Disabled("Temporary removal of external GET endpoints for purposes of seeding the delta_appointments collection in Live")
     @Test
     void fetchAppointmentWhenNonPrivilegedKeyAuthThenAllowed() throws Exception {
         addApiKeyHeaders(false);
@@ -105,6 +109,7 @@ class AuthenticationInterceptorsITest {
                 .andExpect(jsonPath("$.name").value(NAME));
     }
 
+    @Disabled("Temporary removal of external GET endpoints for purposes of seeding the delta_appointments collection in Live")
     @Test
     void fetchAppointmentWhenAuthMissingThenDenied() throws Exception {
         mockMvc.perform(get(URL_TEMPLATE, COMPANY_NUMBER, APP_ID).headers(httpHeaders))

--- a/src/it/java/uk/gov/companieshouse/company_appointments/tests/CompanyAppointmentControllerITest.java
+++ b/src/it/java/uk/gov/companieshouse/company_appointments/tests/CompanyAppointmentControllerITest.java
@@ -261,6 +261,7 @@ class CompanyAppointmentControllerITest {
         result.andExpect(MockMvcResultMatchers.status().isBadRequest());
     }
 
+    @Disabled("Temporary removal of external GET endpoints for purposes of seeding the delta_appointments collection in Live")
     @Test
     @DisplayName("Returns 200 ok when PATCH existing appointments request handled successfully")
     void testPatchExistingAppointmentCompanyNameStatus() throws Exception {
@@ -280,6 +281,7 @@ class CompanyAppointmentControllerITest {
                         String.format("/company/%s/officers", COMPANY_NUMBER)));
     }
 
+    @Disabled("Temporary removal of external GET endpoints for purposes of seeding the delta_appointments collection in Live")
     @Test
     @DisplayName("Patch existing appointments endpoint returns 400 bad request when company name is missing")
     void testPatchExistingAppointmentCompanyNameStatusMissingRequestFields() throws Exception {
@@ -293,6 +295,7 @@ class CompanyAppointmentControllerITest {
                 .andExpect(MockMvcResultMatchers.status().isBadRequest());
     }
 
+    @Disabled("Temporary removal of external GET endpoints for purposes of seeding the delta_appointments collection in Live")
     @Test
     @DisplayName("Patch existing appointments endpoint returns 400 when invalid company status provided")
     void testPatchExistingAppointmentCompanyNameStatusInvalidStatus() throws Exception {

--- a/src/it/java/uk/gov/companieshouse/company_appointments/tests/CompanyAppointmentControllerITest.java
+++ b/src/it/java/uk/gov/companieshouse/company_appointments/tests/CompanyAppointmentControllerITest.java
@@ -14,6 +14,7 @@ import java.nio.charset.StandardCharsets;
 import org.apache.commons.io.IOUtils;
 import org.bson.Document;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
@@ -81,6 +82,7 @@ class CompanyAppointmentControllerITest {
         System.setProperty("company-metrics-api.endpoint", "localhost");
     }
 
+    @Disabled("Temporary removal of external GET endpoints for purposes of seeding the delta_appointments collection in Live")
     @Test
     void testReturn200OKIfOfficerIsFound() throws Exception {
         //when
@@ -100,6 +102,7 @@ class CompanyAppointmentControllerITest {
                 .andExpect(MockMvcResultMatchers.jsonPath("$.date_of_birth.month", is(1)));
     }
 
+    @Disabled("Temporary removal of external GET endpoints for purposes of seeding the delta_appointments collection in Live")
     @Test
     void testReturn404IfOfficerIsNotFound() throws Exception {
         // when
@@ -115,6 +118,7 @@ class CompanyAppointmentControllerITest {
         result.andExpect(MockMvcResultMatchers.status().isNotFound());
     }
 
+    @Disabled("Temporary removal of external GET endpoints for purposes of seeding the delta_appointments collection in Live")
     @Test
     void testReturn401IfUserNotAuthenticated() throws Exception {
         // when
@@ -127,6 +131,7 @@ class CompanyAppointmentControllerITest {
         result.andExpect(MockMvcResultMatchers.status().isUnauthorized());
     }
 
+    @Disabled("Temporary removal of external GET endpoints for purposes of seeding the delta_appointments collection in Live")
     @Test
     void testReturn200OKIfAllOfficersAreFound() throws Exception {
         //when
@@ -151,6 +156,8 @@ class CompanyAppointmentControllerITest {
                 .andExpect(MockMvcResultMatchers.jsonPath("$.resigned_count", is(1)))
                 .andExpect(MockMvcResultMatchers.jsonPath("$.total_results", is(3)));
     }
+
+    @Disabled("Temporary removal of external GET endpoints for purposes of seeding the delta_appointments collection in Live")
     @Test
     void testReturn404IfOfficersForCompanyIsNotFound() throws Exception {
         // when
@@ -167,6 +174,7 @@ class CompanyAppointmentControllerITest {
         result.andExpect(MockMvcResultMatchers.status().isNotFound());
     }
 
+    @Disabled("Temporary removal of external GET endpoints for purposes of seeding the delta_appointments collection in Live")
     @Test
     void testReturn200OKIfAllOfficersAreFoundWithFilter() throws Exception {
         //when
@@ -191,6 +199,7 @@ class CompanyAppointmentControllerITest {
                 .andExpect(MockMvcResultMatchers.jsonPath("$.total_results", is(2)));
     }
 
+    @Disabled("Temporary removal of external GET endpoints for purposes of seeding the delta_appointments collection in Live")
     @Test
     void testReturn200OkWithOfficersOrderedByAppointedOn() throws Exception {
         when(companyMetricsApiService.invokeGetMetricsApi(anyString())).thenReturn(new ApiResponse<>(200, null, metricsApi));
@@ -213,6 +222,7 @@ class CompanyAppointmentControllerITest {
                 .andExpect(MockMvcResultMatchers.jsonPath("$.total_results", is(2)));
     }
 
+    @Disabled("Temporary removal of external GET endpoints for purposes of seeding the delta_appointments collection in Live")
     @Test
     void testReturn200OkWithOfficersOrderedBySurname() throws Exception {
         when(companyMetricsApiService.invokeGetMetricsApi(anyString())).thenReturn(new ApiResponse<>(200, null, metricsApi));
@@ -236,6 +246,7 @@ class CompanyAppointmentControllerITest {
                 .andExpect(MockMvcResultMatchers.jsonPath("$.total_results", is(3)));
     }
 
+    @Disabled("Temporary removal of external GET endpoints for purposes of seeding the delta_appointments collection in Live")
     @Test
     void testReturn400BadRequestWithIncorrectOrderBy() throws Exception {
         when(companyMetricsApiService.invokeGetMetricsApi(anyString())).thenReturn(new ApiResponse<>(200, null, metricsApi));

--- a/src/it/java/uk/gov/companieshouse/company_appointments/tests/CompanyAppointmentControllerMongoUnavailableITest.java
+++ b/src/it/java/uk/gov/companieshouse/company_appointments/tests/CompanyAppointmentControllerMongoUnavailableITest.java
@@ -7,6 +7,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -27,6 +28,7 @@ import uk.gov.companieshouse.company_appointments.CompanyAppointmentsApplication
 import uk.gov.companieshouse.company_appointments.api.ResourceChangedApiService;
 import uk.gov.companieshouse.company_appointments.repository.CompanyAppointmentRepository;
 
+@Disabled("Temporary removal of external GET endpoints for purposes of seeding the delta_appointments collection in Live")
 @Testcontainers
 @AutoConfigureMockMvc
 @SpringBootTest(classes = CompanyAppointmentsApplication.class, webEnvironment = SpringBootTest.WebEnvironment.MOCK)

--- a/src/main/java/uk/gov/companieshouse/company_appointments/controller/CompanyAppointmentController.java
+++ b/src/main/java/uk/gov/companieshouse/company_appointments/controller/CompanyAppointmentController.java
@@ -84,7 +84,7 @@ public class CompanyAppointmentController {
         }
     }
 
-    @PatchMapping(path = "/appointments")
+//    @PatchMapping(path = "/appointments")
     public ResponseEntity<Void> patchCompanyNameStatus(
             @PathVariable("company_number") String companyNumber,
             @RequestBody PatchAppointmentNameStatusApi requestBody) {

--- a/src/main/java/uk/gov/companieshouse/company_appointments/controller/CompanyAppointmentController.java
+++ b/src/main/java/uk/gov/companieshouse/company_appointments/controller/CompanyAppointmentController.java
@@ -35,7 +35,7 @@ public class CompanyAppointmentController {
         this.companyAppointmentService = companyAppointmentService;
     }
 
-    @GetMapping(path = "/appointments/{appointment_id}")
+//    @GetMapping(path = "/appointments/{appointment_id}")
     public ResponseEntity<OfficerSummary> fetchAppointment(@PathVariable("company_number") String companyNumber, @PathVariable("appointment_id") String appointmentID) {
 
         DataMapHolder.get()
@@ -48,7 +48,7 @@ public class CompanyAppointmentController {
         }
     }
 
-    @GetMapping(path = "/officers")
+//    @GetMapping(path = "/officers")
     public ResponseEntity<OfficerList> fetchAppointmentsForCompany(
             @PathVariable("company_number") String companyNumber,
             @RequestParam(required = false) String filter,

--- a/src/main/java/uk/gov/companieshouse/company_appointments/officerappointments/OfficerAppointmentsController.java
+++ b/src/main/java/uk/gov/companieshouse/company_appointments/officerappointments/OfficerAppointmentsController.java
@@ -28,7 +28,7 @@ class OfficerAppointmentsController {
         this.itemsPerPageService = itemsPerPageService;
     }
 
-    @GetMapping(path = "/officers/{officer_id}/appointments")
+//    @GetMapping(path = "/officers/{officer_id}/appointments")
     public ResponseEntity<AppointmentList> getOfficerAppointments(
             @PathVariable("officer_id") String officerId,
             @RequestParam(value = "filter", required = false) String filter,


### PR DESCRIPTION
In order for the seeding of the delta_appointments collection in live to go ahead, we need to remove the external get endpoints in this service.

This is so the external GET request will be routed to the Perl services and, therefore, the appointments collection instead of the delta_appointments collection - which will be being seeded.

[DSND-2014](https://companieshouse.atlassian.net/browse/DSND-2014)

[DSND-2014]: https://companieshouse.atlassian.net/browse/DSND-2014?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ