### PR TITLE
DSND-2062: Transform empty objects into null

### DIFF
--- a/src/main/java/uk/gov/companieshouse/company_appointments/model/transformer/Transformative.java
+++ b/src/main/java/uk/gov/companieshouse/company_appointments/model/transformer/Transformative.java
@@ -35,7 +35,11 @@ public interface Transformative<S, T> {
     T factory();
 
     default T transform(S source) throws FailedToTransformException {
-        return transform(source, factory());
+        T target = transform(source, factory());
+        if (target.equals(factory())) {
+            target = null;
+        }
+        return target;
     }
 
     T transform(S source, T output) throws FailedToTransformException;

--- a/src/test/java/uk/gov/companieshouse/company_appointments/model/transformer/DeltaPrincipalOfficeAddressTransformerTest.java
+++ b/src/test/java/uk/gov/companieshouse/company_appointments/model/transformer/DeltaPrincipalOfficeAddressTransformerTest.java
@@ -53,7 +53,7 @@ class DeltaPrincipalOfficeAddressTransformerTest {
         DeltaPrincipalOfficeAddress actual = transformer.transform(new PrincipalOfficeAddress());
 
         // then
-        assertThat(actual).isEqualTo(new DeltaPrincipalOfficeAddress());
+        assertThat(actual).isNull();
 
     }
 }

--- a/src/test/java/uk/gov/companieshouse/company_appointments/model/transformer/DeltaSensitiveDataTransformerTest.java
+++ b/src/test/java/uk/gov/companieshouse/company_appointments/model/transformer/DeltaSensitiveDataTransformerTest.java
@@ -58,17 +58,14 @@ class DeltaSensitiveDataTransformerTest {
         // given
         SensitiveData source = buildSource()
                 .usualResidentialAddress(null)
-                .dateOfBirth(null);
-
-        DeltaSensitiveData expected = buildExpected()
-                .setUsualResidentialAddress(null)
-                .setDateOfBirth(null);
+                .dateOfBirth(null)
+                .residentialAddressSameAsServiceAddress(null);
 
         // when
         DeltaSensitiveData actual = transformer.transform(source);
 
         // then
-        assertThat(actual).isEqualTo(expected);
+        assertThat(actual).isNull();
         verifyNoInteractions(deltaUsualResidentialAddressTransformer);
     }
 

--- a/src/test/java/uk/gov/companieshouse/company_appointments/model/transformer/DeltaServiceAddressTransformerTest.java
+++ b/src/test/java/uk/gov/companieshouse/company_appointments/model/transformer/DeltaServiceAddressTransformerTest.java
@@ -53,7 +53,7 @@ class DeltaServiceAddressTransformerTest {
         DeltaServiceAddress actual = transformer.transform(new ServiceAddress());
 
         // then
-        assertThat(actual).isEqualTo(new DeltaServiceAddress());
+        assertThat(actual).isNull();
 
     }
 }

--- a/src/test/java/uk/gov/companieshouse/company_appointments/model/transformer/DeltaUsualResidentialAddressTransformerTest.java
+++ b/src/test/java/uk/gov/companieshouse/company_appointments/model/transformer/DeltaUsualResidentialAddressTransformerTest.java
@@ -53,7 +53,7 @@ class DeltaUsualResidentialAddressTransformerTest {
         DeltaUsualResidentialAddress actual = transformer.transform(new UsualResidentialAddress());
 
         // then
-        assertThat(actual).isEqualTo(new DeltaUsualResidentialAddress());
+        assertThat(actual).isNull();
 
     }
 }


### PR DESCRIPTION
* When transforming the PUT request to upsert an appointment, any fields within the request which are an empty object will be tranformed into null and not persisted.

[DSND-2062](https://companieshouse.atlassian.net/browse/DSND-2062)