### PR TITLE
Change routes to only handle /full_record requests

### DIFF
--- a/routes.yaml
+++ b/routes.yaml
@@ -1,7 +1,5 @@
 app_name: company-appointments.api.ch.gov.uk
 group: api
-weight: 900
+weight: 901
 routes:
-  1: ^/company/.*?/appointments(/.*?|$)$
-  2: ^/company/(.){0,10}/officers$
-  3: ^/officers/.*/appointments$
+  1: ^/company/.*?/appointments/.*?/full_record(/delete$|$)


### PR DESCRIPTION
* Changes test whether having two different versions of the same app but with different routes works on Mesos Marathon.