### PR TITLE
Revert routing back to normal

### DIFF
--- a/routes.yaml
+++ b/routes.yaml
@@ -1,5 +1,7 @@
 app_name: company-appointments.api.ch.gov.uk
 group: api
-weight: 899
+weight: 900
 routes:
-  1: ^/company/.*?/appointments/.*?/full_record(/delete$|$)
+  1: ^/company/.*?/appointments(/.*?|$)$
+  2: ^/company/(.){0,10}/officers$
+  3: ^/officers/.*/appointments$


### PR DESCRIPTION
* Reverts routing back to normal working order.
* To be merged once it has been confirmed that our approach of having two different versions of the API works.