### PR TITLE
DSND-2067: Change name of boolean address fields

### DIFF
--- a/src/main/java/uk/gov/companieshouse/company_appointments/model/data/DeltaOfficerData.java
+++ b/src/main/java/uk/gov/companieshouse/company_appointments/model/data/DeltaOfficerData.java
@@ -16,8 +16,8 @@ public class DeltaOfficerData {
   @Field("service_address")
   private DeltaServiceAddress serviceAddress;
 
-  @Field("service_address_same_as_registered_office_address")
-  private Boolean serviceAddressSameAsRegisteredOfficeAddress;
+  @Field("service_address_is_same_as_registered_office_address")
+  private Boolean serviceAddressIsSameAsRegisteredOfficeAddress;
 
   @Field("country_of_residence")
   private String countryOfResidence;
@@ -94,7 +94,7 @@ public class DeltaOfficerData {
     personNumber = builder.personNumber;
     etag = builder.etag;
     serviceAddress = builder.serviceAddress;
-    serviceAddressSameAsRegisteredOfficeAddress = builder.serviceAddressSameAsRegisteredOfficeAddress;
+    serviceAddressIsSameAsRegisteredOfficeAddress = builder.serviceAddressSameAsRegisteredOfficeAddress;
     countryOfResidence = builder.countryOfResidence;
     appointedOn = builder.appointedOn;
     appointedBefore = builder.appointedBefore;
@@ -147,13 +147,13 @@ public class DeltaOfficerData {
     return this;
   }
 
-  public Boolean getServiceAddressSameAsRegisteredOfficeAddress() {
-    return serviceAddressSameAsRegisteredOfficeAddress;
+  public Boolean getServiceAddressIsSameAsRegisteredOfficeAddress() {
+    return serviceAddressIsSameAsRegisteredOfficeAddress;
   }
 
-  public DeltaOfficerData setServiceAddressSameAsRegisteredOfficeAddress(
-          Boolean serviceAddressSameAsRegisteredOfficeAddress) {
-    this.serviceAddressSameAsRegisteredOfficeAddress = serviceAddressSameAsRegisteredOfficeAddress;
+  public DeltaOfficerData setServiceAddressIsSameAsRegisteredOfficeAddress(
+          Boolean serviceAddressIsSameAsRegisteredOfficeAddress) {
+    this.serviceAddressIsSameAsRegisteredOfficeAddress = serviceAddressIsSameAsRegisteredOfficeAddress;
     return this;
   }
 
@@ -371,7 +371,7 @@ public class DeltaOfficerData {
     return Objects.equals(this.personNumber, data.personNumber) &&
         Objects.equals(this.etag, data.etag) &&
         Objects.equals(this.serviceAddress, data.serviceAddress) &&
-        Objects.equals(this.serviceAddressSameAsRegisteredOfficeAddress, data.serviceAddressSameAsRegisteredOfficeAddress) &&
+        Objects.equals(this.serviceAddressIsSameAsRegisteredOfficeAddress, data.serviceAddressIsSameAsRegisteredOfficeAddress) &&
         Objects.equals(this.countryOfResidence, data.countryOfResidence) &&
         Objects.equals(this.appointedOn, data.appointedOn) &&
         Objects.equals(this.appointedBefore, data.appointedBefore) &&
@@ -398,7 +398,7 @@ public class DeltaOfficerData {
 
   @Override
   public int hashCode() {
-    return Objects.hash(personNumber, etag, serviceAddress, serviceAddressSameAsRegisteredOfficeAddress, countryOfResidence, appointedOn, appointedBefore, isPre1992Appointment, links, nationality, occupation, officerRole, isSecureOfficer, identification, companyName, surname, forename, honours, otherForenames, title, companyNumber, contactDetails, principalOfficeAddress, resignedOn, responsibilities, formerNames);
+    return Objects.hash(personNumber, etag, serviceAddress, serviceAddressIsSameAsRegisteredOfficeAddress, countryOfResidence, appointedOn, appointedBefore, isPre1992Appointment, links, nationality, occupation, officerRole, isSecureOfficer, identification, companyName, surname, forename, honours, otherForenames, title, companyNumber, contactDetails, principalOfficeAddress, resignedOn, responsibilities, formerNames);
   }
 
   @Override
@@ -407,7 +407,8 @@ public class DeltaOfficerData {
             + "    personNumber: " + toIndentedString(personNumber) + "\n"
             + "    etag: " + toIndentedString(etag) + "\n"
             + "    serviceAddress: " + toIndentedString(serviceAddress) + "\n"
-            + "    serviceAddressSameAsRegisteredOfficeAddress: " + toIndentedString(serviceAddressSameAsRegisteredOfficeAddress) + "\n"
+            + "    serviceAddressSameAsRegisteredOfficeAddress: " + toIndentedString(
+            serviceAddressIsSameAsRegisteredOfficeAddress) + "\n"
             + "    countryOfResidence: " + toIndentedString(countryOfResidence) + "\n"
             + "    appointedOn: " + toIndentedString(appointedOn) + "\n"
             + "    appointedBefore: " + toIndentedString(appointedBefore) + "\n"

--- a/src/main/java/uk/gov/companieshouse/company_appointments/model/data/DeltaSensitiveData.java
+++ b/src/main/java/uk/gov/companieshouse/company_appointments/model/data/DeltaSensitiveData.java
@@ -7,8 +7,8 @@ import org.springframework.data.mongodb.core.mapping.Field;
 public class DeltaSensitiveData {
   @Field("usual_residential_address")
   private DeltaUsualResidentialAddress usualResidentialAddress;
-  @Field("residential_address_same_as_service_address")
-  private Boolean residentialAddressSameAsServiceAddress;
+  @Field("residential_address_is_same_as_service_address")
+  private Boolean residentialAddressIsSameAsServiceAddress;
   @Field("date_of_birth")
   private Instant dateOfBirth;
 
@@ -21,12 +21,12 @@ public class DeltaSensitiveData {
     return this;
   }
 
-  public Boolean getResidentialAddressSameAsServiceAddress() {
-    return residentialAddressSameAsServiceAddress;
+  public Boolean getResidentialAddressIsSameAsServiceAddress() {
+    return residentialAddressIsSameAsServiceAddress;
   }
 
-  public DeltaSensitiveData setResidentialAddressSameAsServiceAddress(Boolean residentialAddressSameAsServiceAddress) {
-    this.residentialAddressSameAsServiceAddress = residentialAddressSameAsServiceAddress;
+  public DeltaSensitiveData setResidentialAddressIsSameAsServiceAddress(Boolean residentialAddressIsSameAsServiceAddress) {
+    this.residentialAddressIsSameAsServiceAddress = residentialAddressIsSameAsServiceAddress;
     return this;
   }
 
@@ -49,20 +49,21 @@ public class DeltaSensitiveData {
     }
     DeltaSensitiveData sensitiveData = (DeltaSensitiveData) o;
     return Objects.equals(this.usualResidentialAddress, sensitiveData.usualResidentialAddress) &&
-        Objects.equals(this.residentialAddressSameAsServiceAddress, sensitiveData.residentialAddressSameAsServiceAddress) &&
+        Objects.equals(this.residentialAddressIsSameAsServiceAddress, sensitiveData.residentialAddressIsSameAsServiceAddress) &&
         Objects.equals(this.dateOfBirth, sensitiveData.dateOfBirth);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(usualResidentialAddress, residentialAddressSameAsServiceAddress, dateOfBirth);
+    return Objects.hash(usualResidentialAddress, residentialAddressIsSameAsServiceAddress, dateOfBirth);
   }
 
   @Override
   public String toString() {
     return "class SensitiveData {\n"
             + "    usualResidentialAddress: " + toIndentedString(usualResidentialAddress) + "\n"
-            + "    residentialAddressSameAsServiceAddress: " + toIndentedString(residentialAddressSameAsServiceAddress) + "\n"
+            + "    residentialAddressSameAsServiceAddress: " + toIndentedString(
+            residentialAddressIsSameAsServiceAddress) + "\n"
             + "    dateOfBirth: " + toIndentedString(dateOfBirth) + "\n"
             + "}";
   }

--- a/src/main/java/uk/gov/companieshouse/company_appointments/model/transformer/DeltaOfficerDataTransformer.java
+++ b/src/main/java/uk/gov/companieshouse/company_appointments/model/transformer/DeltaOfficerDataTransformer.java
@@ -44,7 +44,7 @@ public class DeltaOfficerDataTransformer implements Transformative<Data, DeltaOf
             entity.setPersonNumber(source.getPersonNumber());
             entity.setServiceAddress(source.getServiceAddress() != null?
                     serviceAddressTransformer.transform(source.getServiceAddress()) : null);
-            entity.setServiceAddressSameAsRegisteredOfficeAddress(
+            entity.setServiceAddressIsSameAsRegisteredOfficeAddress(
                     source.getServiceAddressSameAsRegisteredOfficeAddress());
             entity.setCountryOfResidence(source.getCountryOfResidence());
             entity.setAppointedOn(source.getAppointedOn() != null ?

--- a/src/main/java/uk/gov/companieshouse/company_appointments/model/transformer/DeltaSensitiveDataTransformer.java
+++ b/src/main/java/uk/gov/companieshouse/company_appointments/model/transformer/DeltaSensitiveDataTransformer.java
@@ -38,7 +38,7 @@ public class DeltaSensitiveDataTransformer implements Transformative<SensitiveDa
                                     source.getDateOfBirth().getDay())
                             .atStartOfDay(UTC))
                     : null);
-            entity.setResidentialAddressSameAsServiceAddress(source.getResidentialAddressSameAsServiceAddress());
+            entity.setResidentialAddressIsSameAsServiceAddress(source.getResidentialAddressSameAsServiceAddress());
 
             return entity;
         } catch (Exception e) {

--- a/src/test/java/uk/gov/companieshouse/company_appointments/model/transformer/DeltaOfficerDataTransformerTest.java
+++ b/src/test/java/uk/gov/companieshouse/company_appointments/model/transformer/DeltaOfficerDataTransformerTest.java
@@ -203,7 +203,7 @@ class DeltaOfficerDataTransformerTest {
         return new DeltaOfficerData()
                 .setPersonNumber("person number")
                 .setServiceAddress(deltaServiceAddress)
-                .setServiceAddressSameAsRegisteredOfficeAddress(true)
+                .setServiceAddressIsSameAsRegisteredOfficeAddress(true)
                 .setCountryOfResidence("UK")
                 .setAppointedOn(Instant.from(LOCAL_DATE.atStartOfDay(UTC)))
                 .setAppointedBefore(Instant.from(LOCAL_DATE.atStartOfDay(UTC)))

--- a/src/test/java/uk/gov/companieshouse/company_appointments/model/transformer/DeltaSensitiveDataTransformerTest.java
+++ b/src/test/java/uk/gov/companieshouse/company_appointments/model/transformer/DeltaSensitiveDataTransformerTest.java
@@ -94,6 +94,6 @@ class DeltaSensitiveDataTransformerTest {
         return new DeltaSensitiveData()
                 .setUsualResidentialAddress(deltaUsualResidentialAddress)
                 .setDateOfBirth(deltaDateOfBirth)
-                .setResidentialAddressSameAsServiceAddress(true);
+                .setResidentialAddressIsSameAsServiceAddress(true);
     }
 }

--- a/src/test/java/uk/gov/companieshouse/company_appointments/officerappointments/OfficerAppointmentsMapperTest.java
+++ b/src/test/java/uk/gov/companieshouse/company_appointments/officerappointments/OfficerAppointmentsMapperTest.java
@@ -212,7 +212,7 @@ class OfficerAppointmentsMapperTest {
                         .setPostalCode("CF2 1B6")
                         .setPremises("URA")
                         .setRegion("ura-region"))
-                .setResidentialAddressSameAsServiceAddress(false)
+                .setResidentialAddressIsSameAsServiceAddress(false)
                 .setDateOfBirth(LocalDateTime.of(2000, 1, 1, 0, 0).toInstant(ZoneOffset.UTC));
     }
 


### PR DESCRIPTION
* Persists boolean address fields with "is_same_as" instead of just "same_as" which comes in in the request body.

[DSND-2067](https://companieshouse.atlassian.net/browse/DSND-2067)

[DSND-2067]: https://companieshouse.atlassian.net/browse/DSND-2067?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ