### PR TITLE
DSND-2053: Add configuration to ObjectMapper bean

### DIFF
--- a/src/main/java/uk/gov/companieshouse/company_appointments/config/Config.java
+++ b/src/main/java/uk/gov/companieshouse/company_appointments/config/Config.java
@@ -6,7 +6,9 @@ import java.time.OffsetDateTime;
 import java.util.function.Supplier;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -77,6 +79,8 @@ public class Config implements WebMvcConfigurer {
                 .registerModule(new JavaTimeModule())
                 .setDateFormat(new SimpleDateFormat("yyyy-MM-dd"))
                 .registerModule(new SimpleModule().addDeserializer(String.class, new EmptyFieldDeserializer()))
-                .setSerializationInclusion(JsonInclude.Include.NON_NULL);
+                .setSerializationInclusion(JsonInclude.Include.NON_NULL)
+                .configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+                .configure(SerializationFeature.FAIL_ON_EMPTY_BEANS, false);
     }
 }


### PR DESCRIPTION
This PR adds additional configuration to the ObjectMapper.

Tested locally.

[DSND-2053](https://companieshouse.atlassian.net/browse/DSND-2053)

[DSND-2053]: https://companieshouse.atlassian.net/browse/DSND-2053?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ