### PR TITLE
DSND-2066: Change routes for seeding in live

### DIFF
--- a/routes.yaml
+++ b/routes.yaml
@@ -1,7 +1,5 @@
 app_name: company-appointments.api.ch.gov.uk
 group: api
-weight: 900
+weight: 899
 routes:
-  1: ^/company/.*?/appointments(/.*?|$)$
-  2: ^/company/(.){0,10}/officers$
-  3: ^/officers/.*/appointments$
+  1: ^/company/.*?/appointments/.*?/full_record(/delete$|$)


### PR DESCRIPTION
* Only calls to /full_record endpoints will be handled by this API version.
* Other endpoints will be handled by v0.1.67 in live.

[DSND-2066](https://companieshouse.atlassian.net/browse/DSND-2066)

[DSND-2066]: https://companieshouse.atlassian.net/browse/DSND-2066?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ