### PR TITLE
DSND-2486: Add routing for all endpoints

### DIFF
--- a/routes.yaml
+++ b/routes.yaml
@@ -1,5 +1,7 @@
 app_name: company-appointments.api.ch.gov.uk
 group: api
-weight: 899
+weight: 900
 routes:
-  1: ^/company/.*?/appointments/.*?/full_record(/delete$|$)
+  1: ^/company/.*?/appointments(/.*?|$)$
+  2: ^/company/(.){0,10}/officers$
+  3: ^/officers/.*/appointments$


### PR DESCRIPTION
* Adds the routing back for all appointment endpoints so that they are all using the new collection.

[DSND-2486](https://companieshouse.atlassian.net/browse/DSND-2486)