### PR TITLE
feat: bump up app/eric cpus as well as fargate task count for live env

### DIFF
--- a/terraform/groups/ecs-service/main.tf
+++ b/terraform/groups/ecs-service/main.tf
@@ -63,6 +63,7 @@ module "ecs-service" {
   # Service performance and scaling configs
   desired_task_count                 = var.desired_task_count
   max_task_count                     = var.max_task_count
+  min_task_count                     = var.min_task_count
   required_cpus                      = var.required_cpus
   required_memory                    = var.required_memory
   service_autoscale_enabled          = var.service_autoscale_enabled

--- a/terraform/groups/ecs-service/profiles/live-eu-west-2/live/vars
+++ b/terraform/groups/ecs-service/profiles/live-eu-west-2/live/vars
@@ -3,3 +3,8 @@ aws_profile = "live-eu-west-2"
 
 # service configs
 use_set_environment_files = true
+eric_cpus = 512
+required_memory = 1024
+eric_memory = 1024
+required_cpus = 512
+min_task_count = 2

--- a/terraform/groups/ecs-service/profiles/live-eu-west-2/live/vars
+++ b/terraform/groups/ecs-service/profiles/live-eu-west-2/live/vars
@@ -3,8 +3,10 @@ aws_profile = "live-eu-west-2"
 
 # service configs
 use_set_environment_files = true
-eric_cpus = 512
-required_memory = 1024
-eric_memory = 1024
-required_cpus = 512
+
+# scaling configs
 min_task_count = 2
+required_cpus = 512
+required_memory = 1024
+eric_cpus = 512
+eric_memory = 1024

--- a/terraform/groups/ecs-service/variables.tf
+++ b/terraform/groups/ecs-service/variables.tf
@@ -32,6 +32,11 @@ variable "desired_task_count" {
   description = "The desired ECS task count for this service"
   default = 1 # defaulted low for dev environments, override for production
 }
+variable "min_task_count" {
+  default     = 1
+  type        = number
+  description = "The minimum number of tasks for this service."
+}
 variable "required_cpus" {
   type = number
   description = "The required cpu resource for this service. 1024 here is 1 vCPU"


### PR DESCRIPTION
We need to increase the ECS resources due to the intense traffic received by the service in Live.
This PR bumps up the cpu amount for the app and eric container as well as the desired task count.