### PR TITLE
BI-13919: Change selection of first officer appointment in list

### DIFF
--- a/src/it/java/uk/gov/companieshouse/company_appointments/officerappointments/OfficerAppointmentsControllerITest.java
+++ b/src/it/java/uk/gov/companieshouse/company_appointments/officerappointments/OfficerAppointmentsControllerITest.java
@@ -579,7 +579,7 @@ class OfficerAppointmentsControllerITest {
 
     @DisplayName("Should use the name of the most recently appointed appointment when there are no active appointments")
     @Test
-    void getNaturalOfficerAppointmentsToInactiveCompany() throws Exception {
+    void getNonActiveOfficerAppointments() throws Exception {
         // given
         mongoTemplate.insert(IOUtils.resourceToString("/appointmentdocuments/resigned_officer_appointment.json",
                 StandardCharsets.UTF_8), "delta_appointments");
@@ -614,7 +614,7 @@ class OfficerAppointmentsControllerITest {
 
         // Clean up
         Query query = new Query()
-                .addCriteria(Criteria.where("officer_id").is(NATURAL_OFFICER_ID));
+                .addCriteria(Criteria.where("officer_id").is(NON_ACTIVE_OFFICER_ID));
         mongoTemplate.findAllAndRemove(query, "delta_appointments");
     }
 

--- a/src/it/java/uk/gov/companieshouse/company_appointments/officerappointments/OfficerAppointmentsControllerITest.java
+++ b/src/it/java/uk/gov/companieshouse/company_appointments/officerappointments/OfficerAppointmentsControllerITest.java
@@ -59,6 +59,7 @@ class OfficerAppointmentsControllerITest {
 
     private static final String CORPORATE_OFFICER_ID = UUID.randomUUID().toString();
     private static final String NATURAL_OFFICER_ID = UUID.randomUUID().toString();
+    private static final String NON_ACTIVE_OFFICER_ID = "non_active_officer_ID";
 
     @Container
     private static final MongoDBContainer mongoDBContainer = new MongoDBContainer("mongo:5");
@@ -569,6 +570,36 @@ class OfficerAppointmentsControllerITest {
         assertEquals(0, responseEntity.getResignedCount());
         assertEquals(0, responseEntity.getInactiveCount());
         assertTrue(responseEntity.getItems().isEmpty());
+
+        // Clean up
+        Query query = new Query()
+                .addCriteria(Criteria.where("officer_id").is(NATURAL_OFFICER_ID));
+        mongoTemplate.findAllAndRemove(query, "delta_appointments");
+    }
+
+    @DisplayName("Should use the name of the most recently appointed appointment when there are no active appointments")
+    @Test
+    void getNaturalOfficerAppointmentsToInactiveCompany() throws Exception {
+        // given
+        mongoTemplate.insert(IOUtils.resourceToString("/appointmentdocuments/resigned_officer_appointment.json",
+                StandardCharsets.UTF_8), "delta_appointments");
+        mongoTemplate.insert(IOUtils.resourceToString("/appointmentdocuments/inactive_officer_appointment.json",
+                StandardCharsets.UTF_8), "delta_appointments");
+
+        // when
+        ResultActions result = mockMvc.perform(
+                get("/officers/{officer_id}/appointments", NON_ACTIVE_OFFICER_ID)
+                        .header("ERIC-Identity", "123")
+                        .header("ERIC-Identity-Type", "key")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .accept(MediaType.APPLICATION_JSON));
+
+        // then
+        result.andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(jsonPath("$.date_of_birth", not(contains("day"))))
+//                .andExpect(jsonPath("$.date_of_birth.year", is(1970)))
+//                .andExpect(jsonPath("$.date_of_birth.month", is(1)))
+                .andExpect(jsonPath("$.name", is("Noname1 Noname2 NOSURNAME")));
 
         // Clean up
         Query query = new Query()

--- a/src/it/java/uk/gov/companieshouse/company_appointments/officerappointments/OfficerAppointmentsControllerITest.java
+++ b/src/it/java/uk/gov/companieshouse/company_appointments/officerappointments/OfficerAppointmentsControllerITest.java
@@ -596,10 +596,21 @@ class OfficerAppointmentsControllerITest {
 
         // then
         result.andExpect(MockMvcResultMatchers.status().isOk())
+                .andExpect(jsonPath("$.total_results", is(2)))
+                .andExpect(jsonPath("$.active_count", is(0)))
+                .andExpect(jsonPath("$.resigned_count", is(1)))
+                .andExpect(jsonPath("$.inactive_count", is(1)))
                 .andExpect(jsonPath("$.date_of_birth", not(contains("day"))))
-//                .andExpect(jsonPath("$.date_of_birth.year", is(1970)))
-//                .andExpect(jsonPath("$.date_of_birth.month", is(1)))
-                .andExpect(jsonPath("$.name", is("Noname1 Noname2 NOSURNAME")));
+                .andExpect(jsonPath("$.date_of_birth.year", is(1970)))
+                .andExpect(jsonPath("$.date_of_birth.month", is(1)))
+                .andExpect(jsonPath("$.is_corporate_officer", is(false)))
+                .andExpect(jsonPath("$.items_per_page", is(35)))
+                .andExpect(jsonPath("$.kind", is("personal-appointment")))
+                .andExpect(jsonPath("$.links.self",
+                        is("/officers/%s/appointments".formatted(NON_ACTIVE_OFFICER_ID))))
+                .andExpect(jsonPath("$.items", hasSize(2)))
+                .andExpect(jsonPath("$.name", is("Noname1 Noname2 NOSURNAME")))
+                .andExpect(jsonPath("$.start_index", is(0)));
 
         // Clean up
         Query query = new Query()

--- a/src/main/java/uk/gov/companieshouse/company_appointments/officerappointments/FilterService.java
+++ b/src/main/java/uk/gov/companieshouse/company_appointments/officerappointments/FilterService.java
@@ -5,28 +5,37 @@ import static uk.gov.companieshouse.company_appointments.model.data.CompanyStatu
 import static uk.gov.companieshouse.company_appointments.model.data.CompanyStatus.CONVERTED_CLOSED;
 import static uk.gov.companieshouse.company_appointments.model.data.CompanyStatus.DISSOLVED;
 
-
 import java.util.List;
+import java.util.Optional;
 import org.apache.commons.lang3.StringUtils;
 import org.springframework.stereotype.Component;
 import uk.gov.companieshouse.company_appointments.exception.BadRequestException;
+import uk.gov.companieshouse.company_appointments.model.data.CompanyAppointmentDocument;
 
 @Component
 class FilterService {
 
     private static final String ACTIVE = "active";
+    private static final List<String> INACTIVE_STATUSES = List.of(DISSOLVED.getStatus(), CONVERTED_CLOSED.getStatus(),
+            CLOSED.getStatus());
 
     Filter prepareFilter(String filter, String officerId) {
         if (StringUtils.isNotBlank(filter)) {
             if (ACTIVE.equals(filter)) {
-                return new Filter(true, List.of(DISSOLVED.getStatus(), CONVERTED_CLOSED.getStatus(), CLOSED.getStatus()));
+                return new Filter(true, INACTIVE_STATUSES);
             } else {
                 throw new BadRequestException(
-                        String.format("Invalid filter parameter supplied: %s, officer ID: %s",
-                                filter, officerId));
+                        "Invalid filter parameter supplied: %s, officer ID: %s".formatted(filter, officerId));
             }
         } else {
             return new Filter(false, emptyList());
         }
+    }
+
+    Optional<CompanyAppointmentDocument> findFirstActiveAppointment(List<CompanyAppointmentDocument> documents) {
+        return documents.stream()
+                .filter(document -> !INACTIVE_STATUSES.contains(document.getCompanyStatus()))
+                .filter(document -> document.getData().getResignedOn() == null)
+                .findFirst();
     }
 }

--- a/src/main/java/uk/gov/companieshouse/company_appointments/officerappointments/ItemsPerPageService.java
+++ b/src/main/java/uk/gov/companieshouse/company_appointments/officerappointments/ItemsPerPageService.java
@@ -1,12 +1,11 @@
 package uk.gov.companieshouse.company_appointments.officerappointments;
 
+import static uk.gov.companieshouse.company_appointments.interceptor.AuthenticationHelperImpl.INTERNAL_APP_PRIVILEGE;
+
+import java.util.Optional;
 import org.apache.commons.lang.ArrayUtils;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
-
-import java.util.Optional;
-
-import static uk.gov.companieshouse.company_appointments.interceptor.AuthenticationHelperImpl.INTERNAL_APP_PRIVILEGE;
 
 @Component
 public class ItemsPerPageService {

--- a/src/main/java/uk/gov/companieshouse/company_appointments/officerappointments/OfficerAppointmentsRepository.java
+++ b/src/main/java/uk/gov/companieshouse/company_appointments/officerappointments/OfficerAppointmentsRepository.java
@@ -105,8 +105,11 @@ interface OfficerAppointmentsRepository extends MongoRepository<CompanyAppointme
     int countInactive(String officerId);
 
     @Aggregation(pipeline = {
-            " { $match: { 'officer_id': ?0 } }",
-            "{ $sort: { 'data.appointed_on': -1 } }",
+            "{ $match: { 'officer_id': ?0 } }",
+            "{ $addFields: {"
+                    + "'__sort_appointed__': { $ifNull: ['$data.appointed_on', { $toDate: '$data.appointed_before' } ] }"
+                    + "} }",
+            "{ $sort: { '__sort_appointed__': -1 } }",
             "{ $limit: 1 }"
     })
     CompanyAppointmentDocument findLatestAppointment(String officerId);

--- a/src/main/java/uk/gov/companieshouse/company_appointments/officerappointments/OfficerAppointmentsRequest.java
+++ b/src/main/java/uk/gov/companieshouse/company_appointments/officerappointments/OfficerAppointmentsRequest.java
@@ -1,5 +1,5 @@
 package uk.gov.companieshouse.company_appointments.officerappointments;
 
-record OfficerAppointmentsRequest(String officerId, String filter, Integer startIndex, Integer itemsPerPage) {
+record OfficerAppointmentsRequest(String officerId, String filter, Integer startIndex, int itemsPerPage) {
 
 }

--- a/src/test/java/uk/gov/companieshouse/company_appointments/officerappointments/ItemsPerPageServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/company_appointments/officerappointments/ItemsPerPageServiceTest.java
@@ -1,14 +1,13 @@
 package uk.gov.companieshouse.company_appointments.officerappointments;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Named;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
-
-import java.util.stream.Stream;
-
-import static org.junit.jupiter.api.Assertions.assertEquals;
 
 class ItemsPerPageServiceTest {
 

--- a/src/test/java/uk/gov/companieshouse/company_appointments/officerappointments/OfficerAppointmentsRepositoryITest.java
+++ b/src/test/java/uk/gov/companieshouse/company_appointments/officerappointments/OfficerAppointmentsRepositoryITest.java
@@ -2,12 +2,12 @@ package uk.gov.companieshouse.company_appointments.officerappointments;
 
 import static java.util.Collections.emptyList;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.List;
-import java.util.Optional;
 import org.apache.commons.io.IOUtils;
 import org.bson.Document;
 import org.junit.jupiter.api.BeforeAll;
@@ -287,17 +287,16 @@ class OfficerAppointmentsRepositoryITest {
         assertEquals(0, resigned);
     }
 
-    @DisplayName("Repository should return the first appointment for the given officer ID")
+    @DisplayName("Repository should return the first appointment for the given officer ID sorted by appointed on")
     @Test
     void findFirstByOfficerId() {
         // given
 
         // when
-        Optional<CompanyAppointmentDocument> actual = repository.findFirstByOfficerId(OFFICER_ID);
+        CompanyAppointmentDocument actual = repository.findLatestAppointment(OFFICER_ID);
 
         // then
-        assertTrue(actual.isPresent());
-        assertEquals(OFFICER_ID, actual.get().getOfficerId());
+        assertEquals("active_1", actual.getId());
     }
 
     @DisplayName("Repository should return no appointment for the given officer ID")
@@ -306,9 +305,9 @@ class OfficerAppointmentsRepositoryITest {
         // given
 
         // when
-        Optional<CompanyAppointmentDocument> actual = repository.findFirstByOfficerId("not an officer id");
+        CompanyAppointmentDocument actual = repository.findLatestAppointment("not an officer id");
 
         // then
-        assertTrue(actual.isEmpty());
+        assertNull(actual);
     }
 }

--- a/src/test/resources/appointmentdocuments/inactive_officer_appointment.json
+++ b/src/test/resources/appointmentdocuments/inactive_officer_appointment.json
@@ -1,28 +1,28 @@
 {
-  "_id" : "active_2",
-  "appointment_id" : "active_2",
+  "_id" : "non_active_dissolved",
+  "appointment_id" : "non_active_dissolved",
   "company_name" : "TEST COMPANY LIMITED",
   "company_number" : "12345678",
-  "company_status" : "active",
+  "company_status" : "dissolved",
   "created" : {
     "at" : ISODate("2020-08-26T12:00:00.000Z")
   },
   "data" : {
-    "officer_role" : "secretary",
+    "officer_role" : "director",
     "title" : "Mrs",
     "country_of_residence" : "United Kingdom",
     "links" : {
       "officer" : {
-        "self" : "/officers/active_2",
-        "appointments" : "/officers/active_2/appointments"
+        "self" : "/officers/non_active_officer_ID",
+        "appointments" : "/officers/non_active_officer_ID/appointments"
       },
-      "self" : "/company/12345678/appointments/active_2"
+      "self" : "/company/12345678/appointments/non_active_dissolved"
     },
     "nationality" : "British",
-    "forename" : "John",
-    "surname" : "Test",
-    "other_forenames" : "Forename",
-    "appointed_on" : ISODate("2023-08-26T12:00:00.000Z"),
+    "forename" : "Noname1",
+    "surname" : "NOSURNAME",
+    "other_forenames" : "Noname2",
+    "appointed_before" : ISODate("1992-07-26T12:00:00.000Z"),
     "etag" : "8f58a770d34f982a1b2a5a29fcde12528e82f903",
     "occupation" : "Company Director",
     "service_address" : {
@@ -45,12 +45,12 @@
       "premises" : "URA",
       "region" : "ura_region"
     },
-    "date_of_birth" : ISODate("1980-01-01T00:00:00.000Z")
+    "date_of_birth" : ISODate("1970-01-01T00:00:00.000Z")
   },
   "delta_at" : ISODate("2020-06-23T12:13:03.006Z"),
   "internal_id" : "2500085646",
-  "officer_id" : "5VEOBB4a9dlB_iugw_vieHjWpCk",
-  "officer_role_sort_order" : 10,
+  "officer_id" : "non_active_officer_ID",
+  "officer_role_sort_order" : 200,
   "updated" : {
     "at" : ISODate("2020-08-26T13:00:00.000Z")
   },

--- a/src/test/resources/appointmentdocuments/nat_pre_1992_delta_appointment_document_template.json
+++ b/src/test/resources/appointmentdocuments/nat_pre_1992_delta_appointment_document_template.json
@@ -27,16 +27,10 @@
     "officer_role" : "<officer_role>",
     "is_secure_officer" : false,
     "surname" : "Baggins",
-    "forename" : "Frodo",
+    "forename" : "Bilbo",
     "other_forenames" : "Middlename",
     "title" : "Mr",
-    "company_number" : "<company_number>",
-    "former_names" : [
-      {
-        "forenames" : "Bilbo",
-        "surname" : "Baggins"
-      }
-    ]
+    "company_number" : "<company_number>"
   },
   "sensitive_data" : {
     "usual_residential_address" : {

--- a/src/test/resources/appointmentdocuments/resigned_officer_appointment.json
+++ b/src/test/resources/appointmentdocuments/resigned_officer_appointment.json
@@ -1,6 +1,6 @@
 {
-  "_id" : "active_2",
-  "appointment_id" : "active_2",
+  "_id" : "non_active_resigned",
+  "appointment_id" : "non_active_resigned",
   "company_name" : "TEST COMPANY LIMITED",
   "company_number" : "12345678",
   "company_status" : "active",
@@ -8,21 +8,22 @@
     "at" : ISODate("2020-08-26T12:00:00.000Z")
   },
   "data" : {
-    "officer_role" : "secretary",
+    "officer_role" : "director",
     "title" : "Mrs",
     "country_of_residence" : "United Kingdom",
     "links" : {
       "officer" : {
-        "self" : "/officers/active_2",
-        "appointments" : "/officers/active_2/appointments"
+        "self" : "/officers/non_active_officer_ID",
+        "appointments" : "/officers/non_active_officer_ID/appointments"
       },
-      "self" : "/company/12345678/appointments/active_2"
+      "self" : "/company/12345678/appointments/non_active_resigned"
     },
     "nationality" : "British",
     "forename" : "John",
-    "surname" : "Test",
+    "surname" : "Doe",
     "other_forenames" : "Forename",
-    "appointed_on" : ISODate("2023-08-26T12:00:00.000Z"),
+    "resigned_on": ISODate("2024-08-26T12:00:00.000Z"),
+    "appointed_on" : ISODate("1990-08-26T12:00:00.000Z"),
     "etag" : "8f58a770d34f982a1b2a5a29fcde12528e82f903",
     "occupation" : "Company Director",
     "service_address" : {
@@ -45,11 +46,11 @@
       "premises" : "URA",
       "region" : "ura_region"
     },
-    "date_of_birth" : ISODate("1980-01-01T00:00:00.000Z")
+    "date_of_birth" : ISODate("1990-02-04T00:00:00.000Z")
   },
   "delta_at" : ISODate("2020-06-23T12:13:03.006Z"),
   "internal_id" : "2500085646",
-  "officer_id" : "5VEOBB4a9dlB_iugw_vieHjWpCk",
+  "officer_id" : "non_active_officer_ID",
   "officer_role_sort_order" : 10,
   "updated" : {
     "at" : ISODate("2020-08-26T13:00:00.000Z")


### PR DESCRIPTION
* The name, is_corporate_officer and date_of_birth fields are
  populated using data from the first chosen officer appointment.
* Previously the first one returned from Mongo, now has been changed
  to be the most recently appointed active appointment, if any, or the most recently
  appointed resigned or inactive appointment.

[BI-13919](https://companieshouse.atlassian.net/browse/BI-13919)

[BI-13919]: https://companieshouse.atlassian.net/browse/BI-13919?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ