### PR TITLE
DSND-3019: Change processing order for updates

### DIFF
--- a/src/it/resources/features/upsert_full_record_appointment.feature
+++ b/src/it/resources/features/upsert_full_record_appointment.feature
@@ -58,7 +58,7 @@ Feature: Upsert full record officer information
     And the delta for payload "<payloadFile>" is the most recent delta for "<appointmentId>"
     When a request is sent to the PUT endpoint to upsert an officers delta
     Then I should receive a 503 status code
-    And the changes within the delta for "<appointmentId>" should NOT be persisted in the database
+    And the record should be saved
 
     Examples:
       | payloadFile                        | appointmentId               |

--- a/src/main/java/uk/gov/companieshouse/company_appointments/service/CompanyAppointmentFullRecordService.java
+++ b/src/main/java/uk/gov/companieshouse/company_appointments/service/CompanyAppointmentFullRecordService.java
@@ -147,17 +147,14 @@ public class CompanyAppointmentFullRecordService {
             try {
                 saveDocument(document, instant, existingDocument.getCreated());
             } catch (ServiceUnavailableException e) {
-                // Apply compensatory transaction
-                companyAppointmentRepository.save(existingDocument);
-                LOGGER.info("Call to Kafka API failed, reverting previously updated document to original state",
-                        DataMapHolder.getLogMap());
+                LOGGER.info("Call to Kafka API failed", DataMapHolder.getLogMap());
                 throw e;
             }
         }
     }
 
     private boolean isDeltaStale(final Instant incomingDelta, final Instant existingDelta) {
-        return !incomingDelta.isAfter(existingDelta);
+        return incomingDelta.isBefore(existingDelta);
     }
 
     private void logStaleIncomingDelta(final CompanyAppointmentDocument appointmentAPI, final Instant existingDelta) {
@@ -174,10 +171,7 @@ public class CompanyAppointmentFullRecordService {
         try {
             saveDocument(document, instant, instant);
         } catch (ServiceUnavailableException e) {
-            // Apply compensatory transaction
-            companyAppointmentRepository.deleteByCompanyNumberAndID(document.getCompanyNumber(), document.getId());
-            LOGGER.info("Call to Kafka API failed, deleting previously inserted document",
-                    DataMapHolder.getLogMap());
+            LOGGER.info("Call to Kafka API failed", DataMapHolder.getLogMap());
             throw e;
         }
     }

--- a/src/test/java/uk/gov/companieshouse/company_appointments/service/CompanyAppointmentFullRecordServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/company_appointments/service/CompanyAppointmentFullRecordServiceTest.java
@@ -70,11 +70,11 @@ class CompanyAppointmentFullRecordServiceTest {
     private final FullRecordCompanyOfficerApi fullRecordCompanyOfficerApi = buildFullRecordOfficer();
 
 
-    private final static String COMPANY_NUMBER = "123456";
-    private final static String APPOINTMENT_ID = "345678";
-    private final static OffsetDateTime DELTA_AT_LATER = OffsetDateTime.parse("2022-01-14T00:00:00.000000Z");
-    private final static OffsetDateTime DELTA_AT_STALE = OffsetDateTime.parse("2022-01-12T00:00:00.000000Z");
-    private final static Clock CLOCK = Clock.fixed(Instant.parse("2021-08-01T00:00:00.000000Z"),
+    private static final String COMPANY_NUMBER = "123456";
+    private static final String APPOINTMENT_ID = "345678";
+    private static final OffsetDateTime DELTA_AT_LATER = OffsetDateTime.parse("2022-01-14T00:00:00.000000Z");
+    private static final OffsetDateTime DELTA_AT_STALE = OffsetDateTime.parse("2022-01-12T00:00:00.000000Z");
+    private static final Clock CLOCK = Clock.fixed(Instant.parse("2021-08-01T00:00:00.000000Z"),
             ZoneId.of("UTC"));
 
     private static Stream<Arguments> deltaAtTestCases() {
@@ -86,7 +86,7 @@ class CompanyAppointmentFullRecordServiceTest {
                 // Newer timestamp not stale
                 Arguments.of("2022-01-13T00:00:00.000000Z", DELTA_AT_STALE, true, true),
                 // Older timestamp stale
-                Arguments.of("2022-01-12T00:00:00.000000Z", DELTA_AT_STALE, true, true)
+                Arguments.of("2022-01-12T00:00:00.000000Z", DELTA_AT_STALE, true, false)
                 // 1 == 1 so delta should be stale
         );
     }
@@ -199,7 +199,7 @@ class CompanyAppointmentFullRecordServiceTest {
     }
 
     @Test
-    void testInsertAppointmentHandlesCompensatoryTransactionWhenServiceUnavailableThrown() {
+    void testInsertAppointmentEvenWhenServiceUnavailableThrown() {
         // given
         CompanyAppointmentDocument deltaAppointmentDocument = new CompanyAppointmentDocument()
                 .id("appointmentId")
@@ -216,11 +216,10 @@ class CompanyAppointmentFullRecordServiceTest {
         // then
         assertThrows(ServiceUnavailableException.class, executable);
         verify(companyAppointmentRepository).save(deltaAppointmentDocument);
-        verify(companyAppointmentRepository).deleteByCompanyNumberAndID("012345678", "appointmentId");
     }
 
     @Test
-    void testUpdateAppointmentHandlesCompensatoryTransactionWhenServiceUnavailableThrown() {
+    void testUpdateAppointmentEvenWhenServiceUnavailableThrown() {
         // given
         CompanyAppointmentDocument deltaAppointmentDocument = new CompanyAppointmentDocument()
                 .id("appointmentId")
@@ -245,7 +244,6 @@ class CompanyAppointmentFullRecordServiceTest {
         // then
         assertThrows(ServiceUnavailableException.class, executable);
         verify(companyAppointmentRepository).save(deltaAppointmentDocument);
-        verify(companyAppointmentRepository).save(existingDocument);
     }
 
     @ParameterizedTest


### PR DESCRIPTION
* Removed compensatory transaction for saves
* Modified stale delta checks to allow `delta_at` values on deltas and saved documents to have the same value and still be processed
* Resource changed updates can fail and be retried while leaving updated documents in Mongo

[DSND-3019](https://companieshouse.atlassian.net/browse/DSND-3019)

[DSND-3019]: https://companieshouse.atlassian.net/browse/DSND-3019?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ