### PR TITLE
DSND-3111: Implements a delete delta with a delta_at check

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -32,7 +32,7 @@
         <structured-logging.version>3.0.16</structured-logging.version>
         <sdk-manager-java.version>3.0.9</sdk-manager-java.version>
         <api-sdk-manager-java-library.version>3.0.5</api-sdk-manager-java-library.version>
-        <private-api-sdk-java.version>unversioned-main</private-api-sdk-java.version>
+        <private-api-sdk-java.version>4.0.221</private-api-sdk-java.version>
         <api-helper-java-library.version>3.0.1</api-helper-java-library.version>
         <api-security-java.version>2.0.5</api-security-java.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -29,10 +29,10 @@
         <commons.io.version>2.16.1</commons.io.version>
 
         <!-- internal dependencies -->
-        <structured-logging.version>3.0.12</structured-logging.version>
+        <structured-logging.version>3.0.16</structured-logging.version>
         <sdk-manager-java.version>3.0.9</sdk-manager-java.version>
         <api-sdk-manager-java-library.version>3.0.5</api-sdk-manager-java-library.version>
-        <private-api-sdk-java.version>4.0.181</private-api-sdk-java.version>
+        <private-api-sdk-java.version>unversioned-main</private-api-sdk-java.version>
         <api-helper-java-library.version>3.0.1</api-helper-java-library.version>
         <api-security-java.version>2.0.5</api-security-java.version>
 

--- a/src/it/java/uk/gov/companieshouse/company_appointments/steps/FullRecordAppointmentSteps.java
+++ b/src/it/java/uk/gov/companieshouse/company_appointments/steps/FullRecordAppointmentSteps.java
@@ -37,8 +37,9 @@ public class FullRecordAppointmentSteps {
     private static final String ERIC_AUTHORISED_KEY_PRIVILEGES = "ERIC-Authorised-Key-Privileges";
     private static final String IDENTITY_TYPE_KEY = "key";
     private static final String INTERNAL_APP_PRIVILEGES = "internal-app";
-
+    private static final String DELTA_AT = "20220925171003950844";
     private static final String X_REQUEST_ID = "x-request-id";
+    private static final String X_DELTA_AT = "x-delta-at";
 
     private final HttpHeaders headers = new HttpHeaders();
 
@@ -157,6 +158,7 @@ public class FullRecordAppointmentSteps {
         headers.setAccept(Collections.singletonList(MediaType.APPLICATION_JSON));
 
         headers.set(X_REQUEST_ID, "5234234234");
+        headers.set(X_DELTA_AT, DELTA_AT);
 
         HttpEntity<String> request = new HttpEntity<>(null, headers);
         String uri = String.format("/company/%s/appointments/%s/full_record/delete", COMPANY_NUMBER,

--- a/src/it/java/uk/gov/companieshouse/company_appointments/tests/AuthenticationInterceptorsITest.java
+++ b/src/it/java/uk/gov/companieshouse/company_appointments/tests/AuthenticationInterceptorsITest.java
@@ -30,6 +30,7 @@ import uk.gov.companieshouse.company_appointments.model.data.DeltaSensitiveData;
 import uk.gov.companieshouse.company_appointments.model.view.CompanyAppointmentFullRecordView;
 import uk.gov.companieshouse.company_appointments.service.CompanyAppointmentFullRecordService;
 import uk.gov.companieshouse.company_appointments.service.CompanyAppointmentService;
+import uk.gov.companieshouse.company_appointments.service.DeleteAppointmentService;
 import uk.gov.companieshouse.logging.Logger;
 
 @WebMvcTest(controllers = {CompanyAppointmentController.class, CompanyAppointmentFullRecordController.class})
@@ -52,6 +53,9 @@ class AuthenticationInterceptorsITest {
     private CompanyAppointmentService companyAppointmentService;
     @MockBean
     private CompanyAppointmentFullRecordService companyAppointmentFullRecordService;
+    @MockBean
+    private DeleteAppointmentService deleteAppointmentService;
+
     private HttpHeaders httpHeaders;
     private OfficerSummary officerSummary;
     private CompanyAppointmentFullRecordView companyAppointmentFullRecordView;

--- a/src/it/java/uk/gov/companieshouse/company_appointments/tests/CompanyAppointmentControllerITest.java
+++ b/src/it/java/uk/gov/companieshouse/company_appointments/tests/CompanyAppointmentControllerITest.java
@@ -355,8 +355,7 @@ class CompanyAppointmentControllerITest {
 
     @Test
     @DisplayName("Patch existing appointments endpoint returns 400 bad request when company name is missing")
-    @ExtendWith(OutputCaptureExtension.class)
-    void testPatchExistingAppointmentCompanyNameStatusMissingRequestFields(CapturedOutput capture) throws Exception {
+    void testPatchExistingAppointmentCompanyNameStatusMissingRequestFields() throws Exception {
         mockMvc.perform(patch("/company/{company_number}/appointments", COMPANY_NUMBER)
                         .contentType(MediaType.APPLICATION_JSON)
                         .header(X_REQUEST_ID, "5342342")
@@ -365,13 +364,11 @@ class CompanyAppointmentControllerITest {
                         .header(ERIC_AUTHORISED_KEY_PRIVILEGES, "internal-app")
                         .content(objectMapper.writeValueAsString(new PatchAppointmentNameStatusApi())))
                 .andExpect(MockMvcResultMatchers.status().isBadRequest());
-        assertThat(capture.getOut()).doesNotContain("event: error");
     }
 
     @Test
     @DisplayName("Patch existing appointments endpoint returns 400 when invalid company status provided")
-    @ExtendWith(OutputCaptureExtension.class)
-    void testPatchExistingAppointmentCompanyNameStatusInvalidStatus(CapturedOutput capture) throws Exception {
+    void testPatchExistingAppointmentCompanyNameStatusInvalidStatus() throws Exception {
         PatchAppointmentNameStatusApi requestBody = new PatchAppointmentNameStatusApi()
                 .companyName("company name")
                 .companyStatus("fake");
@@ -384,7 +381,6 @@ class CompanyAppointmentControllerITest {
                         .header(ERIC_AUTHORISED_KEY_PRIVILEGES, "internal-app")
                         .content(objectMapper.writeValueAsString(requestBody)))
                 .andExpect(MockMvcResultMatchers.status().isBadRequest());
-        assertThat(capture.getOut()).doesNotContain("event: error");
     }
 
     @Test

--- a/src/it/java/uk/gov/companieshouse/company_appointments/tests/CompanyAppointmentFullRecordControllerITest.java
+++ b/src/it/java/uk/gov/companieshouse/company_appointments/tests/CompanyAppointmentFullRecordControllerITest.java
@@ -5,6 +5,8 @@ import static org.hamcrest.Matchers.notNullValue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
@@ -48,6 +50,8 @@ class CompanyAppointmentFullRecordControllerITest {
     private static final String APPOINTMENT_ID = "7IjxamNGLlqtIingmTZJJ42Hw9Q";
     private static final String NULL_FIELD_COMPANY_NUMBER = "CN008888";
     private static final String NULL_FIELD_APPOINTMENT_ID = "testNullFieldsId123";
+    private static final String DELTA_AT = "20220925171003950844";
+    private static final String X_DELTA_AT = "x-delta-at";
 
     @Autowired
     private MockMvc mockMvc;
@@ -128,7 +132,9 @@ class CompanyAppointmentFullRecordControllerITest {
                         APPOINTMENT_ID)
                         .header("ERIC-Identity", "123").header("ERIC-Identity-Type", "key")
                         .header("ERIC-authorised-key-privileges", "internal-app")
-                        .header("x-request-id", "contextId"));
+                        .header("x-request-id", "contextId")
+                        .header(X_DELTA_AT, DELTA_AT)
+                        .queryParam("delta_at", DELTA_AT));
 
         result.andExpect(status().isOk());
 
@@ -168,20 +174,19 @@ class CompanyAppointmentFullRecordControllerITest {
 
     @Test
     @ExtendWith(OutputCaptureExtension.class)
-    void testReturn404IfOfficerIsNotDeleted(CapturedOutput capture) throws Exception{
+    void shouldPublishResourceChangedWhenAppointmentHasAlreadyBeenDeleted(CapturedOutput capture) throws Exception{
         ResultActions result = mockMvc
-                .perform(delete("/company/{company_number}/appointments/{appointment_id}/full_record/delete", COMPANY_NUMBER,
-                        "Incorrect")
+                .perform(delete("/company/{company_number}/appointments/{appointment_id}/full_record/delete",
+                        COMPANY_NUMBER, "Incorrect")
                         .header("ERIC-Identity", "123").header("ERIC-Identity-Type", "key")
                         .header("ERIC-authorised-key-privileges", "internal-app")
-                        .header("x-request-id", "contextId"));
+                        .header("x-request-id", "contextId")
+                        .header(X_DELTA_AT, DELTA_AT)
+                        .queryParam("delta_at", DELTA_AT));
 
-        result.andExpect(status().isNotFound());
+        result.andExpect(status().isOk());
 
-        Query query = new Query();
-        query.addCriteria(Criteria.where("_id").is("7IjxamNGLlqtIingmTZJJ42Hw9Q"));
-        List<CompanyAppointmentDocument> appointments = mongoTemplate.find(query, CompanyAppointmentDocument.class);
-        assertThat(appointments).hasSize(1);
+        verify(resourceChangedApiService).invokeChsKafkaApi(any());
         assertThat(capture.getOut()).doesNotContain("event: error");
     }
 }

--- a/src/it/java/uk/gov/companieshouse/company_appointments/tests/CompanyAppointmentFullRecordControllerITest.java
+++ b/src/it/java/uk/gov/companieshouse/company_appointments/tests/CompanyAppointmentFullRecordControllerITest.java
@@ -133,8 +133,7 @@ class CompanyAppointmentFullRecordControllerITest {
                         .header("ERIC-Identity", "123").header("ERIC-Identity-Type", "key")
                         .header("ERIC-authorised-key-privileges", "internal-app")
                         .header("x-request-id", "contextId")
-                        .header(X_DELTA_AT, DELTA_AT)
-                        .queryParam("delta_at", DELTA_AT));
+                        .header(X_DELTA_AT, DELTA_AT));
 
         result.andExpect(status().isOk());
 
@@ -181,8 +180,7 @@ class CompanyAppointmentFullRecordControllerITest {
                         .header("ERIC-Identity", "123").header("ERIC-Identity-Type", "key")
                         .header("ERIC-authorised-key-privileges", "internal-app")
                         .header("x-request-id", "contextId")
-                        .header(X_DELTA_AT, DELTA_AT)
-                        .queryParam("delta_at", DELTA_AT));
+                        .header(X_DELTA_AT, DELTA_AT));
 
         result.andExpect(status().isOk());
 

--- a/src/it/java/uk/gov/companieshouse/company_appointments/tests/CompanyAppointmentFullRecordControllerMongoUnavailableITest.java
+++ b/src/it/java/uk/gov/companieshouse/company_appointments/tests/CompanyAppointmentFullRecordControllerMongoUnavailableITest.java
@@ -39,11 +39,13 @@ class CompanyAppointmentFullRecordControllerMongoUnavailableITest {
     private static final String COMPANY_NUMBER = "12345678";
     private static final String APPOINTMENT_ID = "7IjxamNGLlqtIingmTZJJ42Hw9Q";
     private static final String X_REQUEST_ID = "x-request-id";
+    private static final String X_DELTA_AT = "x-delta-at";
     private static final String ERIC_IDENTITY = "ERIC-Identity";
     private static final String ERIC_IDENTITY_TYPE = "ERIC-Identity-Type";
     private static final String ERIC_AUTHORISED_KEY_PRIVILEGES = "ERIC-Authorised-Key-Privileges";
     private static final String FULL_RECORD_DELETE_ENDPOINT = "/company/{company_number}/appointments/{appointment_id}/full_record/delete";
     private static final String FULL_RECORD_PUT_ENDPOINT = "/company/{company_number}/appointments/{appointment_id}/full_record";
+    private static final String DELTA_AT = "20140925171003950844";
 
     @Autowired
     private MockMvc mockMvc;
@@ -96,7 +98,8 @@ class CompanyAppointmentFullRecordControllerMongoUnavailableITest {
                         .header(X_REQUEST_ID, "5342342")
                         .header(ERIC_IDENTITY, "SOME_IDENTITY")
                         .header(ERIC_IDENTITY_TYPE, "key")
-                        .header(ERIC_AUTHORISED_KEY_PRIVILEGES, "internal-app"))
+                        .header(ERIC_AUTHORISED_KEY_PRIVILEGES, "internal-app")
+                        .header(X_DELTA_AT, DELTA_AT))
                 .andExpect(status().isServiceUnavailable());
     }
 }

--- a/src/it/resources/features/delete_full_record_appointment.feature
+++ b/src/it/resources/features/delete_full_record_appointment.feature
@@ -11,9 +11,10 @@ Feature: Delete full record officer information
 
     Scenario: Record not found in database
       Given the user is authenticated and authorised with internal app privileges
+      And CHS kafka is available
       And the record is not present in the delta_appointment database
       When a request is sent to the DELETE endpoint to delete an officer
-      Then I should receive a 404 status code
+      Then I should receive a 200 status code
 
     Scenario: User not authorised with internal app privileges
       Given the user is not authenticated or authorised
@@ -35,4 +36,4 @@ Feature: Delete full record officer information
       And the user is authenticated and authorised with internal app privileges
       When a request is sent to the DELETE endpoint to delete an officer
       And I should receive a 503 status code
-      And the record should NOT be deleted
+      And the record should be deleted successfully

--- a/src/main/java/uk/gov/companieshouse/company_appointments/service/DeleteAppointmentService.java
+++ b/src/main/java/uk/gov/companieshouse/company_appointments/service/DeleteAppointmentService.java
@@ -1,0 +1,120 @@
+package uk.gov.companieshouse.company_appointments.service;
+
+import static java.time.ZoneOffset.UTC;
+
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import java.io.UncheckedIOException;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Map;
+import java.util.Optional;
+import org.apache.commons.lang3.StringUtils;
+import org.springframework.dao.DataAccessException;
+import org.springframework.stereotype.Service;
+import uk.gov.companieshouse.company_appointments.CompanyAppointmentsApplication;
+import uk.gov.companieshouse.company_appointments.api.ResourceChangedApiService;
+import uk.gov.companieshouse.company_appointments.exception.BadRequestException;
+import uk.gov.companieshouse.company_appointments.exception.ServiceUnavailableException;
+import uk.gov.companieshouse.company_appointments.logging.DataMapHolder;
+import uk.gov.companieshouse.company_appointments.mapper.CompanyAppointmentMapper;
+import uk.gov.companieshouse.company_appointments.model.data.CompanyAppointmentDocument;
+import uk.gov.companieshouse.company_appointments.model.data.ResourceChangedRequest;
+import uk.gov.companieshouse.company_appointments.repository.CompanyAppointmentRepository;
+import uk.gov.companieshouse.logging.Logger;
+import uk.gov.companieshouse.logging.LoggerFactory;
+
+@Service
+public class DeleteAppointmentService {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(CompanyAppointmentsApplication.APPLICATION_NAME_SPACE);
+    private static final ObjectMapper NULL_CLEANING_OBJECT_MAPPER = new ObjectMapper()
+            .registerModule(new JavaTimeModule())
+            .setSerializationInclusion(Include.NON_NULL);
+    private static final DateTimeFormatter DELTA_AT_FORMATTER = DateTimeFormatter.ofPattern("yyyyMMddHHmmssSSSSSS")
+            .withZone(UTC);
+
+    private final CompanyAppointmentRepository companyAppointmentRepository;
+    private final ResourceChangedApiService resourceChangedApiService;
+    private final CompanyAppointmentMapper companyAppointmentMapper;
+
+    public DeleteAppointmentService(
+            CompanyAppointmentRepository companyAppointmentRepository,
+            ResourceChangedApiService resourceChangedApiService,
+            CompanyAppointmentMapper companyAppointmentMapper) {
+        this.companyAppointmentRepository = companyAppointmentRepository;
+        this.resourceChangedApiService = resourceChangedApiService;
+        this.companyAppointmentMapper = companyAppointmentMapper;
+    }
+
+    public void deleteAppointment(String companyNumber, String appointmentId, String deltaAt) {
+
+        if (StringUtils.isBlank(deltaAt)) {
+            throw new BadRequestException("deltaAt is null or empty");
+        }
+
+        try {
+            LOGGER.info("Deleting appointment [%s] for company [%s]".formatted(appointmentId, companyNumber),
+                    DataMapHolder.getLogMap());
+
+            Optional<CompanyAppointmentDocument> document = companyAppointmentRepository.readByCompanyNumberAndID(
+                    companyNumber, appointmentId);
+
+            if (document.isEmpty()) {
+
+                LOGGER.info("Appointment [%s] for company [%s] not found".formatted(appointmentId, companyNumber),
+                        DataMapHolder.getLogMap());
+                publishResourceChanged(companyNumber, appointmentId, null);
+
+            } else {
+
+                CompanyAppointmentDocument companyAppointmentDocument = document.get();
+                Instant deltaAtInstant = LocalDateTime.parse(deltaAt, DELTA_AT_FORMATTER).toInstant(UTC);
+
+                if (deltaAtInstant.isBefore(companyAppointmentDocument.getDeltaAt())) {
+                    logStaleIncomingDelta(companyAppointmentDocument, deltaAtInstant);
+                } else {
+                    companyAppointmentRepository.deleteByCompanyNumberAndID(companyNumber, appointmentId);
+                    publishResourceChanged(companyNumber, appointmentId, cleanDocument(document.get()));
+                }
+            }
+        } catch (DataAccessException e) {
+            LOGGER.error(String.format("%s: %s", e.getClass().getName(), e.getMessage()), DataMapHolder.getLogMap());
+            throw new ServiceUnavailableException("Error connecting to MongoDB");
+        } catch (IllegalArgumentException e) {
+            LOGGER.error(String.format("%s: %s", e.getClass().getName(), e.getMessage()), DataMapHolder.getLogMap());
+            throw new ServiceUnavailableException("Error connecting to chs-kafka-api");
+        }
+    }
+
+    private void publishResourceChanged(String companyNumber, String appointmentId, Object officersData) {
+        resourceChangedApiService.invokeChsKafkaApi(new ResourceChangedRequest(DataMapHolder.getRequestId(),
+                companyNumber, appointmentId, officersData, true));
+        LOGGER.debug(String.format("ChsKafka api DELETED invoked for appointment [%s] for company [%s]",
+                appointmentId, companyNumber), DataMapHolder.getLogMap());
+    }
+
+    private Object cleanDocument(CompanyAppointmentDocument document) {
+        try {
+            String officerJson = NULL_CLEANING_OBJECT_MAPPER.writeValueAsString(
+                    companyAppointmentMapper.map(document));
+            return NULL_CLEANING_OBJECT_MAPPER.readValue(officerJson, Object.class);
+        } catch (JsonProcessingException e) {
+            LOGGER.error("Failed to serialise/deserialise officer summary", DataMapHolder.getLogMap());
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    private void logStaleIncomingDelta(final CompanyAppointmentDocument appointmentAPI, final Instant deltaAt) {
+
+        Map<String, Object> logInfo = DataMapHolder.getLogMap();
+        logInfo.put("existingDeltaAt", appointmentAPI.getDeltaAt().toString());
+        logInfo.put("incomingDeltaAt", deltaAt.toString().isBlank() ? deltaAt.toString() : "No existing delta");
+        final String context = appointmentAPI.getAppointmentId();
+        LOGGER.errorContext(context, "Received stale delta", null, logInfo);
+    }
+}
+

--- a/src/test/java/uk/gov/companieshouse/company_appointments/CompanyAppointmentFullRecordControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/company_appointments/CompanyAppointmentFullRecordControllerTest.java
@@ -20,9 +20,15 @@ import uk.gov.companieshouse.company_appointments.exception.NotFoundException;
 import uk.gov.companieshouse.company_appointments.exception.ServiceUnavailableException;
 import uk.gov.companieshouse.company_appointments.model.view.CompanyAppointmentFullRecordView;
 import uk.gov.companieshouse.company_appointments.service.CompanyAppointmentFullRecordService;
+import uk.gov.companieshouse.company_appointments.service.DeleteAppointmentService;
 
 @ExtendWith(MockitoExtension.class)
 class CompanyAppointmentFullRecordControllerTest {
+
+    private static final String COMPANY_NUMBER = "123456";
+    private static final String APPOINTMENT_ID = "345678";
+    private static final String DELTA_AT = "20140925171003950844";
+
     private CompanyAppointmentFullRecordController companyAppointmentFullRecordController;
 
     @Mock
@@ -34,12 +40,14 @@ class CompanyAppointmentFullRecordControllerTest {
     @Mock
     private CompanyAppointmentFullRecordView appointmentView;
 
-    private final static String COMPANY_NUMBER = "123456";
-    private final static String APPOINTMENT_ID = "345678";
+    @Mock
+    private DeleteAppointmentService deleteAppointmentService;
 
     @BeforeEach
     void setUp() {
-        companyAppointmentFullRecordController = new CompanyAppointmentFullRecordController(companyAppointmentService);
+        companyAppointmentFullRecordController = new CompanyAppointmentFullRecordController(
+                companyAppointmentService,
+                deleteAppointmentService);
     }
 
     @Test
@@ -108,29 +116,31 @@ class CompanyAppointmentFullRecordControllerTest {
 
     @Test
     void testControllerReturns200WhenOfficerDeleted() {
-
-        ResponseEntity<Void> response = companyAppointmentFullRecordController.deleteOfficerData(COMPANY_NUMBER, APPOINTMENT_ID);
+        ResponseEntity<Void> response = companyAppointmentFullRecordController.deleteOfficerData(COMPANY_NUMBER,
+                APPOINTMENT_ID, DELTA_AT);
 
         assertEquals(HttpStatus.OK, response.getStatusCode());
     }
 
     @Test
     void testControllerReturns404WhenOfficerNotDeleted() {
-        doThrow(NotFoundException.class).when(companyAppointmentService).deleteAppointmentDelta(any(), any());
+        doThrow(NotFoundException.class).when(deleteAppointmentService).deleteAppointment(any(), any(), any());
 
-        ResponseEntity<Void> response = companyAppointmentFullRecordController.deleteOfficerData(COMPANY_NUMBER, APPOINTMENT_ID);
+        ResponseEntity<Void> response = companyAppointmentFullRecordController.deleteOfficerData(COMPANY_NUMBER,
+                APPOINTMENT_ID, DELTA_AT);
 
         assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
     }
 
     @Test
-    void testControllerReturns503StatusWhenDeleteEndpointIsCalled() throws ServiceUnavailableException, NotFoundException {
+    void testControllerReturns503StatusWhenDeleteEndpointIsCalled() {
         // given
         doThrow(ServiceUnavailableException.class)
-                .when(companyAppointmentService).deleteAppointmentDelta(any(), any());
+                .when(deleteAppointmentService).deleteAppointment(any(), any(), any());
 
         // when
-        ResponseEntity<Void> response = companyAppointmentFullRecordController.deleteOfficerData(COMPANY_NUMBER, APPOINTMENT_ID);
+        ResponseEntity<Void> response = companyAppointmentFullRecordController.deleteOfficerData(COMPANY_NUMBER,
+                APPOINTMENT_ID, DELTA_AT);
 
         // then
         assertEquals(HttpStatus.SERVICE_UNAVAILABLE, response.getStatusCode());

--- a/src/test/java/uk/gov/companieshouse/company_appointments/service/CompanyAppointmentFullRecordServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/company_appointments/service/CompanyAppointmentFullRecordServiceTest.java
@@ -69,7 +69,6 @@ class CompanyAppointmentFullRecordServiceTest {
 
     private final FullRecordCompanyOfficerApi fullRecordCompanyOfficerApi = buildFullRecordOfficer();
 
-
     private static final String COMPANY_NUMBER = "123456";
     private static final String APPOINTMENT_ID = "345678";
     private static final OffsetDateTime DELTA_AT_LATER = OffsetDateTime.parse("2022-01-14T00:00:00.000000Z");
@@ -95,7 +94,7 @@ class CompanyAppointmentFullRecordServiceTest {
     void setUp() {
         companyAppointmentService =
                 new CompanyAppointmentFullRecordService(deltaAppointmentTransformer,
-                        companyAppointmentRepository, resourceChangedApiService, companyAppointmentMapper, CLOCK);
+                        companyAppointmentRepository, resourceChangedApiService, CLOCK);
     }
 
     @Test
@@ -284,67 +283,12 @@ class CompanyAppointmentFullRecordServiceTest {
     }
 
     @Test
-    void deleteOfficer() {
-        when(companyAppointmentRepository.readByCompanyNumberAndID(COMPANY_NUMBER,
-                APPOINTMENT_ID))
-                .thenReturn(Optional.of(new CompanyAppointmentDocument()));
-
-        companyAppointmentService.deleteAppointmentDelta(COMPANY_NUMBER, APPOINTMENT_ID);
-
-        verify(companyAppointmentRepository).deleteByCompanyNumberAndID(COMPANY_NUMBER,
-                APPOINTMENT_ID);
-    }
-
-    @Test
     void testServiceThrows500WhenTransformFails() {
         when(deltaAppointmentTransformer.transform(any(FullRecordCompanyOfficerApi.class)))
                 .thenThrow(new FailedToTransformException("message"));
 
         Assert.assertThrows(ServiceUnavailableException.class, () ->
                 companyAppointmentService.upsertAppointmentDelta(new FullRecordCompanyOfficerApi()));
-    }
-
-    @Test
-    void deleteOfficerThrowsNotFound() {
-        when(companyAppointmentRepository.readByCompanyNumberAndID(COMPANY_NUMBER,
-                APPOINTMENT_ID))
-                .thenReturn(Optional.empty());
-
-        Executable executable = () -> companyAppointmentService.deleteAppointmentDelta(COMPANY_NUMBER,
-                APPOINTMENT_ID);
-
-        assertThrows(NotFoundException.class, executable);
-    }
-
-    @Test
-    void testDeleteAppointmentDataThrowsServiceUnavailableException() {
-        // given
-        when(companyAppointmentRepository.readByCompanyNumberAndID(any(),
-                any())).thenThrow(new DataAccessException("...") {
-        });
-
-        // When
-        Executable executable = () -> companyAppointmentService.deleteAppointmentDelta(COMPANY_NUMBER,
-                APPOINTMENT_ID);
-
-        // then
-        assertThrows(ServiceUnavailableException.class, executable);
-    }
-
-    @Test
-    void testDeleteAppointmentDataThrowsServiceUnavailableExceptionWhenIllegalArgumentExceptionCaught()
-            throws ServiceUnavailableException {
-        // given
-        when(companyAppointmentRepository.readByCompanyNumberAndID(COMPANY_NUMBER, APPOINTMENT_ID))
-                .thenReturn(Optional.of(new CompanyAppointmentDocument()));
-        when(resourceChangedApiService.invokeChsKafkaApi(any())).thenThrow(IllegalArgumentException.class);
-
-        // When
-        Executable executable = () -> companyAppointmentService.deleteAppointmentDelta(COMPANY_NUMBER,
-                APPOINTMENT_ID);
-
-        // then
-        assertThrows(ServiceUnavailableException.class, executable);
     }
 
     private FullRecordCompanyOfficerApi buildFullRecordOfficer() {

--- a/src/test/java/uk/gov/companieshouse/company_appointments/service/DeleteAppointmentWithRetryServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/company_appointments/service/DeleteAppointmentWithRetryServiceTest.java
@@ -1,0 +1,147 @@
+package uk.gov.companieshouse.company_appointments.service;
+
+import static java.time.ZoneOffset.UTC;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.function.Executable;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DataAccessException;
+import uk.gov.companieshouse.company_appointments.api.ResourceChangedApiService;
+import uk.gov.companieshouse.company_appointments.exception.BadRequestException;
+import uk.gov.companieshouse.company_appointments.exception.ServiceUnavailableException;
+import uk.gov.companieshouse.company_appointments.mapper.CompanyAppointmentMapper;
+import uk.gov.companieshouse.company_appointments.model.data.CompanyAppointmentDocument;
+import uk.gov.companieshouse.company_appointments.model.data.ResourceChangedRequest;
+import uk.gov.companieshouse.company_appointments.repository.CompanyAppointmentRepository;
+
+@ExtendWith(MockitoExtension.class)
+class DeleteAppointmentWithRetryServiceTest {
+
+    private static final DateTimeFormatter DELTA_AT_FORMATTER = DateTimeFormatter.ofPattern("yyyyMMddHHmmssSSSSSS")
+            .withZone(UTC);
+    private static final String COMPANY_NUMBER = "123456";
+    private static final String APPOINTMENT_ID = "345678";
+    private static final String DELTA_AT = "20140925171003950844";
+    private static final Instant OLDER_DELTA_AT = LocalDateTime.parse("20140924171003950844", DELTA_AT_FORMATTER).toInstant(UTC);
+    private static final Instant NEWER_DELTA_AT = LocalDateTime.parse("20140926171003950844", DELTA_AT_FORMATTER).toInstant(UTC);
+
+    private DeleteAppointmentService deleteAppointmentService;
+
+    @Mock
+    private CompanyAppointmentRepository companyAppointmentRepository;
+    @Mock
+    private ResourceChangedApiService resourceChangedApiService;
+    @Mock
+    private CompanyAppointmentMapper companyAppointmentMapper;
+    @Captor
+    private ArgumentCaptor<ResourceChangedRequest> resourceChangedRequestArgumentCaptor;
+
+    @BeforeEach
+    void setUp() {
+        deleteAppointmentService =
+                new DeleteAppointmentService(
+                        companyAppointmentRepository,
+                        resourceChangedApiService,
+                        companyAppointmentMapper);
+    }
+
+    @Test
+    void deleteOfficer() {
+        when(companyAppointmentRepository.readByCompanyNumberAndID(COMPANY_NUMBER, APPOINTMENT_ID))
+                .thenReturn(Optional.of(new CompanyAppointmentDocument()
+                        .deltaAt(OLDER_DELTA_AT)));
+
+        deleteAppointmentService.deleteAppointment(COMPANY_NUMBER, APPOINTMENT_ID, DELTA_AT);
+
+        verify(companyAppointmentRepository).deleteByCompanyNumberAndID(COMPANY_NUMBER,
+                APPOINTMENT_ID);
+        verify(resourceChangedApiService).invokeChsKafkaApi(resourceChangedRequestArgumentCaptor.capture());
+        assertNotNull(resourceChangedRequestArgumentCaptor.getValue());
+    }
+
+    @Test
+    void shouldIgnoreStaleDeleteDelta() {
+        when(companyAppointmentRepository.readByCompanyNumberAndID(COMPANY_NUMBER, APPOINTMENT_ID))
+                .thenReturn(Optional.of(new CompanyAppointmentDocument()
+                        .deltaAt(NEWER_DELTA_AT)));
+
+        deleteAppointmentService.deleteAppointment(COMPANY_NUMBER, APPOINTMENT_ID, DELTA_AT);
+
+        verify(companyAppointmentRepository, never()).deleteByCompanyNumberAndID(any(), any());
+        verify(resourceChangedApiService, never()).invokeChsKafkaApi(any());
+    }
+
+    @Test
+    void shouldNotifyRetriedDelta() {
+        when(companyAppointmentRepository.readByCompanyNumberAndID(COMPANY_NUMBER, APPOINTMENT_ID))
+                .thenReturn(Optional.empty());
+
+        deleteAppointmentService.deleteAppointment(COMPANY_NUMBER, APPOINTMENT_ID, DELTA_AT);
+
+        verify(companyAppointmentRepository, never()).deleteByCompanyNumberAndID(COMPANY_NUMBER, APPOINTMENT_ID);
+        verify(resourceChangedApiService).invokeChsKafkaApi(resourceChangedRequestArgumentCaptor.capture());
+        assertNotNull(resourceChangedRequestArgumentCaptor.getValue());
+    }
+
+    @Test
+    void shouldThrowBadRequestExceptionOnMissingDeltaAt() {
+        // given
+
+        // When
+        Executable executable = () -> deleteAppointmentService.deleteAppointment(COMPANY_NUMBER,
+                APPOINTMENT_ID, null);
+
+        // then
+        assertThrows(BadRequestException.class, executable);
+        verify(companyAppointmentRepository, never()).deleteByCompanyNumberAndID(any(), any());
+        verify(resourceChangedApiService, never()).invokeChsKafkaApi(any());
+    }
+
+    @Test
+    void shouldThrowServiceUnavailableExceptionOnMongoReadFailure() {
+        // given
+        when(companyAppointmentRepository.readByCompanyNumberAndID(any(), any()))
+                .thenThrow(new DataAccessException("...") {
+                });
+
+        // When
+        Executable executable = () -> deleteAppointmentService.deleteAppointment(COMPANY_NUMBER,
+                APPOINTMENT_ID, DELTA_AT);
+
+        // then
+        assertThrows(ServiceUnavailableException.class, executable);
+        verify(resourceChangedApiService, never()).invokeChsKafkaApi(any());
+    }
+
+    @Test
+    void shouldThrowServiceUnavailableExceptionOnKafkaNotificationFailure()
+            throws ServiceUnavailableException {
+        // given
+        when(companyAppointmentRepository.readByCompanyNumberAndID(COMPANY_NUMBER, APPOINTMENT_ID))
+                .thenReturn(Optional.of(new CompanyAppointmentDocument()
+                        .deltaAt(OLDER_DELTA_AT)));
+        when(resourceChangedApiService.invokeChsKafkaApi(any())).thenThrow(IllegalArgumentException.class);
+
+        // When
+        Executable executable = () -> deleteAppointmentService.deleteAppointment(COMPANY_NUMBER,
+                APPOINTMENT_ID, DELTA_AT);
+
+        // then
+        assertThrows(ServiceUnavailableException.class, executable);
+    }
+}


### PR DESCRIPTION
After updates to the private-api-sdk-java delete resource API, delete offices now include a `delta_at` check to stop stale deltas deleting new documents

[DSND-3111](https://companieshouse.atlassian.net/browse/DSND-3111)

[DSND-3111]: https://companieshouse.atlassian.net/browse/DSND-3111?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ