### PR TITLE
DSND-3268: Add sorting thresholds to officer appointments

### DIFF
--- a/src/it/java/uk/gov/companieshouse/company_appointments/officerappointments/OfficerAppointmentsControllerITest.java
+++ b/src/it/java/uk/gov/companieshouse/company_appointments/officerappointments/OfficerAppointmentsControllerITest.java
@@ -303,10 +303,10 @@ class OfficerAppointmentsControllerITest {
         assertTrue(mongoTemplate.find(query, CompanyAppointmentDocument.class).isEmpty());
     }
 
-    @DisplayName("Should return HTTP 200 OK and a list of 500K appointments for an officer with 400K appointments")
+    @DisplayName("Should return HTTP 200 OK and a list of 500 appointments for an officer with 400K appointments")
     @Test
     @Disabled("Causes a Java Heap memory exception on Concourse")
-    void getOfficerAppointmentsInternalWhenOfficerHas150KAppointments() throws Exception {
+    void getOfficerAppointmentsInternalUnsortedWhenOfficerHas400KAppointments() throws Exception {
         // given
         final String officerId = UUID.randomUUID().toString();
         final int expectedItemsPerPage = 500;

--- a/src/main/java/uk/gov/companieshouse/company_appointments/interceptor/AuthenticationHelperImpl.java
+++ b/src/main/java/uk/gov/companieshouse/company_appointments/interceptor/AuthenticationHelperImpl.java
@@ -1,11 +1,11 @@
 package uk.gov.companieshouse.company_appointments.interceptor;
 
+import jakarta.servlet.http.HttpServletRequest;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import jakarta.servlet.http.HttpServletRequest;
 import org.apache.commons.lang.ArrayUtils;
 import org.springframework.stereotype.Component;
 
@@ -14,18 +14,17 @@ import org.springframework.stereotype.Component;
  */
 @Component
 public class AuthenticationHelperImpl implements AuthenticationHelper {
+
     public static final String OAUTH2_IDENTITY_TYPE = "oauth2";
     public static final String API_KEY_IDENTITY_TYPE = "key";
+    public static final String ERIC_AUTHORISED_KEY_PRIVILEGES_HEADER = "ERIC-Authorised-Key-Privileges";
 
-    public static final int USER_EMAIL_INDEX = 0;
-    public static final int USER_FORENAME_INDEX = 1;
-    public static final int USER_SURNAME_INDEX = 2;
-    public static final String INTERNAL_APP_PRIVILEGE = "internal-app";
+    private static final int USER_EMAIL_INDEX = 0;
+    private static final int USER_FORENAME_INDEX = 1;
+    private static final int USER_SURNAME_INDEX = 2;
+    private static final String INTERNAL_APP_PRIVILEGE = "internal-app";
     private static final String SENSITIVE_DATA_PRIVILEGE = "sensitive-data";
-    public static final String ERIC_AUTHORISED_KEY_PRIVILEGES_HEADER
-            = "ERIC-Authorised-Key-Privileges";
-    private static final String ERIC_AUTHORISED_TOKEN_PERMISSIONS_HEADER
-            = "ERIC-Authorised-Token-Permissions";
+    private static final String ERIC_AUTHORISED_TOKEN_PERMISSIONS_HEADER = "ERIC-Authorised-Token-Permissions";
     private static final String ERIC_IDENTITY = "ERIC-Identity";
     private static final String ERIC_IDENTITY_TYPE = "ERIC-Identity-Type";
     private static final String ERIC_AUTHORISED_USER = "ERIC-Authorised-User";
@@ -34,7 +33,6 @@ public class AuthenticationHelperImpl implements AuthenticationHelper {
     private static final String COMPANY_OFFICER_PERMISSION = "company_officers";
     private static final String READ_PROTECTED = "readprotected";
     private static final String COMPANY_NUMBER_PERMISSION = "company_number";
-
     private static final String GET_METHOD = "GET";
 
     @Override
@@ -162,6 +160,13 @@ public class AuthenticationHelperImpl implements AuthenticationHelper {
                 privileges.get(COMPANY_OFFICER_PERMISSION).contains(READ_PROTECTED) &&
                 privileges.containsKey(COMPANY_NUMBER_PERMISSION) &&
                 privileges.get(COMPANY_NUMBER_PERMISSION).contains(companyNumber);
+    }
+
+    public static boolean hasInternalAppPrivileges(String authPrivileges) {
+        return Optional.ofNullable(authPrivileges)
+                .map(rawAuthPrivileges -> rawAuthPrivileges.split(","))
+                .map(privileges -> ArrayUtils.contains(privileges, INTERNAL_APP_PRIVILEGE))
+                .orElse(false);
     }
 
     private String getRequestHeader(HttpServletRequest request, String header) {

--- a/src/main/java/uk/gov/companieshouse/company_appointments/officerappointments/ItemsPerPageService.java
+++ b/src/main/java/uk/gov/companieshouse/company_appointments/officerappointments/ItemsPerPageService.java
@@ -1,11 +1,10 @@
 package uk.gov.companieshouse.company_appointments.officerappointments;
 
-import static uk.gov.companieshouse.company_appointments.interceptor.AuthenticationHelperImpl.INTERNAL_APP_PRIVILEGE;
+import static uk.gov.companieshouse.company_appointments.interceptor.AuthenticationHelperImpl.hasInternalAppPrivileges;
 
-import java.util.Optional;
-import org.apache.commons.lang.ArrayUtils;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
+import uk.gov.companieshouse.company_appointments.logging.DataMapHolder;
 
 @Component
 public class ItemsPerPageService {
@@ -15,11 +14,11 @@ public class ItemsPerPageService {
 
     private final int maxItemsPerPageInternal;
 
-    public ItemsPerPageService(@Value("${items-per-page-max-internal}") final int maxItemsPerPageInternal) {
+    public ItemsPerPageService(@Value("${officer-appointments.items-per-page-max-internal}") final int maxItemsPerPageInternal) {
         this.maxItemsPerPageInternal = maxItemsPerPageInternal;
     }
 
-    public int getItemsPerPage(Integer itemsPerPage, String authPrivileges) {
+    public int adjustItemsPerPage(Integer itemsPerPage, String authPrivileges) {
         if (itemsPerPage == null || itemsPerPage == 0) {
             itemsPerPage = DEFAULT_ITEMS_PER_PAGE;
         } else {
@@ -27,13 +26,7 @@ public class ItemsPerPageService {
                     maxItemsPerPageInternal : MAX_ITEMS_PER_PAGE_EXTERNAL;
             itemsPerPage = Math.min(Math.abs(itemsPerPage), maxItemsPerPage);
         }
+        DataMapHolder.get().itemsPerPage(String.valueOf(itemsPerPage));
         return itemsPerPage;
-    }
-
-    private boolean hasInternalAppPrivileges(String authPrivileges) {
-        return Optional.ofNullable(authPrivileges)
-                .map(rawAuthPrivileges -> rawAuthPrivileges.split(","))
-                .map(privileges -> ArrayUtils.contains(privileges, INTERNAL_APP_PRIVILEGE))
-                .orElse(false);
     }
 }

--- a/src/main/java/uk/gov/companieshouse/company_appointments/officerappointments/OfficerAppointmentsRepository.java
+++ b/src/main/java/uk/gov/companieshouse/company_appointments/officerappointments/OfficerAppointmentsRepository.java
@@ -69,6 +69,26 @@ interface OfficerAppointmentsRepository extends MongoRepository<CompanyAppointme
             List<String> filterStatuses, int startIndex, int pageSize);
 
     @Aggregation(pipeline = {
+            "{ $match: { "
+                    + "$and: [ "
+                    + "{'officer_id': ?0 },"
+                    + "{ $or: [ "
+                    + "{ 'data.resigned_on': { $exists: false } },"
+                    + "{ 'data.resigned_on': { $not: { $exists: ?1 } } }"
+                    + "]"
+                    + "},"
+                    + "{ 'company_status': { $nin: ?2 } }"
+                    + "]"
+                    + "}"
+                    + "}",
+            "{ $skip: ?3 }",
+            "{ $limit: ?4 }"
+    })
+    @Meta(allowDiskUse = true)
+    List<CompanyAppointmentDocument> findOfficerAppointmentsUnsorted(String officerId, boolean filterEnabled,
+            List<String> filterStatuses, int startIndex, int pageSize);
+
+    @Aggregation(pipeline = {
             "{ $match: { _id: { $in: ?0 } } }",
 
             "{ $addFields: {"

--- a/src/main/java/uk/gov/companieshouse/company_appointments/officerappointments/OfficerAppointmentsRequest.java
+++ b/src/main/java/uk/gov/companieshouse/company_appointments/officerappointments/OfficerAppointmentsRequest.java
@@ -1,5 +1,54 @@
 package uk.gov.companieshouse.company_appointments.officerappointments;
 
-record OfficerAppointmentsRequest(String officerId, String filter, Integer startIndex, int itemsPerPage) {
+record OfficerAppointmentsRequest(String officerId, String filter, Integer startIndex, Integer itemsPerPage,
+                                  String authPrivileges) {
 
+    OfficerAppointmentsRequest(String officerId, String filter, Integer startIndex, Integer itemsPerPage) {
+        this(officerId, filter, startIndex, itemsPerPage, null);
+    }
+
+    static Builder builder() {
+        return new Builder();
+    }
+
+    static final class Builder {
+
+        private String officerId;
+        private String filter;
+        private Integer startIndex;
+        private Integer itemsPerPage;
+        private String authPrivileges;
+
+        private Builder() {
+        }
+
+        Builder officerId(String officerId) {
+            this.officerId = officerId;
+            return this;
+        }
+
+        Builder filter(String filter) {
+            this.filter = filter;
+            return this;
+        }
+
+        Builder startIndex(Integer startIndex) {
+            this.startIndex = startIndex;
+            return this;
+        }
+
+        Builder itemsPerPage(Integer itemsPerPage) {
+            this.itemsPerPage = itemsPerPage;
+            return this;
+        }
+
+        Builder authPrivileges(String authPrivileges) {
+            this.authPrivileges = authPrivileges;
+            return this;
+        }
+
+        OfficerAppointmentsRequest build() {
+            return new OfficerAppointmentsRequest(officerId, filter, startIndex, itemsPerPage, authPrivileges);
+        }
+    }
 }

--- a/src/main/java/uk/gov/companieshouse/company_appointments/officerappointments/SortingThresholdService.java
+++ b/src/main/java/uk/gov/companieshouse/company_appointments/officerappointments/SortingThresholdService.java
@@ -1,0 +1,24 @@
+package uk.gov.companieshouse.company_appointments.officerappointments;
+
+import static uk.gov.companieshouse.company_appointments.interceptor.AuthenticationHelperImpl.hasInternalAppPrivileges;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Component
+class SortingThresholdService {
+
+    private final int internalSortingThreshold;
+    private final int externalSortingThreshold;
+
+    SortingThresholdService(@Value("${officer-appointments.sorting-threshold-internal}") final int internalSortingThreshold,
+            @Value("${officer-appointments.sorting-threshold-external}") final int externalSortingThreshold) {
+        this.internalSortingThreshold = internalSortingThreshold;
+        this.externalSortingThreshold = externalSortingThreshold;
+    }
+
+    boolean shouldSort(int totalResults, String authPrivileges) {
+        int sortingThreshold = hasInternalAppPrivileges(authPrivileges) ? internalSortingThreshold : externalSortingThreshold;
+        return sortingThreshold == -1 || totalResults <= sortingThreshold;
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -8,7 +8,9 @@ company-metrics-api.endpoint=${COMPANY_METRICS_API_URL:localhost}
 
 feature.seeding_collection_enabled=${SEEDING_COLLECTION_ENABLED:false}
 
-items-per-page-max-internal=${OFFICER_APPOINTMENTS_THRESHOLD:500}
+officer-appointments.items-per-page-max-internal=${OFFICER_APPOINTMENTS_THRESHOLD:500}
+officer-appointments.sorting-threshold-internal=${OFFICER_APPOINTMENTS_SORTING_THRESHOLD_INTERNAL:-1}
+officer-appointments.sorting-threshold-external=${OFFICER_APPOINTMENTS_SORTING_THRESHOLD_EXTERNAL:-1}
 
 logging.level.org.springframework.web=${WEB_LOGGING_LEVEL:INFO}
 logging.level.uk.gov.companieshouse.company_appointments=${LOGLEVEL:INFO}

--- a/src/test/java/uk/gov/companieshouse/company_appointments/officerappointments/ItemsPerPageServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/company_appointments/officerappointments/ItemsPerPageServiceTest.java
@@ -20,11 +20,11 @@ class ItemsPerPageServiceTest {
 
     @ParameterizedTest
     @MethodSource("itemsPerPageScenarios")
-    void testGetItemsPerPage(ItemsPerPageTestArgument argument) {
+    void testAdjustItemsPerPage(ItemsPerPageTestArgument argument) {
         // given
 
         // when
-        int actual = service.getItemsPerPage(argument.getItemsPerPage(), argument.getAuthPrivileges());
+        int actual = service.adjustItemsPerPage(argument.getItemsPerPage(), argument.getAuthPrivileges());
 
         // then
         assertEquals(argument.getExpectedItemsPerPage(), actual);

--- a/src/test/java/uk/gov/companieshouse/company_appointments/officerappointments/OfficerAppointmentsControllerTest.java
+++ b/src/test/java/uk/gov/companieshouse/company_appointments/officerappointments/OfficerAppointmentsControllerTest.java
@@ -3,7 +3,6 @@ package uk.gov.companieshouse.company_appointments.officerappointments;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -31,16 +30,12 @@ class OfficerAppointmentsControllerTest {
     private OfficerAppointmentsService service;
 
     @Mock
-    private ItemsPerPageService itemsPerPageService;
-
-    @Mock
     private AppointmentList officerAppointments;
 
     @Test
     @DisplayName("Call to get officer appointments returns http 200 ok and officer appointments api")
     void testGetOfficerAppointments() throws BadRequestException {
         // given
-        when(itemsPerPageService.getItemsPerPage(any(), anyString())).thenReturn(5);
         when(service.getOfficerAppointments(any())).thenReturn(Optional.of(officerAppointments));
 
         // when
@@ -49,14 +44,13 @@ class OfficerAppointmentsControllerTest {
         // then
         assertEquals(HttpStatus.OK, response.getStatusCode());
         assertEquals(officerAppointments, response.getBody());
-        verify(service).getOfficerAppointments(new OfficerAppointmentsRequest(OFFICER_ID, null, 0, 5));
+        verify(service).getOfficerAppointments(new OfficerAppointmentsRequest(OFFICER_ID, null, 0, 5, ""));
     }
 
     @Test
     @DisplayName("Call to get officer appointments returns http 404 not found when officer id does not exist")
     void testGetOfficerAppointmentsNotFound() throws BadRequestException {
         // given
-        when(itemsPerPageService.getItemsPerPage(any(), anyString())).thenReturn(35);
         when(service.getOfficerAppointments(any())).thenReturn(Optional.empty());
 
         // when
@@ -65,14 +59,13 @@ class OfficerAppointmentsControllerTest {
         // then
         assertEquals(HttpStatus.NOT_FOUND, response.getStatusCode());
         assertNull(response.getBody());
-        verify(service).getOfficerAppointments(new OfficerAppointmentsRequest(OFFICER_ID, null, null, 35));
+        verify(service).getOfficerAppointments(new OfficerAppointmentsRequest(OFFICER_ID, null, null, null, ""));
     }
 
     @Test
     @DisplayName("Call to get officer appointments returns http 400 bad request when filter parameter is invalid")
     void testGetOfficerAppointmentsBadRequest() throws BadRequestException {
         // given
-        when(itemsPerPageService.getItemsPerPage(any(), anyString())).thenReturn(35);
         when(service.getOfficerAppointments(any())).thenThrow(BadRequestException.class);
 
         // when
@@ -81,6 +74,6 @@ class OfficerAppointmentsControllerTest {
         // then
         assertEquals(HttpStatus.BAD_REQUEST, response.getStatusCode());
         assertNull(response.getBody());
-        verify(service).getOfficerAppointments(new OfficerAppointmentsRequest(OFFICER_ID, "invalid", null, 35));
+        verify(service).getOfficerAppointments(new OfficerAppointmentsRequest(OFFICER_ID, "invalid", null, null, ""));
     }
 }

--- a/src/test/java/uk/gov/companieshouse/company_appointments/officerappointments/OfficerAppointmentsRepositoryITest.java
+++ b/src/test/java/uk/gov/companieshouse/company_appointments/officerappointments/OfficerAppointmentsRepositoryITest.java
@@ -85,6 +85,7 @@ class OfficerAppointmentsRepositoryITest {
                 START_INDEX, DEFAULT_ITEMS_PER_PAGE);
 
         // then
+        assertEquals(6, appointmentsIds.getIds().size());
         assertEquals("active_1", appointmentsIds.getIds().get(0));
         assertEquals("dissolved_1", appointmentsIds.getIds().get(1));
         assertEquals("active_2", appointmentsIds.getIds().get(2));
@@ -116,8 +117,10 @@ class OfficerAppointmentsRepositoryITest {
                 FILTER_STATUSES, START_INDEX, DEFAULT_ITEMS_PER_PAGE);
 
         // then
+        assertEquals(3, appointmentsIds.getIds().size());
         assertEquals("active_1", appointmentsIds.getIds().get(0));
         assertEquals("active_2", appointmentsIds.getIds().get(1));
+        assertEquals("active_3", appointmentsIds.getIds().get(2));
     }
 
     @DisplayName("Repository returns no appointments IDs when there are no matches when the filter is enabled")
@@ -143,6 +146,7 @@ class OfficerAppointmentsRepositoryITest {
                 4);
 
         // then
+        assertEquals(4, appointmentsIds.getIds().size());
         assertEquals("dissolved_1", appointmentsIds.getIds().get(0));
         assertEquals("active_2", appointmentsIds.getIds().get(1));
         assertEquals("active_3", appointmentsIds.getIds().get(2));
@@ -159,6 +163,7 @@ class OfficerAppointmentsRepositoryITest {
                 FILTER_STATUSES, 1, 3);
 
         // then
+        assertEquals(2, appointmentsIds.getIds().size());
         assertEquals("active_2", appointmentsIds.getIds().get(0));
         assertEquals("active_3", appointmentsIds.getIds().get(1));
     }
@@ -188,6 +193,7 @@ class OfficerAppointmentsRepositoryITest {
         List<CompanyAppointmentDocument> documents = repository.findFullOfficerAppointments(appointmentsIds);
 
         // then
+        assertEquals(6, documents.size());
         assertEquals(appointmentsIds, documents.stream().map(CompanyAppointmentDocument::getId).toList());
     }
 
@@ -309,5 +315,114 @@ class OfficerAppointmentsRepositoryITest {
 
         // then
         assertNull(actual);
+    }
+
+    @DisplayName("Repository returns unsorted officer appointments")
+    @Test
+    void findOfficerAppointmentsUnsorted() {
+        // given
+
+        // when
+        List<CompanyAppointmentDocument> appointments = repository.findOfficerAppointmentsUnsorted(OFFICER_ID, false, emptyList(),
+                START_INDEX, DEFAULT_ITEMS_PER_PAGE);
+
+        // then
+        assertEquals(6, appointments.size());
+        assertEquals("dissolved_1", appointments.get(0).getId());
+        assertEquals("active_3", appointments.get(1).getId());
+        assertEquals("resigned_2", appointments.get(2).getId());
+        assertEquals("active_2", appointments.get(3).getId());
+        assertEquals("resigned_1", appointments.get(4).getId());
+        assertEquals("active_1", appointments.get(5).getId());
+    }
+
+    @DisplayName("Repository returns no unsorted appointments when there are no matches")
+    @Test
+    void findOfficerAppointmentsUnsortedNoResults() {
+        // given
+
+        // when
+        List<CompanyAppointmentDocument> appointments = repository.findOfficerAppointmentsUnsorted("officerId", false,
+                emptyList(),
+                START_INDEX, DEFAULT_ITEMS_PER_PAGE);
+
+        // then
+        assertTrue(appointments.isEmpty());
+    }
+
+    @DisplayName("Repository returns only active unsorted appointments when the filter is enabled")
+    @Test
+    void findActiveOfficerAppointmentsUnsorted() {
+        // given
+
+        // when
+        List<CompanyAppointmentDocument> appointments = repository.findOfficerAppointmentsUnsorted(OFFICER_ID, true,
+                FILTER_STATUSES, START_INDEX, DEFAULT_ITEMS_PER_PAGE);
+
+        // then
+        assertEquals(3, appointments.size());
+        assertEquals("active_3", appointments.get(0).getId());
+        assertEquals("active_2", appointments.get(1).getId());
+        assertEquals("active_1", appointments.get(2).getId());
+    }
+
+    @DisplayName("Repository returns no unsorted appointments when there are no matches when the filter is enabled")
+    @Test
+    void findActiveOfficerAppointmentsUnsortedNoResults() {
+        // given
+
+        // when
+        List<CompanyAppointmentDocument> appointments = repository.findOfficerAppointmentsUnsorted("officerId", true, emptyList(),
+                START_INDEX, DEFAULT_ITEMS_PER_PAGE);
+
+        // then
+        assertTrue(appointments.isEmpty());
+    }
+
+    @DisplayName("Repository returns a paged list of unsorted officer appointments")
+    @Test
+    void findOfficerAppointmentsUnsortedWithPaging() {
+        // given
+
+        // when
+        List<CompanyAppointmentDocument> appointments = repository.findOfficerAppointmentsUnsorted(OFFICER_ID, false, emptyList(),
+                1,
+                4);
+
+        // then
+        assertEquals(4, appointments.size());
+        assertEquals("active_3", appointments.get(0).getId());
+        assertEquals("resigned_2", appointments.get(1).getId());
+        assertEquals("active_2", appointments.get(2).getId());
+        assertEquals("resigned_1", appointments.get(3).getId());
+    }
+
+    @DisplayName("Repository returns a paged list of unsorted officer appointments with the filter applied")
+    @Test
+    void findActiveOfficerAppointmentsUnsortedWithPaging() {
+        // given
+
+        // when
+        List<CompanyAppointmentDocument> appointments = repository.findOfficerAppointmentsUnsorted(OFFICER_ID, true,
+                FILTER_STATUSES, 1, 3);
+
+        // then
+        assertEquals(2, appointments.size());
+        assertEquals("active_2", appointments.get(0).getId());
+        assertEquals("active_1", appointments.get(1).getId());
+    }
+
+    @DisplayName("Repository returns no unsorted officer appointments when start index is greater than total matches")
+    @Test
+    void findOfficerAppointmentsUnsortedHighStartIndex() {
+        // given
+
+        // when
+        List<CompanyAppointmentDocument> appointments = repository.findOfficerAppointmentsUnsorted(OFFICER_ID, false, emptyList(),
+                10,
+                DEFAULT_ITEMS_PER_PAGE);
+
+        // then
+        assertTrue(appointments.isEmpty());
     }
 }

--- a/src/test/java/uk/gov/companieshouse/company_appointments/officerappointments/OfficerAppointmentsServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/company_appointments/officerappointments/OfficerAppointmentsServiceTest.java
@@ -50,6 +50,10 @@ class OfficerAppointmentsServiceTest {
     @Mock
     private FilterService filterService;
     @Mock
+    private ItemsPerPageService itemsPerPageService;
+    @Mock
+    private SortingThresholdService sortingThresholdService;
+    @Mock
     private AppointmentList appointmentList;
     @Mock
     private CompanyAppointmentDocument companyAppointmentDocument;
@@ -135,12 +139,14 @@ class OfficerAppointmentsServiceTest {
         // given
         Filter filter = new Filter(argument.filterEnabled(), argument.filterStatuses());
 
+        when(itemsPerPageService.adjustItemsPerPage(any(), any())).thenReturn(argument.itemsPerPage());
         when(filterService.prepareFilter(any(), any())).thenReturn(filter);
+        when(repository.countTotal(any(), anyBoolean(), any())).thenReturn(3);
+        when(sortingThresholdService.shouldSort(anyInt(), any())).thenReturn(true);
         when(repository.findOfficerAppointmentsIds(anyString(), anyBoolean(), any(), anyInt(), anyInt()))
                 .thenReturn(officerAppointments);
         when(officerAppointments.getIds()).thenReturn(List.of(APPOINTMENT_ID));
         when(repository.findFullOfficerAppointments(any())).thenReturn(List.of(companyAppointmentDocument));
-        when(repository.countTotal(any(), anyBoolean(), any())).thenReturn(3);
         when(repository.countResigned(any())).thenReturn(1);
         when(repository.countInactive(any())).thenReturn(1);
         when(filterService.findFirstActiveAppointment(any())).thenReturn(Optional.of(companyAppointmentDocument));
@@ -152,12 +158,14 @@ class OfficerAppointmentsServiceTest {
         // then
         assertTrue(actual.isPresent());
         assertEquals(appointmentList, actual.get());
+        verify(itemsPerPageService).adjustItemsPerPage(argument.itemsPerPage(), null);
         verify(filterService).prepareFilter(argument.request().filter(), OFFICER_ID);
+        verify(repository).countTotal(OFFICER_ID, argument.filterEnabled(), argument.filterStatuses());
+        verify(sortingThresholdService).shouldSort(3, null);
         verify(repository).findOfficerAppointmentsIds(OFFICER_ID, argument.filterEnabled(), argument.filterStatuses(),
                 argument.startIndex(), argument.itemsPerPage());
         verify(repository).findFullOfficerAppointments(List.of(APPOINTMENT_ID));
-        verify(repository).countTotal(OFFICER_ID, argument.filterEnabled(), argument.filterStatuses());
-        verify(repository).countInactive(OFFICER_ID);
+        verify(repository).countResigned(OFFICER_ID);
         verify(repository).countInactive(OFFICER_ID);
         verify(filterService).findFirstActiveAppointment(List.of(companyAppointmentDocument));
         verify(mapper).mapOfficerAppointments(MapperRequest.builder()
@@ -177,12 +185,14 @@ class OfficerAppointmentsServiceTest {
         // given
         Filter filter = new Filter(argument.filterEnabled(), argument.filterStatuses());
 
+        when(itemsPerPageService.adjustItemsPerPage(any(), any())).thenReturn(argument.itemsPerPage());
         when(filterService.prepareFilter(any(), any())).thenReturn(filter);
+        when(repository.countTotal(any(), anyBoolean(), any())).thenReturn(3);
+        when(sortingThresholdService.shouldSort(anyInt(), any())).thenReturn(true);
         when(repository.findOfficerAppointmentsIds(anyString(), anyBoolean(), any(), anyInt(), anyInt()))
                 .thenReturn(officerAppointments);
         when(officerAppointments.getIds()).thenReturn(List.of(APPOINTMENT_ID));
         when(repository.findFullOfficerAppointments(any())).thenReturn(List.of(companyAppointmentDocument));
-        when(repository.countTotal(any(), anyBoolean(), any())).thenReturn(3);
         when(filterService.findFirstActiveAppointment(any())).thenReturn(Optional.of(companyAppointmentDocument));
         when(mapper.mapOfficerAppointments(any())).thenReturn(Optional.of(appointmentList));
 
@@ -192,11 +202,13 @@ class OfficerAppointmentsServiceTest {
         // then
         assertTrue(actual.isPresent());
         assertEquals(appointmentList, actual.get());
+        verify(itemsPerPageService).adjustItemsPerPage(argument.itemsPerPage(), null);
         verify(filterService).prepareFilter(argument.request().filter(), OFFICER_ID);
+        verify(repository).countTotal(OFFICER_ID, argument.filterEnabled(), argument.filterStatuses());
+        verify(sortingThresholdService).shouldSort(3, null);
         verify(repository).findOfficerAppointmentsIds(OFFICER_ID, argument.filterEnabled(), argument.filterStatuses(),
                 argument.startIndex(), argument.itemsPerPage());
         verify(repository).findFullOfficerAppointments(List.of(APPOINTMENT_ID));
-        verify(repository).countTotal(OFFICER_ID, argument.filterEnabled(), argument.filterStatuses());
         verifyNoMoreInteractions(repository);
         verify(filterService).findFirstActiveAppointment(List.of(companyAppointmentDocument));
         verify(mapper).mapOfficerAppointments(MapperRequest.builder()
@@ -214,16 +226,19 @@ class OfficerAppointmentsServiceTest {
     @Test
     void getOfficerAppointmentsNonActiveFirstAppointment() throws BadRequestException {
         // given
-        Filter filter = new Filter(false, List.of());
+        OfficerAppointmentsRequest request = OfficerAppointmentsRequest.builder()
+                .officerId(OFFICER_ID)
+                .itemsPerPage(ITEMS_PER_PAGE)
+                .build();
 
-        OfficerAppointmentsRequest request = new OfficerAppointmentsRequest(OFFICER_ID, null, null, ITEMS_PER_PAGE);
-
-        when(filterService.prepareFilter(any(), any())).thenReturn(filter);
+        when(itemsPerPageService.adjustItemsPerPage(any(), any())).thenReturn(ITEMS_PER_PAGE);
+        when(filterService.prepareFilter(any(), any())).thenReturn(new Filter(false, List.of()));
+        when(repository.countTotal(any(), anyBoolean(), any())).thenReturn(3);
+        when(sortingThresholdService.shouldSort(anyInt(), any())).thenReturn(true);
         when(repository.findOfficerAppointmentsIds(anyString(), anyBoolean(), any(), anyInt(), anyInt()))
                 .thenReturn(officerAppointments);
         when(officerAppointments.getIds()).thenReturn(List.of(APPOINTMENT_ID));
         when(repository.findFullOfficerAppointments(any())).thenReturn(List.of(companyAppointmentDocument));
-        when(repository.countTotal(any(), anyBoolean(), any())).thenReturn(3);
         when(repository.countResigned(any())).thenReturn(1);
         when(repository.countInactive(any())).thenReturn(1);
         when(filterService.findFirstActiveAppointment(any())).thenReturn(Optional.empty());
@@ -236,12 +251,14 @@ class OfficerAppointmentsServiceTest {
         // then
         assertTrue(actual.isPresent());
         assertEquals(appointmentList, actual.get());
+        verify(itemsPerPageService).adjustItemsPerPage(ITEMS_PER_PAGE, null);
         verify(filterService).prepareFilter(null, OFFICER_ID);
+        verify(repository).countTotal(OFFICER_ID, false, List.of());
+        verify(sortingThresholdService).shouldSort(3, null);
         verify(repository).findOfficerAppointmentsIds(OFFICER_ID, false, List.of(),
                 0, ITEMS_PER_PAGE);
         verify(repository).findFullOfficerAppointments(List.of(APPOINTMENT_ID));
-        verify(repository).countTotal(OFFICER_ID, false, List.of());
-        verify(repository).countInactive(OFFICER_ID);
+        verify(repository).countResigned(OFFICER_ID);
         verify(repository).countInactive(OFFICER_ID);
         verify(filterService).findFirstActiveAppointment(List.of(companyAppointmentDocument));
         verify(repository).findLatestAppointment(OFFICER_ID);
@@ -260,25 +277,34 @@ class OfficerAppointmentsServiceTest {
     @Test
     void getOfficerAppointmentsEmpty() throws BadRequestException {
         // given
+        OfficerAppointmentsRequest request = OfficerAppointmentsRequest.builder()
+                .officerId(OFFICER_ID)
+                .itemsPerPage(ITEMS_PER_PAGE)
+                .build();
+
+        when(itemsPerPageService.adjustItemsPerPage(any(), any())).thenReturn(ITEMS_PER_PAGE);
         when(filterService.prepareFilter(any(), any())).thenReturn(new Filter(false, List.of()));
+        when(repository.countTotal(any(), anyBoolean(), any())).thenReturn(0);
+        when(sortingThresholdService.shouldSort(anyInt(), any())).thenReturn(true);
         when(repository.findOfficerAppointmentsIds(any(), anyBoolean(), any(), anyInt(), anyInt()))
                 .thenReturn(officerAppointments);
         when(officerAppointments.getIds()).thenReturn(List.of());
 
         // when
-        Optional<AppointmentList> actual = service.getOfficerAppointments(
-                new OfficerAppointmentsRequest(OFFICER_ID, null, null, ITEMS_PER_PAGE));
+        Optional<AppointmentList> actual = service.getOfficerAppointments(request);
 
         // then
         assertTrue(actual.isEmpty());
+        verify(itemsPerPageService).adjustItemsPerPage(ITEMS_PER_PAGE, null);
         verify(filterService).prepareFilter(null, OFFICER_ID);
-        verify(repository).findOfficerAppointmentsIds(OFFICER_ID, false, List.of(), 0, ITEMS_PER_PAGE);
-        verify(repository).findFullOfficerAppointments(List.of());
         verify(repository).countTotal(OFFICER_ID, false, List.of());
-        verify(repository).countInactive(OFFICER_ID);
+        verify(sortingThresholdService).shouldSort(0, null);
+        verify(repository).findOfficerAppointmentsIds(OFFICER_ID, false, List.of(), 0, ITEMS_PER_PAGE);
+        verify(repository).countResigned(OFFICER_ID);
         verify(repository).countInactive(OFFICER_ID);
         verify(filterService).findFirstActiveAppointment(List.of());
         verify(repository).findLatestAppointment(OFFICER_ID);
+        verifyNoMoreInteractions(repository);
         verify(mapper).mapOfficerAppointments(MapperRequest.builder()
                 .startIndex(START_INDEX)
                 .itemsPerPage(ITEMS_PER_PAGE)
@@ -286,6 +312,102 @@ class OfficerAppointmentsServiceTest {
                 .totalResults(0)
                 .resignedCount(0)
                 .inactiveCount(0)
+                .build());
+    }
+
+    @Test
+    void getOfficerAppointmentsUnsortedOverThreshold() throws BadRequestException {
+        // given
+        String authPrivileges = "internal";
+        OfficerAppointmentsRequest request = OfficerAppointmentsRequest.builder()
+                .officerId(OFFICER_ID)
+                .itemsPerPage(ITEMS_PER_PAGE)
+                .authPrivileges(authPrivileges)
+                .build();
+
+        when(itemsPerPageService.adjustItemsPerPage(any(), any())).thenReturn(ITEMS_PER_PAGE);
+        when(filterService.prepareFilter(any(), any())).thenReturn(new Filter(false, List.of()));
+        when(repository.countTotal(any(), anyBoolean(), any())).thenReturn(501);
+        when(sortingThresholdService.shouldSort(anyInt(), any())).thenReturn(false);
+        when(repository.findOfficerAppointmentsUnsorted(anyString(), anyBoolean(), any(), anyInt(), anyInt()))
+                .thenReturn(List.of(companyAppointmentDocument));
+        when(repository.countResigned(any())).thenReturn(1);
+        when(repository.countInactive(any())).thenReturn(1);
+        when(filterService.findFirstActiveAppointment(any())).thenReturn(Optional.of(companyAppointmentDocument));
+        when(mapper.mapOfficerAppointments(any())).thenReturn(Optional.of(appointmentList));
+
+        // when
+        Optional<AppointmentList> actual = service.getOfficerAppointments(request);
+
+        // then
+        assertTrue(actual.isPresent());
+        assertEquals(appointmentList, actual.get());
+        verify(itemsPerPageService).adjustItemsPerPage(ITEMS_PER_PAGE, authPrivileges);
+        verify(filterService).prepareFilter(null, OFFICER_ID);
+        verify(repository).countTotal(OFFICER_ID, false, List.of());
+        verify(sortingThresholdService).shouldSort(501, authPrivileges);
+        verify(repository).findOfficerAppointmentsUnsorted(OFFICER_ID, false, List.of(),
+                0, ITEMS_PER_PAGE);
+        verify(repository).countResigned(OFFICER_ID);
+        verify(repository).countInactive(OFFICER_ID);
+        verify(filterService).findFirstActiveAppointment(List.of(companyAppointmentDocument));
+        verifyNoMoreInteractions(repository);
+        verify(mapper).mapOfficerAppointments(MapperRequest.builder()
+                .startIndex(START_INDEX)
+                .itemsPerPage(ITEMS_PER_PAGE)
+                .firstAppointment(companyAppointmentDocument)
+                .officerAppointments(List.of(companyAppointmentDocument))
+                .totalResults(501)
+                .resignedCount(1)
+                .inactiveCount(1)
+                .build());
+    }
+
+    @Test
+    void getOfficerAppointmentsSortedUnderThreshold() throws BadRequestException {
+        // given
+        OfficerAppointmentsRequest request = OfficerAppointmentsRequest.builder()
+                .officerId(OFFICER_ID)
+                .itemsPerPage(ITEMS_PER_PAGE)
+                .build();
+
+        when(itemsPerPageService.adjustItemsPerPage(any(), any())).thenReturn(ITEMS_PER_PAGE);
+        when(filterService.prepareFilter(any(), any())).thenReturn(new Filter(false, List.of()));
+        when(repository.countTotal(any(), anyBoolean(), any())).thenReturn(499);
+        when(sortingThresholdService.shouldSort(anyInt(), any())).thenReturn(true);
+        when(repository.findOfficerAppointmentsIds(anyString(), anyBoolean(), any(), anyInt(), anyInt()))
+                .thenReturn(officerAppointments);
+        when(officerAppointments.getIds()).thenReturn(List.of(APPOINTMENT_ID));
+        when(repository.findFullOfficerAppointments(any())).thenReturn(List.of(companyAppointmentDocument));
+        when(repository.countResigned(any())).thenReturn(1);
+        when(repository.countInactive(any())).thenReturn(1);
+        when(filterService.findFirstActiveAppointment(any())).thenReturn(Optional.of(companyAppointmentDocument));
+        when(mapper.mapOfficerAppointments(any())).thenReturn(Optional.of(appointmentList));
+
+        // when
+        Optional<AppointmentList> actual = service.getOfficerAppointments(request);
+
+        // then
+        assertTrue(actual.isPresent());
+        assertEquals(appointmentList, actual.get());
+        verify(itemsPerPageService).adjustItemsPerPage(ITEMS_PER_PAGE, null);
+        verify(filterService).prepareFilter(null, OFFICER_ID);
+        verify(repository).countTotal(OFFICER_ID, false, List.of());
+        verify(sortingThresholdService).shouldSort(499, null);
+        verify(repository).findOfficerAppointmentsIds(OFFICER_ID, false, List.of(), 0, ITEMS_PER_PAGE);
+        verify(repository).findFullOfficerAppointments(List.of(APPOINTMENT_ID));
+        verify(repository).countResigned(OFFICER_ID);
+        verify(repository).countInactive(OFFICER_ID);
+        verify(filterService).findFirstActiveAppointment(List.of(companyAppointmentDocument));
+        verifyNoMoreInteractions(repository);
+        verify(mapper).mapOfficerAppointments(MapperRequest.builder()
+                .startIndex(START_INDEX)
+                .itemsPerPage(ITEMS_PER_PAGE)
+                .firstAppointment(companyAppointmentDocument)
+                .officerAppointments(List.of(companyAppointmentDocument))
+                .totalResults(499)
+                .resignedCount(1)
+                .inactiveCount(1)
                 .build());
     }
 

--- a/src/test/java/uk/gov/companieshouse/company_appointments/officerappointments/SortingThresholdServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/company_appointments/officerappointments/SortingThresholdServiceTest.java
@@ -1,0 +1,134 @@
+package uk.gov.companieshouse.company_appointments.officerappointments;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Named;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+class SortingThresholdServiceTest {
+
+    @ParameterizedTest
+    @MethodSource("sortingThresholdScenarios")
+    void testShouldSortGivenTotalResultsAndThresholds(SortingThresholdTestArgument argument) {
+        // given
+        SortingThresholdService service = new SortingThresholdService(argument.internalSortingThreshold(),
+                argument.externalSortingThreshold());
+
+        // when
+        boolean actual = service.shouldSort(argument.totalResults(), argument.authPrivileges());
+
+        // then
+        assertEquals(argument.expected(), actual);
+    }
+
+    private static Stream<Arguments> sortingThresholdScenarios() {
+        return Stream.of(
+                Arguments.of(
+                        Named.of("Should sort unauthorised request within external threshold",
+                                SortingThresholdTestArgument.builder()
+                                        .internalSortingThreshold(5)
+                                        .externalSortingThreshold(25)
+                                        .totalResults(10)
+                                        .authPrivileges(null)
+                                        .expected(true)
+                                        .build())),
+                Arguments.of(
+                        Named.of("Should sort unauthorised request when external threshold -1",
+                                SortingThresholdTestArgument.builder()
+                                        .internalSortingThreshold(25)
+                                        .externalSortingThreshold(-1)
+                                        .totalResults(30)
+                                        .authPrivileges(null)
+                                        .expected(true)
+                                        .build())),
+                Arguments.of(
+                        Named.of("Should not sort unauthorised request over external threshold",
+                                SortingThresholdTestArgument.builder()
+                                        .internalSortingThreshold(50)
+                                        .externalSortingThreshold(25)
+                                        .totalResults(30)
+                                        .authPrivileges(null)
+                                        .expected(false)
+                                        .build())),
+                Arguments.of(
+                        Named.of("Should sort authorised request within internal threshold",
+                                SortingThresholdTestArgument.builder()
+                                        .internalSortingThreshold(25)
+                                        .externalSortingThreshold(5)
+                                        .totalResults(10)
+                                        .authPrivileges("internal-app")
+                                        .expected(true)
+                                        .build())),
+                Arguments.of(
+                        Named.of("Should sort authorised request when internal threshold -1",
+                                SortingThresholdTestArgument.builder()
+                                        .internalSortingThreshold(-1)
+                                        .externalSortingThreshold(25)
+                                        .totalResults(30)
+                                        .authPrivileges("internal-app")
+                                        .expected(true)
+                                        .build())),
+                Arguments.of(
+                        Named.of("Should not sort authorised request over internal threshold",
+                                SortingThresholdTestArgument.builder()
+                                        .internalSortingThreshold(25)
+                                        .externalSortingThreshold(50)
+                                        .totalResults(30)
+                                        .authPrivileges("internal-app")
+                                        .expected(false)
+                                        .build())));
+    }
+
+    private record SortingThresholdTestArgument(int internalSortingThreshold, int externalSortingThreshold, int totalResults,
+                                                String authPrivileges, boolean expected) {
+
+        private static Builder builder() {
+            return new Builder();
+        }
+
+        private static final class Builder {
+
+            private int internalSortingThreshold;
+            private int externalSortingThreshold;
+            private int totalResults;
+            private String authPrivileges;
+            private boolean expected;
+
+            private Builder() {
+            }
+
+            private Builder internalSortingThreshold(int internalSortingThreshold) {
+                this.internalSortingThreshold = internalSortingThreshold;
+                return this;
+            }
+
+            private Builder externalSortingThreshold(int externalSortingThreshold) {
+                this.externalSortingThreshold = externalSortingThreshold;
+                return this;
+            }
+
+            private Builder totalResults(int totalResults) {
+                this.totalResults = totalResults;
+                return this;
+            }
+
+            private Builder authPrivileges(String authPrivileges) {
+                this.authPrivileges = authPrivileges;
+                return this;
+            }
+
+            private Builder expected(boolean expected) {
+                this.expected = expected;
+                return this;
+            }
+
+            private SortingThresholdTestArgument build() {
+                return new SortingThresholdTestArgument(internalSortingThreshold, externalSortingThreshold, totalResults,
+                        authPrivileges, expected);
+            }
+        }
+    }
+}

--- a/src/test/resources/application-feature_flag_enabled.properties
+++ b/src/test/resources/application-feature_flag_enabled.properties
@@ -13,4 +13,6 @@ api.api-key=${CHS_API_KEY:chsApiKey}
 
 feature.seeding_collection_enabled=true
 
-items-per-page-max-internal=500
+officer-appointments.items-per-page-max-internal=500
+officer-appointments.sorting-threshold-internal=500
+officer-appointments.sorting-threshold-external=500

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -13,7 +13,9 @@ api.api-key=${CHS_API_KEY:chsApiKey}
 
 feature.seeding_collection_enabled=false
 
-items-per-page-max-internal=500
+officer-appointments.items-per-page-max-internal=500
+officer-appointments.sorting-threshold-internal=500
+officer-appointments.sorting-threshold-external=500
 
 logging.level.org.springframework.data.mongodb.core.MongoTemplate=DEBUG
 


### PR DESCRIPTION
* External requests for officer appointments over the configured external sorting threshold, if present, will be returned in their database order.
* Internal requests, those with internal privileges, for officer appointments over the configured internal sorting threshold, if present, will be returned in their database order.
* Refactored so that authPrivileges are passed to the service which now depends on both the ItemsPerPageService (previously controller) and the new SortingThresholdService.
* Configure `OFFICER_APPOINTMENTS_SORTING_THRESHOLD_EXTERNAL` or `OFFICER_APPOINTMENTS_SORTING_THRESHOLD_INTERNAL` to set an external or internal sorting threshold respectively.
* The max items per page for an internal request is still set by the current env var `OFFICER_APPOINTMENTS_THRESHOLD`.

[DSND-3268](https://companieshouse.atlassian.net/browse/DSND-3268)

[DSND-3268]: https://companieshouse.atlassian.net/browse/DSND-3268?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ