### PR TITLE
BI-14441: Add sorting behaviour to officer appointment list query

### DIFF
--- a/src/it/java/uk/gov/companieshouse/company_appointments/tests/CompanyAppointmentControllerITest.java
+++ b/src/it/java/uk/gov/companieshouse/company_appointments/tests/CompanyAppointmentControllerITest.java
@@ -37,7 +37,6 @@ import org.mockito.Mock;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.boot.test.system.CapturedOutput;
 import org.springframework.boot.test.system.OutputCaptureExtension;
 import org.springframework.data.mongodb.core.MongoTemplate;
@@ -45,6 +44,7 @@ import org.springframework.data.mongodb.core.SimpleMongoClientDatabaseFactory;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
@@ -84,7 +84,7 @@ class CompanyAppointmentControllerITest {
     @Autowired
     private ObjectMapper objectMapper;
 
-    @MockBean
+    @MockitoBean
     private CompanyMetricsApiService companyMetricsApiService;
 
     @Mock
@@ -110,7 +110,7 @@ class CompanyAppointmentControllerITest {
     @Test
     void testReturn200OKIfOfficerIsFound() throws Exception {
         //when
-        ResultActions result = mockMvc.perform(get("/company/{company_number}/appointments/{appointment_id}", COMPANY_NUMBER, "active_1")
+        ResultActions result = mockMvc.perform(get("/company/{company_number}/appointments/{appointment_id}", COMPANY_NUMBER, "active_appointed_on_1")
                 .header(X_REQUEST_ID, CONTEXT_ID)
                 .header(ERIC_IDENTITY, "123")
                 .header(ERIC_IDENTITY_TYPE, "key")
@@ -120,7 +120,7 @@ class CompanyAppointmentControllerITest {
         //then
         result.andExpect(MockMvcResultMatchers.status().isOk())
                 .andExpect(MockMvcResultMatchers.jsonPath("$.name", is("NOSURNAME, Noname1 Noname2")))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.appointed_on", is("2024-08-26")))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.appointed_on", is("2025-08-26")))
                 .andExpect(MockMvcResultMatchers.jsonPath("$.date_of_birth", not(contains("day"))))
                 .andExpect(MockMvcResultMatchers.jsonPath("$.date_of_birth.year", is(1980)))
                 .andExpect(MockMvcResultMatchers.jsonPath("$.date_of_birth.month", is(1)));

--- a/src/main/java/uk/gov/companieshouse/company_appointments/officerappointments/OfficerAppointmentsRepository.java
+++ b/src/main/java/uk/gov/companieshouse/company_appointments/officerappointments/OfficerAppointmentsRepository.java
@@ -81,11 +81,17 @@ interface OfficerAppointmentsRepository extends MongoRepository<CompanyAppointme
                     + "]"
                     + "}"
                     + "}",
+            "{"
+                    + "$addFields: {"
+                    + "'__sort_active__': { $ifNull: ['$data.appointed_on', { $toDate: '$data.appointed_before' } ] }"
+                    + "}"
+                    + "}",
+            "{ $sort:  {'__sort_active__': -1 } }",
             "{ $skip: ?3 }",
             "{ $limit: ?4 }"
     })
     @Meta(allowDiskUse = true)
-    List<CompanyAppointmentDocument> findOfficerAppointmentsUnsorted(String officerId, boolean filterEnabled,
+    List<CompanyAppointmentDocument> findOfficerAppointments(String officerId, boolean filterEnabled,
             List<String> filterStatuses, int startIndex, int pageSize);
 
     @Aggregation(pipeline = {

--- a/src/main/java/uk/gov/companieshouse/company_appointments/officerappointments/OfficerAppointmentsService.java
+++ b/src/main/java/uk/gov/companieshouse/company_appointments/officerappointments/OfficerAppointmentsService.java
@@ -53,7 +53,7 @@ class OfficerAppointmentsService {
                 documents = List.of();
             }
         } else {
-            documents = repository.findOfficerAppointmentsUnsorted(officerId, filterEnabled, filterStatuses, startIndex,
+            documents = repository.findOfficerAppointments(officerId, filterEnabled, filterStatuses, startIndex,
                     adjustedItemsPerPage);
         }
 

--- a/src/test/java/uk/gov/companieshouse/company_appointments/officerappointments/OfficerAppointmentsRepositoryITest.java
+++ b/src/test/java/uk/gov/companieshouse/company_appointments/officerappointments/OfficerAppointmentsRepositoryITest.java
@@ -55,6 +55,9 @@ class OfficerAppointmentsRepositoryITest {
         mongoTemplate.createCollection("delta_appointments");
 
         mongoTemplate.insert(
+                Document.parse(IOUtils.resourceToString("/appointment-data7.json", StandardCharsets.UTF_8)),
+                "delta_appointments");
+        mongoTemplate.insert(
                 Document.parse(IOUtils.resourceToString("/appointment-data6.json", StandardCharsets.UTF_8)),
                 "delta_appointments");
         mongoTemplate.insert(
@@ -85,13 +88,14 @@ class OfficerAppointmentsRepositoryITest {
                 START_INDEX, DEFAULT_ITEMS_PER_PAGE);
 
         // then
-        assertEquals(6, appointmentsIds.getIds().size());
-        assertEquals("active_1", appointmentsIds.getIds().get(0));
-        assertEquals("dissolved_1", appointmentsIds.getIds().get(1));
-        assertEquals("active_2", appointmentsIds.getIds().get(2));
-        assertEquals("active_3", appointmentsIds.getIds().get(3));
-        assertEquals("resigned_1", appointmentsIds.getIds().get(4));
-        assertEquals("resigned_2", appointmentsIds.getIds().get(5));
+        assertEquals(7, appointmentsIds.getIds().size());
+        assertEquals("active_appointed_on_1", appointmentsIds.getIds().get(0));
+        assertEquals("active_appointed_on_2", appointmentsIds.getIds().get(1));
+        assertEquals("active_appointed_before_1", appointmentsIds.getIds().get(2));
+        assertEquals("dissolved_appointed_before_1", appointmentsIds.getIds().get(3));
+        assertEquals("active_appointed_before_2", appointmentsIds.getIds().get(4));
+        assertEquals("active_resigned_on_1", appointmentsIds.getIds().get(5));
+        assertEquals("active_resigned_on_2", appointmentsIds.getIds().get(6));
     }
 
     @DisplayName("Repository returns no appointments IDs when there are no matches")
@@ -117,10 +121,11 @@ class OfficerAppointmentsRepositoryITest {
                 FILTER_STATUSES, START_INDEX, DEFAULT_ITEMS_PER_PAGE);
 
         // then
-        assertEquals(3, appointmentsIds.getIds().size());
-        assertEquals("active_1", appointmentsIds.getIds().get(0));
-        assertEquals("active_2", appointmentsIds.getIds().get(1));
-        assertEquals("active_3", appointmentsIds.getIds().get(2));
+        assertEquals(4, appointmentsIds.getIds().size());
+        assertEquals("active_appointed_on_1", appointmentsIds.getIds().get(0));
+        assertEquals("active_appointed_on_2", appointmentsIds.getIds().get(1));
+        assertEquals("active_appointed_before_1", appointmentsIds.getIds().get(2));
+        assertEquals("active_appointed_before_2", appointmentsIds.getIds().get(3));
     }
 
     @DisplayName("Repository returns no appointments IDs when there are no matches when the filter is enabled")
@@ -143,14 +148,15 @@ class OfficerAppointmentsRepositoryITest {
 
         // when
         OfficerAppointments appointmentsIds = repository.findOfficerAppointmentsIds(OFFICER_ID, false, emptyList(), 1,
-                4);
+                5);
 
         // then
-        assertEquals(4, appointmentsIds.getIds().size());
-        assertEquals("dissolved_1", appointmentsIds.getIds().get(0));
-        assertEquals("active_2", appointmentsIds.getIds().get(1));
-        assertEquals("active_3", appointmentsIds.getIds().get(2));
-        assertEquals("resigned_1", appointmentsIds.getIds().get(3));
+        assertEquals(5, appointmentsIds.getIds().size());
+        assertEquals("active_appointed_on_2", appointmentsIds.getIds().get(0));
+        assertEquals("active_appointed_before_1", appointmentsIds.getIds().get(1));
+        assertEquals("dissolved_appointed_before_1", appointmentsIds.getIds().get(2));
+        assertEquals("active_appointed_before_2", appointmentsIds.getIds().get(3));
+        assertEquals("active_resigned_on_1", appointmentsIds.getIds().get(4));
     }
 
     @DisplayName("Repository returns a paged list of officer appointments IDs with the filter applied")
@@ -163,9 +169,10 @@ class OfficerAppointmentsRepositoryITest {
                 FILTER_STATUSES, 1, 3);
 
         // then
-        assertEquals(2, appointmentsIds.getIds().size());
-        assertEquals("active_2", appointmentsIds.getIds().get(0));
-        assertEquals("active_3", appointmentsIds.getIds().get(1));
+        assertEquals(3, appointmentsIds.getIds().size());
+        assertEquals("active_appointed_on_2", appointmentsIds.getIds().get(0));
+        assertEquals("active_appointed_before_1", appointmentsIds.getIds().get(1));
+        assertEquals("active_appointed_before_2", appointmentsIds.getIds().get(2));
     }
 
     @DisplayName("Repository returns no officer appointments IDs when start index is greater than total matches")
@@ -193,7 +200,7 @@ class OfficerAppointmentsRepositoryITest {
         List<CompanyAppointmentDocument> documents = repository.findFullOfficerAppointments(appointmentsIds);
 
         // then
-        assertEquals(6, documents.size());
+        assertEquals(7, documents.size());
         assertEquals(appointmentsIds, documents.stream().map(CompanyAppointmentDocument::getId).toList());
     }
 
@@ -206,7 +213,7 @@ class OfficerAppointmentsRepositoryITest {
         int total = repository.countTotal(OFFICER_ID, false, emptyList());
 
         // then
-        assertEquals(6, total);
+        assertEquals(7, total);
     }
 
     @DisplayName("Repository returns count of zero total officer appointments")
@@ -230,7 +237,7 @@ class OfficerAppointmentsRepositoryITest {
         int total = repository.countTotal(OFFICER_ID, true, FILTER_STATUSES);
 
         // then
-        assertEquals(3, total);
+        assertEquals(4, total);
     }
 
     @DisplayName("Repository returns count of zero total active officer appointments")
@@ -302,7 +309,7 @@ class OfficerAppointmentsRepositoryITest {
         CompanyAppointmentDocument actual = repository.findLatestAppointment(OFFICER_ID);
 
         // then
-        assertEquals("active_1", actual.getId());
+        assertEquals("active_appointed_on_1", actual.getId());
     }
 
     @DisplayName("Repository should return no appointment for the given officer ID")
@@ -317,32 +324,34 @@ class OfficerAppointmentsRepositoryITest {
         assertNull(actual);
     }
 
-    @DisplayName("Repository returns unsorted officer appointments")
+    @DisplayName("Repository returns officer appointments sorted to appointed_on and appointed_before dates descending")
     @Test
-    void findOfficerAppointmentsUnsorted() {
+    void findOfficerAppointments() {
         // given
 
         // when
-        List<CompanyAppointmentDocument> appointments = repository.findOfficerAppointmentsUnsorted(OFFICER_ID, false, emptyList(),
+        List<CompanyAppointmentDocument> appointments = repository.findOfficerAppointments(OFFICER_ID, false, emptyList(),
                 START_INDEX, DEFAULT_ITEMS_PER_PAGE);
 
         // then
-        assertEquals(6, appointments.size());
-        assertEquals("dissolved_1", appointments.get(0).getId());
-        assertEquals("active_3", appointments.get(1).getId());
-        assertEquals("resigned_2", appointments.get(2).getId());
-        assertEquals("active_2", appointments.get(3).getId());
-        assertEquals("resigned_1", appointments.get(4).getId());
-        assertEquals("active_1", appointments.get(5).getId());
+        assertEquals(7, appointments.size());
+        assertEquals("active_appointed_on_1", appointments.get(0).getId());
+        assertEquals("active_appointed_on_2", appointments.get(1).getId());
+        assertEquals("active_resigned_on_1", appointments.get(2).getId());
+        assertEquals("active_appointed_before_1", appointments.get(3).getId());
+        // there is business logic wherein in live an appointed_on can be before an appointed_before.
+        assertEquals("active_resigned_on_2", appointments.get(4).getId());
+        assertEquals("dissolved_appointed_before_1", appointments.get(5).getId());
+        assertEquals("active_appointed_before_2", appointments.get(6).getId());
     }
 
-    @DisplayName("Repository returns no unsorted appointments when there are no matches")
+    @DisplayName("Repository returns no appointments when there are no matches")
     @Test
-    void findOfficerAppointmentsUnsortedNoResults() {
+    void findOfficerAppointmentsNoResults() {
         // given
 
         // when
-        List<CompanyAppointmentDocument> appointments = repository.findOfficerAppointmentsUnsorted("officerId", false,
+        List<CompanyAppointmentDocument> appointments = repository.findOfficerAppointments("officerId", false,
                 emptyList(),
                 START_INDEX, DEFAULT_ITEMS_PER_PAGE);
 
@@ -350,20 +359,21 @@ class OfficerAppointmentsRepositoryITest {
         assertTrue(appointments.isEmpty());
     }
 
-    @DisplayName("Repository returns only active unsorted appointments when the filter is enabled")
+    @DisplayName("Repository returns only active sorted appointments when the filter is enabled")
     @Test
-    void findActiveOfficerAppointmentsUnsorted() {
+    void findActiveOfficerAppointments() {
         // given
 
         // when
-        List<CompanyAppointmentDocument> appointments = repository.findOfficerAppointmentsUnsorted(OFFICER_ID, true,
+        List<CompanyAppointmentDocument> appointments = repository.findOfficerAppointments(OFFICER_ID, true,
                 FILTER_STATUSES, START_INDEX, DEFAULT_ITEMS_PER_PAGE);
 
         // then
-        assertEquals(3, appointments.size());
-        assertEquals("active_3", appointments.get(0).getId());
-        assertEquals("active_2", appointments.get(1).getId());
-        assertEquals("active_1", appointments.get(2).getId());
+        assertEquals(4, appointments.size());
+        assertEquals("active_appointed_on_1", appointments.get(0).getId());
+        assertEquals("active_appointed_on_2", appointments.get(1).getId());
+        assertEquals("active_appointed_before_1", appointments.get(2).getId());
+        assertEquals("active_appointed_before_2", appointments.get(3).getId());
     }
 
     @DisplayName("Repository returns no unsorted appointments when there are no matches when the filter is enabled")
@@ -372,53 +382,54 @@ class OfficerAppointmentsRepositoryITest {
         // given
 
         // when
-        List<CompanyAppointmentDocument> appointments = repository.findOfficerAppointmentsUnsorted("officerId", true, emptyList(),
+        List<CompanyAppointmentDocument> appointments = repository.findOfficerAppointments("officerId", true, emptyList(),
                 START_INDEX, DEFAULT_ITEMS_PER_PAGE);
 
         // then
         assertTrue(appointments.isEmpty());
     }
 
-    @DisplayName("Repository returns a paged list of unsorted officer appointments")
+    @DisplayName("Repository returns a paged list of sorted officer appointments")
     @Test
-    void findOfficerAppointmentsUnsortedWithPaging() {
+    void findOfficerAppointmentsWithPaging() {
         // given
 
         // when
-        List<CompanyAppointmentDocument> appointments = repository.findOfficerAppointmentsUnsorted(OFFICER_ID, false, emptyList(),
+        List<CompanyAppointmentDocument> appointments = repository.findOfficerAppointments(OFFICER_ID, false, emptyList(),
                 1,
                 4);
 
         // then
         assertEquals(4, appointments.size());
-        assertEquals("active_3", appointments.get(0).getId());
-        assertEquals("resigned_2", appointments.get(1).getId());
-        assertEquals("active_2", appointments.get(2).getId());
-        assertEquals("resigned_1", appointments.get(3).getId());
+        assertEquals("active_resigned_on_1", appointments.get(0).getId());
+        assertEquals("active_appointed_on_2", appointments.get(1).getId());
+        assertEquals("active_appointed_before_1", appointments.get(2).getId());
+        assertEquals("active_resigned_on_2", appointments.get(3).getId());
     }
 
-    @DisplayName("Repository returns a paged list of unsorted officer appointments with the filter applied")
+    @DisplayName("Repository returns a paged list of sorted officer appointments with the filter applied")
     @Test
-    void findActiveOfficerAppointmentsUnsortedWithPaging() {
+    void findActiveOfficerAppointmentsWithPaging() {
         // given
 
         // when
-        List<CompanyAppointmentDocument> appointments = repository.findOfficerAppointmentsUnsorted(OFFICER_ID, true,
+        List<CompanyAppointmentDocument> appointments = repository.findOfficerAppointments(OFFICER_ID, true,
                 FILTER_STATUSES, 1, 3);
 
         // then
-        assertEquals(2, appointments.size());
-        assertEquals("active_2", appointments.get(0).getId());
-        assertEquals("active_1", appointments.get(1).getId());
+        assertEquals(3, appointments.size());
+        assertEquals("active_appointed_on_2", appointments.get(0).getId());
+        assertEquals("active_appointed_before_1", appointments.get(1).getId());
+        assertEquals("active_appointed_before_2", appointments.get(2).getId());
     }
 
     @DisplayName("Repository returns no unsorted officer appointments when start index is greater than total matches")
     @Test
-    void findOfficerAppointmentsUnsortedHighStartIndex() {
+    void findOfficerAppointmentsHighStartIndex() {
         // given
 
         // when
-        List<CompanyAppointmentDocument> appointments = repository.findOfficerAppointmentsUnsorted(OFFICER_ID, false, emptyList(),
+        List<CompanyAppointmentDocument> appointments = repository.findOfficerAppointments(OFFICER_ID, false, emptyList(),
                 10,
                 DEFAULT_ITEMS_PER_PAGE);
 

--- a/src/test/java/uk/gov/companieshouse/company_appointments/officerappointments/OfficerAppointmentsServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/company_appointments/officerappointments/OfficerAppointmentsServiceTest.java
@@ -329,7 +329,7 @@ class OfficerAppointmentsServiceTest {
         when(filterService.prepareFilter(any(), any())).thenReturn(new Filter(false, List.of()));
         when(repository.countTotal(any(), anyBoolean(), any())).thenReturn(501);
         when(sortingThresholdService.shouldSort(anyInt(), any())).thenReturn(false);
-        when(repository.findOfficerAppointmentsUnsorted(anyString(), anyBoolean(), any(), anyInt(), anyInt()))
+        when(repository.findOfficerAppointments(anyString(), anyBoolean(), any(), anyInt(), anyInt()))
                 .thenReturn(List.of(companyAppointmentDocument));
         when(repository.countResigned(any())).thenReturn(1);
         when(repository.countInactive(any())).thenReturn(1);
@@ -346,7 +346,7 @@ class OfficerAppointmentsServiceTest {
         verify(filterService).prepareFilter(null, OFFICER_ID);
         verify(repository).countTotal(OFFICER_ID, false, List.of());
         verify(sortingThresholdService).shouldSort(501, authPrivileges);
-        verify(repository).findOfficerAppointmentsUnsorted(OFFICER_ID, false, List.of(),
+        verify(repository).findOfficerAppointments(OFFICER_ID, false, List.of(),
                 0, ITEMS_PER_PAGE);
         verify(repository).countResigned(OFFICER_ID);
         verify(repository).countInactive(OFFICER_ID);

--- a/src/test/resources/appointment-data.json
+++ b/src/test/resources/appointment-data.json
@@ -1,6 +1,6 @@
 {
-  "_id" : "active_1",
-  "appointment_id" : "active_1",
+  "_id" : "active_appointed_on_1",
+  "appointment_id" : "active_appointed_on_1",
   "company_name" : "TEST COMPANY LIMITED",
   "company_number" : "12345678",
   "company_status" : "active",
@@ -22,7 +22,7 @@
     "forename" : "Noname1",
     "surname" : "NOSURNAME",
     "other_forenames" : "Noname2",
-    "appointed_on" : ISODate("2024-08-26T12:00:00.000Z"),
+    "appointed_on" : ISODate("2025-08-26T12:00:00.000Z"),
     "etag" : "8f58a770d34f982a1b2a5a29fcde12528e82f903",
     "occupation" : "Company Director",
     "service_address" : {

--- a/src/test/resources/appointment-data2.json
+++ b/src/test/resources/appointment-data2.json
@@ -1,6 +1,6 @@
 {
-  "_id" : "resigned_1",
-  "appointment_id" : "resigned_1",
+  "_id" : "active_resigned_on_1",
+  "appointment_id" : "active_resigned_on_1",
   "company_name" : "TEST COMPANY LIMITED",
   "company_number" : "12345678",
   "company_status" : "active",

--- a/src/test/resources/appointment-data3.json
+++ b/src/test/resources/appointment-data3.json
@@ -1,6 +1,6 @@
 {
-  "_id" : "active_2",
-  "appointment_id" : "active_2",
+  "_id" : "active_appointed_on_2",
+  "appointment_id" : "active_appointed_on_2",
   "company_name" : "TEST COMPANY LIMITED",
   "company_number" : "12345678",
   "company_status" : "active",
@@ -13,10 +13,10 @@
     "country_of_residence" : "United Kingdom",
     "links" : {
       "officer" : {
-        "self" : "/officers/active_2",
-        "appointments" : "/officers/active_2/appointments"
+        "self" : "/officers/active_appointed_on_2",
+        "appointments" : "/officers/active_appointed_on_2/appointments"
       },
-      "self" : "/company/12345678/appointments/active_2"
+      "self" : "/company/12345678/appointments/active_appointed_on_2"
     },
     "nationality" : "British",
     "forename" : "John",

--- a/src/test/resources/appointment-data4.json
+++ b/src/test/resources/appointment-data4.json
@@ -1,6 +1,6 @@
 {
-  "_id" : "resigned_2",
-  "appointment_id" : "resigned_2",
+  "_id" : "active_resigned_on_2",
+  "appointment_id" : "active_resigned_on_2",
   "company_name" : "TEST COMPANY LIMITED",
   "company_number" : "12345678",
   "company_status" : "active",

--- a/src/test/resources/appointment-data5.json
+++ b/src/test/resources/appointment-data5.json
@@ -1,6 +1,6 @@
 {
-  "_id" : "active_3",
-  "appointment_id" : "active_3",
+  "_id" : "active_appointed_before_1",
+  "appointment_id" : "active_appointed_before_1",
   "company_name" : "TEST COMPANY LIMITED",
   "company_number" : "12345678",
   "company_status" : "active",
@@ -16,13 +16,13 @@
         "self" : "/officers/5VEOBB4a9dlB_iugw_vieHjWpCk",
         "appointments" : "/officers/5VEOBB4a9dlB_iugw_vieHjWpCk/appointments"
       },
-      "self" : "/company/12345678/appointments/active_3"
+      "self" : "/company/12345678/appointments/active_appointed_before_1"
     },
     "nationality" : "British",
     "forename" : "Noname1",
     "surname" : "NOSURNAME",
     "other_forenames" : "Noname2",
-    "appointed_before" : ISODate("2022-08-26T00:00:00.000Z"),
+    "appointed_before" : ISODate("2018-08-26T00:00:00.000Z"),
     "etag" : "8f58a770d34f982a1b2a5a29fcde12528e82f903",
     "occupation" : "Company Director",
     "service_address" : {

--- a/src/test/resources/appointment-data6.json
+++ b/src/test/resources/appointment-data6.json
@@ -1,6 +1,6 @@
 {
-  "_id" : "dissolved_1",
-  "appointment_id" : "dissolved_1",
+  "_id" : "dissolved_appointed_before_1",
+  "appointment_id" : "dissolved_appointed_before_1",
   "company_name" : "TEST COMPANY LIMITED",
   "company_number" : "12345678",
   "company_status" : "dissolved",
@@ -22,7 +22,7 @@
     "forename" : "Noname1",
     "surname" : "NOSURNAME",
     "other_forenames" : "Noname2",
-    "appointed_before" : ISODate("2024-07-26T12:00:00.000Z"),
+    "appointed_before" : ISODate("2002-07-26T12:00:00.000Z"),
     "etag" : "8f58a770d34f982a1b2a5a29fcde12528e82f903",
     "occupation" : "Company Director",
     "service_address" : {
@@ -45,7 +45,7 @@
       "premises" : "URA",
       "region" : "ura_region"
     },
-    "date_of_birth" : ISODate("1980-01-01T00:00:00.000Z")
+    "date_of_birth" : ISODate("1970-01-01T00:00:00.000Z")
   },
   "delta_at" : ISODate("2020-06-23T12:13:03.006Z"),
   "internal_id" : "2500085646",

--- a/src/test/resources/appointment-data7.json
+++ b/src/test/resources/appointment-data7.json
@@ -1,0 +1,42 @@
+{
+  "_id" : "active_appointed_before_2",
+  "data" : {
+    "person_number" : "1234567890",
+    "etag" : "04f9e3527169562a674bc813e0f68f8a37ae83b4",
+    "service_address" : {
+      "address_line_1" : "1 Crown Way",
+      "address_line_2" : "Pavement",
+      "locality" : "Cardiff",
+      "postal_code" : "CF14 3UZ",
+      "premises" : "First Floor"
+    },
+    "service_address_is_same_as_registered_office_address" : false,
+    "appointed_before" : ISODate("1989-12-31T00:00:00.000Z"),
+    "is_pre_1992_appointment" : true,
+    "links" : {
+      "self" : "/company/12345678/appointments/active_appointed_before_2",
+      "officer" : {
+        "self" : "/officers/5VEOBB4a9dlB_iugw_vieHjWpCk",
+        "appointments" : "/officers/5VEOBB4a9dlB_iugw_vieHjWpCk/appointments"
+      }
+    },
+    "officer_role" : "corporate-secretary",
+    "company_name" : "TEST COMPANY LIMITED",
+    "company_number" : "12345678"
+  },
+  "internal_id" : "2500085646",
+  "appointment_id" : "active_appointed_before_2",
+  "officer_id" : "5VEOBB4a9dlB_iugw_vieHjWpCk",
+  "previous_officer_id" : "vuIAhYYbRDhqzx9b3e_jd6Xhmes",
+  "company_number" : "12345678",
+  "updated" : {
+    "at" : ISODate("2024-04-25T13:28:28.738Z")
+  },
+  "created" : {
+    "at" : ISODate("2024-04-25T13:28:28.738Z")
+  },
+  "delta_at" : ISODate("2025-04-19T13:42:17.615Z"),
+  "officer_role_sort_order" : NumberInt(10),
+  "company_name" : "TEST COMPANY",
+  "company_status" : "active"
+}


### PR DESCRIPTION
* change test data dates to more accurately reflect live business logic.
* add basic sorting logic to Officer appointments list repository call.
* add additional test data to more thoroughly test appointed_before dates behaviours

Pending swift local test 