### PR TITLE
BI-14516: Do not trigger officer merge on default previous officer ID

### DIFF
--- a/src/main/java/uk/gov/companieshouse/company_appointments/service/CompanyAppointmentFullRecordService.java
+++ b/src/main/java/uk/gov/companieshouse/company_appointments/service/CompanyAppointmentFullRecordService.java
@@ -110,7 +110,8 @@ public class CompanyAppointmentFullRecordService {
                     !isBlank(existingDocument.getOfficerId())) {
                 previousOfficerId = existingDocument.getOfficerId();
             } else if (!document.getOfficerId().equals(document.getPreviousOfficerId()) &&
-                    !isBlank(document.getPreviousOfficerId())) {
+                    !isBlank(document.getPreviousOfficerId()) &&
+                    !"vuIAhYYbRDhqzx9b3e_jd6Uhres".equals(document.getPreviousOfficerId())) {
                 previousOfficerId = document.getPreviousOfficerId();
             }
 

--- a/src/test/java/uk/gov/companieshouse/company_appointments/service/CompanyAppointmentFullRecordServiceTest.java
+++ b/src/test/java/uk/gov/companieshouse/company_appointments/service/CompanyAppointmentFullRecordServiceTest.java
@@ -393,6 +393,7 @@ class CompanyAppointmentFullRecordServiceTest {
 
     @ParameterizedTest
     @CsvSource(value = {
+            "vuIAhYYbRDhqzx9b3e_jd6Uhres",
             "''",
             "null"
     }, nullValues = "null")


### PR DESCRIPTION
* All documents get set a constant `previous_officer_id` value on insert and so should not trigger an officer merge when this is the case.

[BI-14516](https://companieshouse.atlassian.net/browse/BI-14516)
