### PR TITLE
Feature/mongo8 upgrade

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,8 +30,6 @@
     <commons-compress.version>1.28.0</commons-compress.version>
     <maven-compiler-plugin.version>3.14.0</maven-compiler-plugin.version>
     <opentelemetry-instrumentation-bom.version>2.14.0</opentelemetry-instrumentation-bom.version>
-<!--    <spring-core.version>6.2.11</spring-core.version>-->
-    <tomcat-embed-dependencies.version>10.1.47</tomcat-embed-dependencies.version>
 
     <!-- internal dependencies -->
     <structured-logging.version>3.0.39</structured-logging.version>
@@ -44,15 +42,6 @@
 
     <skip.integration.tests>false</skip.integration.tests>
     <skip.unit.tests>false</skip.unit.tests>
-
-      <!-- Transitive Dependencies -->
-      <!-- When the latest version of a direct dependency has vulnerable transative dependencies please define them here -->
-      <!-- Also define the direct dependency from which the dependency has derived -->
-      <!-- Once a new version of the parent dependency contains a fix, please upgrade and remove transative dependency -->
-
-      <!-- Direct dependency: spring-boot-starter-tomcat.version: 3.5.5 -->
-      <tomcat-embed-core.version>11.0.10</tomcat-embed-core.version>
-
 
       <!--sonar configuration-->
     <sonar.token>${CODE_ANALYSIS_TOKEN}</sonar.token>
@@ -73,19 +62,6 @@
 
   <dependencyManagement>
     <dependencies>
-        <!-- Transitive Dependencies -->
-        <!-- CVE-2025-52520 -->
-<!--        <dependency>-->
-<!--            <groupId>org.apache.tomcat.embed</groupId>-->
-<!--            <artifactId>tomcat-embed-core</artifactId>-->
-<!--            <version>${tomcat-embed-core.version}</version>-->
-<!--        </dependency>-->
-<!--        <dependency>-->
-<!--            <groupId>org.apache.tomcat.embed</groupId>-->
-<!--            <artifactId>tomcat-embed-websocket</artifactId>-->
-<!--            <version>${tomcat-embed-core.version}</version>-->
-<!--        </dependency>-->
-        <!-- Transitive Dependencies End -->
 
         <dependency>
         <groupId>io.opentelemetry.instrumentation</groupId>
@@ -324,28 +300,6 @@
         </exclusion>
       </exclusions>
     </dependency>
-
-    <!-- CVE-2025-41242 and CVE-2025-48989 -->
-<!--    <dependency>-->
-<!--      <groupId>org.springframework</groupId>-->
-<!--      <artifactId>spring-core</artifactId>-->
-<!--      <version>${spring-core.version}</version>-->
-<!--    </dependency>-->
-<!--    <dependency>-->
-<!--      <groupId>org.apache.tomcat.embed</groupId>-->
-<!--      <artifactId>tomcat-embed-core</artifactId>-->
-<!--      <version>${tomcat-embed-dependencies.version}</version>-->
-<!--    </dependency>-->
-<!--    <dependency>-->
-<!--      <groupId>org.apache.tomcat.embed</groupId>-->
-<!--      <artifactId>tomcat-embed-websocket</artifactId>-->
-<!--      <version>${tomcat-embed-dependencies.version}</version>-->
-<!--    </dependency>-->
-<!--    <dependency>-->
-<!--      <groupId>org.apache.tomcat.embed</groupId>-->
-<!--      <artifactId>tomcat-embed-el</artifactId>-->
-<!--      <version>${tomcat-embed-dependencies.version}</version>-->
-<!--    </dependency>-->
 
     <!-- Pinning version to address CVE-2025-68161(6.3) log4j-api pulled transitively-->
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
   <properties>
     <maven.compiler.source>21</maven.compiler.source>
     <maven.compiler.target>21</maven.compiler.target>
-    <spring-boot-dependencies.version>3.5.7</spring-boot-dependencies.version>
+    <spring-boot-dependencies.version>3.5.14</spring-boot-dependencies.version>
     <maven-surefire.version>3.5.4</maven-surefire.version>
     <maven-failsafe.version>3.5.4</maven-failsafe.version>
     <maven-build-helper-plugin.version>3.6.1</maven-build-helper-plugin.version>
@@ -30,7 +30,7 @@
     <commons-compress.version>1.28.0</commons-compress.version>
     <maven-compiler-plugin.version>3.14.0</maven-compiler-plugin.version>
     <opentelemetry-instrumentation-bom.version>2.14.0</opentelemetry-instrumentation-bom.version>
-    <spring-core.version>6.2.11</spring-core.version>
+<!--    <spring-core.version>6.2.11</spring-core.version>-->
     <tomcat-embed-dependencies.version>10.1.47</tomcat-embed-dependencies.version>
 
     <!-- internal dependencies -->
@@ -75,16 +75,16 @@
     <dependencies>
         <!-- Transitive Dependencies -->
         <!-- CVE-2025-52520 -->
-        <dependency>
-            <groupId>org.apache.tomcat.embed</groupId>
-            <artifactId>tomcat-embed-core</artifactId>
-            <version>${tomcat-embed-core.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.tomcat.embed</groupId>
-            <artifactId>tomcat-embed-websocket</artifactId>
-            <version>${tomcat-embed-core.version}</version>
-        </dependency>
+<!--        <dependency>-->
+<!--            <groupId>org.apache.tomcat.embed</groupId>-->
+<!--            <artifactId>tomcat-embed-core</artifactId>-->
+<!--            <version>${tomcat-embed-core.version}</version>-->
+<!--        </dependency>-->
+<!--        <dependency>-->
+<!--            <groupId>org.apache.tomcat.embed</groupId>-->
+<!--            <artifactId>tomcat-embed-websocket</artifactId>-->
+<!--            <version>${tomcat-embed-core.version}</version>-->
+<!--        </dependency>-->
         <!-- Transitive Dependencies End -->
 
         <dependency>
@@ -326,26 +326,26 @@
     </dependency>
 
     <!-- CVE-2025-41242 and CVE-2025-48989 -->
-    <dependency>
-      <groupId>org.springframework</groupId>
-      <artifactId>spring-core</artifactId>
-      <version>${spring-core.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.tomcat.embed</groupId>
-      <artifactId>tomcat-embed-core</artifactId>
-      <version>${tomcat-embed-dependencies.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.tomcat.embed</groupId>
-      <artifactId>tomcat-embed-websocket</artifactId>
-      <version>${tomcat-embed-dependencies.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.tomcat.embed</groupId>
-      <artifactId>tomcat-embed-el</artifactId>
-      <version>${tomcat-embed-dependencies.version}</version>
-    </dependency>
+<!--    <dependency>-->
+<!--      <groupId>org.springframework</groupId>-->
+<!--      <artifactId>spring-core</artifactId>-->
+<!--      <version>${spring-core.version}</version>-->
+<!--    </dependency>-->
+<!--    <dependency>-->
+<!--      <groupId>org.apache.tomcat.embed</groupId>-->
+<!--      <artifactId>tomcat-embed-core</artifactId>-->
+<!--      <version>${tomcat-embed-dependencies.version}</version>-->
+<!--    </dependency>-->
+<!--    <dependency>-->
+<!--      <groupId>org.apache.tomcat.embed</groupId>-->
+<!--      <artifactId>tomcat-embed-websocket</artifactId>-->
+<!--      <version>${tomcat-embed-dependencies.version}</version>-->
+<!--    </dependency>-->
+<!--    <dependency>-->
+<!--      <groupId>org.apache.tomcat.embed</groupId>-->
+<!--      <artifactId>tomcat-embed-el</artifactId>-->
+<!--      <version>${tomcat-embed-dependencies.version}</version>-->
+<!--    </dependency>-->
 
     <!-- Pinning version to address CVE-2025-68161(6.3) log4j-api pulled transitively-->
     <dependency>

--- a/src/it/java/uk/gov/companieshouse/company_appointments/config/AbstractMongoConfig.java
+++ b/src/it/java/uk/gov/companieshouse/company_appointments/config/AbstractMongoConfig.java
@@ -15,7 +15,7 @@ import org.testcontainers.utility.DockerImageName;
 public class AbstractMongoConfig {
 
     public static final MongoDBContainer mongoDBContainer = new MongoDBContainer(
-            DockerImageName.parse("mongo:5"));
+            DockerImageName.parse("mongo:8"));
 
     @DynamicPropertySource
     public static void setProperties(DynamicPropertyRegistry registry) {

--- a/src/it/java/uk/gov/companieshouse/company_appointments/config/CustomCorsFilterIntegrationTest.java
+++ b/src/it/java/uk/gov/companieshouse/company_appointments/config/CustomCorsFilterIntegrationTest.java
@@ -45,7 +45,7 @@ class CustomCorsFilterIntegrationTest {
     @Autowired
     private MockMvc mockMvc;
     @Container
-    private static final MongoDBContainer mongoDBContainer = new MongoDBContainer("mongo:5");
+    private static final MongoDBContainer mongoDBContainer = new MongoDBContainer("mongo:8");
     private static final String DELTA_APPOINTMENTS_COLLECTION = "delta_appointments";
     private static MongoTemplate mongoTemplate;
 

--- a/src/it/java/uk/gov/companieshouse/company_appointments/officerappointments/OfficerAppointmentsControllerITest.java
+++ b/src/it/java/uk/gov/companieshouse/company_appointments/officerappointments/OfficerAppointmentsControllerITest.java
@@ -62,7 +62,7 @@ class OfficerAppointmentsControllerITest {
     private static final String NON_ACTIVE_OFFICER_ID = "non_active_officer_ID";
 
     @Container
-    private static final MongoDBContainer mongoDBContainer = new MongoDBContainer("mongo:5");
+    private static final MongoDBContainer mongoDBContainer = new MongoDBContainer("mongo:8");
     private static final String DELTA_APPOINTMENTS_COLLECTION = "delta_appointments";
     private static MongoTemplate mongoTemplate;
 

--- a/src/it/java/uk/gov/companieshouse/company_appointments/tests/CompanyAppointmentControllerITest.java
+++ b/src/it/java/uk/gov/companieshouse/company_appointments/tests/CompanyAppointmentControllerITest.java
@@ -74,7 +74,7 @@ class CompanyAppointmentControllerITest {
     private MockMvc mockMvc;
 
     @Container
-    private static final MongoDBContainer mongoDBContainer = new MongoDBContainer("mongo:5");
+    private static final MongoDBContainer mongoDBContainer = new MongoDBContainer("mongo:8");
 
     @Autowired
     private ObjectMapper objectMapper;

--- a/src/it/java/uk/gov/companieshouse/company_appointments/tests/CompanyAppointmentFullRecordControllerITest.java
+++ b/src/it/java/uk/gov/companieshouse/company_appointments/tests/CompanyAppointmentFullRecordControllerITest.java
@@ -59,7 +59,7 @@ class CompanyAppointmentFullRecordControllerITest {
     private MockMvc mockMvc;
 
     @Container
-    private static final MongoDBContainer mongoDBContainer = new MongoDBContainer("mongo:5");
+    private static final MongoDBContainer mongoDBContainer = new MongoDBContainer("mongo:8");
 
     @MockitoBean
     private ResourceChangedApiService resourceChangedApiService;

--- a/src/it/java/uk/gov/companieshouse/company_appointments/tests/CompanyAppointmentFullRecordControllerMongoUnavailableITest.java
+++ b/src/it/java/uk/gov/companieshouse/company_appointments/tests/CompanyAppointmentFullRecordControllerMongoUnavailableITest.java
@@ -57,7 +57,7 @@ class CompanyAppointmentFullRecordControllerMongoUnavailableITest {
     private CompanyAppointmentRepository fullRecordRepository;
 
     @Container
-    private static final MongoDBContainer mongoDBContainer = new MongoDBContainer("mongo:5");
+    private static final MongoDBContainer mongoDBContainer = new MongoDBContainer("mongo:8");
 
     @Autowired
     private ObjectMapper objectMapper;

--- a/src/it/java/uk/gov/companieshouse/company_appointments/tests/CompanyAppointmentRepositoryITest.java
+++ b/src/it/java/uk/gov/companieshouse/company_appointments/tests/CompanyAppointmentRepositoryITest.java
@@ -44,7 +44,7 @@ class CompanyAppointmentRepositoryITest {
     private MongoTemplate mongoTemplate;
 
     @Container
-    private static final MongoDBContainer mongoDBContainer = new MongoDBContainer("mongo:5");
+    private static final MongoDBContainer mongoDBContainer = new MongoDBContainer("mongo:8");
 
     @BeforeAll
     static void start() {

--- a/src/test/java/uk/gov/companieshouse/company_appointments/officerappointments/OfficerAppointmentsRepositoryITest.java
+++ b/src/test/java/uk/gov/companieshouse/company_appointments/officerappointments/OfficerAppointmentsRepositoryITest.java
@@ -42,7 +42,7 @@ class OfficerAppointmentsRepositoryITest {
     private static final List<String> FILTER_STATUSES = List.of(DISSOLVED, CONVERTED_CLOSED, REMOVED);
 
     @Container
-    private static final MongoDBContainer mongoDBContainer = new MongoDBContainer("mongo:5");
+    private static final MongoDBContainer mongoDBContainer = new MongoDBContainer("mongo:8");
     private static final String MISSING_OFFICER_ID = "missing";
     @Autowired
     private OfficerAppointmentsRepository repository;

--- a/src/test/java/uk/gov/companieshouse/company_appointments/repository/CompanyAppointmentRepositoryTest.java
+++ b/src/test/java/uk/gov/companieshouse/company_appointments/repository/CompanyAppointmentRepositoryTest.java
@@ -52,7 +52,7 @@ class CompanyAppointmentRepositoryTest {
     private static final String COLLECTION = "delta_appointments";
 
     @Container
-    private static final MongoDBContainer mongoDBContainer = new MongoDBContainer("mongo:5");
+    private static final MongoDBContainer mongoDBContainer = new MongoDBContainer("mongo:8");
 
     @Autowired
     private CompanyAppointmentRepository repository;


### PR DESCRIPTION
**POM tidyup**
- updated to Spring Boot 3.5.14
- Removed hard override of spring-core version to use the one from the SB BOM
- Removed hard override of tomcat-embedded version to use the one from the SB BOM
- Pre-existing vulnerabilities in chs-kafka-api and api-helper-java will be addressed as part of the spring boot 4 upgrade later

**Mongo8 upgrade**
- Upgraded out of date Mongo 5 test containers to use Mongo 8
- Removed commented out dependencies from POM