### PR TITLE
LP-1572 Map and return Capital Contribution details for officer appointments

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
         <structured-logging.version>3.0.39</structured-logging.version>
         <sdk-manager-java.version>3.0.11</sdk-manager-java.version>
         <api-sdk-manager-java-library.version>3.0.7</api-sdk-manager-java-library.version>
-        <private-api-sdk-java.version>4.0.452</private-api-sdk-java.version>
+        <private-api-sdk-java.version>6.0.26</private-api-sdk-java.version>
         <api-helper-java-library.version>3.0.4</api-helper-java-library.version>
         <api-security-java.version>2.0.11</api-security-java.version>
         <kafka-models.version>3.0.20</kafka-models.version>

--- a/src/it/java/uk/gov/companieshouse/company_appointments/tests/CompanyAppointmentControllerITest.java
+++ b/src/it/java/uk/gov/companieshouse/company_appointments/tests/CompanyAppointmentControllerITest.java
@@ -122,7 +122,11 @@ class CompanyAppointmentControllerITest {
                 .andExpect(MockMvcResultMatchers.jsonPath("$.appointed_on", is("2025-08-26")))
                 .andExpect(MockMvcResultMatchers.jsonPath("$.date_of_birth", not(contains("day"))))
                 .andExpect(MockMvcResultMatchers.jsonPath("$.date_of_birth.year", is(1980)))
-                .andExpect(MockMvcResultMatchers.jsonPath("$.date_of_birth.month", is(1)));
+                .andExpect(MockMvcResultMatchers.jsonPath("$.date_of_birth.month", is(1)))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.contribution_currency_type", is("EGP")))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.contribution_currency_value", is("1266.32")))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.contribution_sub_types.[0].sub_type", is("money")))
+                .andExpect(MockMvcResultMatchers.jsonPath("$.contribution_sub_types.[1].sub_type", is("land-or-property")));
     }
 
     @Test

--- a/src/main/java/uk/gov/companieshouse/company_appointments/officerappointments/ContributionSubTypesMapper.java
+++ b/src/main/java/uk/gov/companieshouse/company_appointments/officerappointments/ContributionSubTypesMapper.java
@@ -1,0 +1,22 @@
+package uk.gov.companieshouse.company_appointments.officerappointments;
+
+import org.springframework.stereotype.Component;
+import uk.gov.companieshouse.api.officer.ContributionSubType;
+import uk.gov.companieshouse.company_appointments.model.data.DeltaContributionSubType;
+
+import java.util.List;
+
+import static java.util.Optional.ofNullable;
+
+@Component
+class ContributionSubTypesMapper {
+
+    List<ContributionSubType> map(List<DeltaContributionSubType> contributionSubTypes) {
+        return ofNullable(contributionSubTypes)
+                .map(subTypesData -> subTypesData.stream()
+                        .map(subTypes -> new ContributionSubType()
+                                .subType(subTypes.getSubType()))
+                        .toList())
+                .orElse(null);
+    }
+}

--- a/src/main/java/uk/gov/companieshouse/company_appointments/officerappointments/ItemsMapper.java
+++ b/src/main/java/uk/gov/companieshouse/company_appointments/officerappointments/ItemsMapper.java
@@ -20,6 +20,7 @@ class ItemsMapper {
     private final IdentificationMapper identificationMapper;
     private final OfficerRoleMapper roleMapper;
     private final IdentityVerificationDetailsMapper identityVerificationDetailsMapper;
+    private final ContributionSubTypesMapper contributionSubTypesMapper;
 
     ItemsMapper(AddressMapper addressMapper,
                 ContactDetailsMapper contactDetailsMapper,
@@ -28,7 +29,8 @@ class ItemsMapper {
                 FormerNamesMapper formerNamesMapper,
                 IdentificationMapper identificationMapper,
                 OfficerRoleMapper roleMapper,
-                IdentityVerificationDetailsMapper identityVerificationDetailsMapper) {
+                IdentityVerificationDetailsMapper identityVerificationDetailsMapper,
+                ContributionSubTypesMapper contributionSubTypesMapper) {
         this.addressMapper = addressMapper;
         this.contactDetailsMapper = contactDetailsMapper;
         this.nameMapper = nameMapper;
@@ -37,6 +39,7 @@ class ItemsMapper {
         this.identificationMapper = identificationMapper;
         this.roleMapper = roleMapper;
         this.identityVerificationDetailsMapper = identityVerificationDetailsMapper;
+        this.contributionSubTypesMapper = contributionSubTypesMapper;
     }
 
     List<OfficerAppointmentSummary> map(List<CompanyAppointmentDocument> appointments) {
@@ -66,7 +69,10 @@ class ItemsMapper {
                                 .officerRole(roleMapper.mapOfficerRole(data.getOfficerRole()))
                                 .principalOfficeAddress(addressMapper.map(data.getPrincipalOfficeAddress()))
                                 .resignedOn(localDateMapper.map(data.getResignedOn()))
-                                .responsibilities(data.getResponsibilities()))
+                                .responsibilities(data.getResponsibilities())
+                                .contributionCurrencyValue(data.getContributionCurrencyValue())
+                                .contributionCurrencyType(data.getContributionCurrencyType())
+                                .contributionSubTypes(contributionSubTypesMapper.map(data.getContributionSubTypes())))
                         .orElse(new OfficerAppointmentSummary()))
                 .toList();
     }

--- a/src/test/java/uk/gov/companieshouse/company_appointments/officerappointments/ContributionSubTypesMapperTest.java
+++ b/src/test/java/uk/gov/companieshouse/company_appointments/officerappointments/ContributionSubTypesMapperTest.java
@@ -1,0 +1,73 @@
+package uk.gov.companieshouse.company_appointments.officerappointments;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import uk.gov.companieshouse.api.officer.ContributionSubType;
+import uk.gov.companieshouse.company_appointments.model.data.DeltaContributionSubType;
+
+import java.util.List;
+
+import static java.util.Collections.emptyList;
+import static java.util.Collections.singletonList;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class ContributionSubTypesMapperTest {
+
+    private ContributionSubTypesMapper mapper;
+
+    @BeforeEach
+    void setUp() {
+        mapper = new ContributionSubTypesMapper();
+    }
+
+    @Test
+    void mapContributionSubTypes() {
+        // given
+        List<DeltaContributionSubType> subTypes = singletonList(new DeltaContributionSubType("money"));
+        List<ContributionSubType> expected = singletonList(new ContributionSubType().subType("money"));
+
+        // when
+        List<ContributionSubType> actual = mapper.map(subTypes);
+
+        // then
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    void mapContributionSubTypesWhenNonePresent() {
+        // given
+        List<DeltaContributionSubType> subTypes = singletonList(new DeltaContributionSubType());
+        List<ContributionSubType> expected = singletonList(new ContributionSubType());
+
+        // when
+        List<ContributionSubType> actual = mapper.map(subTypes);
+
+        // then
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    void mapContributionSubTypesWhenListIsEmpty() {
+        // given
+        List<DeltaContributionSubType> subTypes = emptyList();
+        List<ContributionSubType> expected = emptyList();
+
+        // when
+        List<ContributionSubType> actual = mapper.map(subTypes);
+
+        // then
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    void mapContributionSubTypesWithNullValue() {
+        // given
+
+        // when
+        List<ContributionSubType> actual = mapper.map(null);
+
+        // then
+        assertNull(actual);
+    }
+}

--- a/src/test/java/uk/gov/companieshouse/company_appointments/officerappointments/ItemsMapperTest.java
+++ b/src/test/java/uk/gov/companieshouse/company_appointments/officerappointments/ItemsMapperTest.java
@@ -25,6 +25,7 @@ import uk.gov.companieshouse.api.officer.Address;
 import uk.gov.companieshouse.api.officer.AppointedTo;
 import uk.gov.companieshouse.api.officer.AppointmentLinkTypes;
 import uk.gov.companieshouse.api.officer.ContactDetails;
+import uk.gov.companieshouse.api.officer.ContributionSubType;
 import uk.gov.companieshouse.api.officer.CorporateIdent;
 import uk.gov.companieshouse.api.officer.FormerNames;
 import uk.gov.companieshouse.api.officer.IdentityVerificationDetails;
@@ -33,6 +34,7 @@ import uk.gov.companieshouse.api.officer.OfficerAppointmentSummary;
 import uk.gov.companieshouse.api.officer.OfficerAppointmentSummary.OfficerRoleEnum;
 import uk.gov.companieshouse.company_appointments.model.data.CompanyAppointmentDocument;
 import uk.gov.companieshouse.company_appointments.model.data.DeltaContactDetails;
+import uk.gov.companieshouse.company_appointments.model.data.DeltaContributionSubType;
 import uk.gov.companieshouse.company_appointments.model.data.DeltaFormerNames;
 import uk.gov.companieshouse.company_appointments.model.data.DeltaIdentification;
 import uk.gov.companieshouse.company_appointments.model.data.DeltaIdentityVerificationDetails;
@@ -87,6 +89,12 @@ class ItemsMapperTest {
     private IdentityVerificationDetails identityVerificationDetails;
     @Mock
     private DeltaIdentityVerificationDetails deltaIdentityVerificationDetails;
+    @Mock
+    private ContributionSubTypesMapper contributionSubTypesMapper;
+    @Mock
+    private ContributionSubType contributionSubType;
+    @Mock
+    private DeltaContributionSubType contributionSubTypeData;
 
     private final Instant appointedBefore = Instant.from(
             LocalDate.of(1993, 3, 13).atStartOfDay(ZoneOffset.UTC));
@@ -113,6 +121,7 @@ class ItemsMapperTest {
         when(roleMapper.mapOfficerRole(anyString())).thenReturn(OfficerRoleEnum.DIRECTOR);
         when(nameMapper.mapNameElements(any())).thenReturn(nameElements);
         when(identityVerificationDetailsMapper.map(any())).thenReturn(identityVerificationDetails);
+        when(contributionSubTypesMapper.map(any())).thenReturn(singletonList(contributionSubType));
 
         List<CompanyAppointmentDocument> appointmentList = getAppointmentList();
 
@@ -134,6 +143,7 @@ class ItemsMapperTest {
         verify(identificationMapper).map(identificationData);
         verify(roleMapper).mapOfficerRole("director");
         verify(identityVerificationDetailsMapper).map(deltaIdentityVerificationDetails);
+        verify(contributionSubTypesMapper).map(singletonList(contributionSubTypeData));
     }
 
     @Test
@@ -155,6 +165,7 @@ class ItemsMapperTest {
         verifyNoInteractions(formerNamesMapper);
         verifyNoInteractions(identificationMapper);
         verifyNoInteractions(roleMapper);
+        verifyNoInteractions(contributionSubTypesMapper);
     }
 
     @Test
@@ -177,6 +188,7 @@ class ItemsMapperTest {
         verifyNoInteractions(formerNamesMapper);
         verifyNoInteractions(identificationMapper);
         verifyNoInteractions(roleMapper);
+        verifyNoInteractions(contributionSubTypesMapper);
     }
 
     private List<CompanyAppointmentDocument> getAppointmentList() {
@@ -211,7 +223,10 @@ class ItemsMapperTest {
                 .setAppointedBefore(appointedBefore)
                 .setOccupation("Company Director")
                 .setServiceAddress(serviceAddressData)
-                .setPrincipalOfficeAddress(deltaPrincipalOfficeAddress);
+                .setPrincipalOfficeAddress(deltaPrincipalOfficeAddress)
+                .setContributionCurrencyValue("4356.22")
+                .setContributionCurrencyType("USD")
+                .setContributionSubTypes(singletonList(contributionSubTypeData));
     }
 
     private List<OfficerAppointmentSummary> getOfficerAppointments() {
@@ -236,6 +251,9 @@ class ItemsMapperTest {
                 .occupation("Company Director")
                 .officerRole(OfficerRoleEnum.DIRECTOR)
                 .principalOfficeAddress(principalOfficeAddress)
-                .resignedOn(LocalDate.from(resignedOn.atZone(ZoneOffset.UTC))));
+                .resignedOn(LocalDate.from(resignedOn.atZone(ZoneOffset.UTC)))
+                .contributionCurrencyValue("4356.22")
+                .contributionCurrencyType("USD")
+                .contributionSubTypes(singletonList(contributionSubType)));
     }
 }

--- a/src/test/resources/PUT_full_record_request_body_with_empty_locality_fields.json
+++ b/src/test/resources/PUT_full_record_request_body_with_empty_locality_fields.json
@@ -55,7 +55,10 @@
       "principal_office_address":null,
       "resigned_on":null,
       "responsibilities":null,
-      "former_names":null
+      "former_names":null,
+      "contribution_currency_type":null,
+      "contribution_currency_value":null,
+      "contribution_sub_types":null
     },
     "sensitive_data":{
       "usual_residential_address":{

--- a/src/test/resources/appointment-data.json
+++ b/src/test/resources/appointment-data.json
@@ -31,7 +31,17 @@
       "postal_code" : "CF14 3UZ",
       "address_line_2" : "Pavement",
       "locality" : "Cardiff"
-    }
+    },
+    "contribution_currency_type" : "EGP",
+    "contribution_currency_value" : "1266.32",
+    "contribution_sub_types": [
+      {
+        "sub_type": "money"
+      },
+      {
+        "sub_type": "land-or-property"
+      }
+    ]
   },
   "sensitive_data" : {
     "usual_residential_address" : {


### PR DESCRIPTION
https://companieshouse.atlassian.net/browse/LP-1572

* Update POM to use the latest private API SDK Java library version in order to pick up new capital contribution fields for company appointments
* Map fields and add to the returned data structure
* Changes to integration and unit tests as well as test data resources